### PR TITLE
fix: remove staff API secret from public README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The voucher management portal lives at `ujstaff.happyk.au/vouchers/`. It connect
 
 ### First-time setup (per browser / per device)
 
-The portal uses a URL-hash seeding approach so staff never see a login screen. The secret is stored in `localStorage` after the first visit and never prompts again. the secret is: d60d61624f016b78e84c2caf04980e53
+The portal uses a URL-hash seeding approach so staff never see a login screen. The secret is stored in `localStorage` after the first visit and never prompts again. The secret value lives **only** in the team password manager ("UJ Staff Voucher Secret") — never write it into this repo, which is public.
 
 **Step 1 — get the setup URL** (from the password manager entry "UJ Staff Voucher Secret"):
 


### PR DESCRIPTION
README.md line 116 contained the live `STAFF_SHARED_SECRET` in plain text since 2026-06-19 — this repo is **public**, so treat that credential as compromised.

This PR removes the value and replaces it with a password-manager pointer + warning.

**Merging this is not sufficient**: the value remains in public git history (commit `1da50ec`). The secret must be **rotated** on the `uj-payments` worker and re-seeded on staff devices — being coordinated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)