### PR TITLE
Staff CSV export — Export panel

### DIFF
--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -1588,62 +1588,108 @@
         </div>
       </div>
 
-    </div>
+    <!-- ── Export ───────────────────────────────────────────────────────── -->
+    <div x-show="view==='export'" x-cloak>
 
-    <!-- ══ Export ═══════════════════════════════════════════════════════════ -->
-    <div x-show="view==='export'" x-cloak class="bg-white rounded-2xl shadow-sm p-5 sm:p-6">
-      <h2 class="text-lg font-semibold text-slate-800 mb-4">Export</h2>
+      <h2 class="flex items-center gap-2 text-[1.05rem] font-semibold text-neutral-800 mb-4">
+        <span class="section-icon"><svg viewBox="0 0 24 24"><path d="M12 3v12"/><path d="m8 11 4 4 4-4"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg></span>
+        Export
+      </h2>
 
+      <!-- Dataset. Segmented, matching the Reports sub-tabs — purchases and
+           redemptions are different row shapes, so they are separate exports. -->
       <div class="mb-5">
-        <div class="text-sm font-medium text-slate-600 mb-2">Dataset</div>
-        <div class="flex gap-2 flex-wrap">
-          <template x-for="ds in [['purchases','Purchases'],['redemptions','Redemptions']]" :key="ds[0]">
-            <button @click="exportDataset = ds[0]; restoreExportFields(ds[0]); exportManagerSecret=''; exportError=''; exportNotice=''"
-              :class="exportDataset===ds[0] ? 'bg-slate-800 text-white border-slate-800' : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-50'"
-              class="px-4 py-2 rounded-xl border text-sm font-medium transition-all"
-              x-text="ds[1]"></button>
-          </template>
+        <div class="filter-heading mb-2">Dataset</div>
+        <div class="flex bg-white border border-neutral-200 rounded-xl overflow-hidden w-max max-w-full">
+          <button type="button" @click="setExportDataset('purchases')"
+            :class="exportDataset==='purchases' ? 'bg-uj text-white font-semibold' : 'text-neutral-600 hover:bg-neutral-50'"
+            class="px-3.5 py-1.5 text-[0.84rem] font-medium transition-colors">Purchases</button>
+          <button type="button" @click="setExportDataset('redemptions')"
+            :class="exportDataset==='redemptions' ? 'bg-uj text-white font-semibold' : 'text-neutral-600 hover:bg-neutral-50'"
+            class="px-3.5 py-1.5 text-[0.84rem] font-medium border-l border-neutral-200 transition-colors">Redemptions</button>
         </div>
       </div>
 
+      <!-- Period. "Last month" is the previous CALENDAR month, so it reconciles
+           against a monthly P&L rather than drifting like a rolling window. -->
       <div class="mb-5">
-        <div class="text-sm font-medium text-slate-600 mb-2">Period</div>
-        <div class="flex gap-2 flex-wrap">
-          <template x-for="p in [['thisMonth','This month'],['lastMonth','Last month'],['thisYear','This year'],['custom','Custom']]" :key="p[0]">
-            <button @click="exportPeriod = p[0]; applyExportPeriod()"
-              :class="exportPeriod===p[0] ? 'bg-slate-800 text-white border-slate-800' : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-50'"
-              class="px-3 py-1.5 rounded-lg border text-sm font-medium transition-all"
-              x-text="p[1]"></button>
+        <div class="filter-heading mb-2">Period</div>
+        <div class="flex bg-white border border-neutral-200 rounded-xl overflow-hidden w-max max-w-full">
+          <template x-for="(p, i) in EXPORT_PERIODS" :key="p.key">
+            <button type="button" @click="exportPeriod = p.key; applyExportPeriod()"
+              :class="[exportPeriod===p.key ? 'bg-uj text-white font-semibold' : 'text-neutral-600 hover:bg-neutral-50', i > 0 ? 'border-l border-neutral-200' : '']"
+              class="px-3.5 py-1.5 text-[0.84rem] font-medium transition-colors" x-text="p.label"></button>
           </template>
         </div>
-        <div x-show="exportPeriod==='custom'" class="flex gap-2 items-center mt-3">
-          <input type="date" x-model="exportFrom" class="border border-slate-300 rounded-lg px-3 py-1.5 text-sm">
-          <span class="text-slate-400 text-sm">to</span>
-          <input type="date" x-model="exportTo" class="border border-slate-300 rounded-lg px-3 py-1.5 text-sm">
+
+        <!-- Custom range. Native <input type="date"> is banned here — see the
+             .day-menu CSS note — so these are the same custom pickers the
+             search filters use, scoped to the export range. -->
+        <div x-show="exportPeriod==='custom'" x-cloak class="filter-row mt-3">
+          <template x-for="f in [{ key: 'from', label: 'From' }, { key: 'to', label: 'To' }]" :key="f.key">
+            <div class="combo combo-sm w-[124px]" @click.outside="exportDayOpen[f.key] = false" @keydown.escape.window="exportDayOpen[f.key] = false">
+              <button type="button" class="combo-trigger" @click="toggleExportDay(f.key)"
+                :aria-expanded="exportDayOpen[f.key].toString()" aria-haspopup="dialog"
+                :aria-label="`Export range ${f.label.toLowerCase()}`">
+                <span x-text="exportDayFieldLabel(exportFrom, exportTo, f.key)"></span>
+                <svg class="combo-chevron" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+              <div x-show="exportDayOpen[f.key]" x-transition.origin.top x-cloak
+                class="combo-menu day-menu" role="dialog"
+                :aria-label="`Choose the export ${f.label.toLowerCase()} date`">
+                <div class="day-nav">
+                  <button type="button" class="day-nav-btn" @click="stepExportMonth(f.key, -1)" aria-label="Previous month">
+                    <svg viewBox="0 0 24 24"><path d="M15 6l-6 6 6 6"/></svg>
+                  </button>
+                  <span class="day-nav-label" x-text="exportDayNavLabel(f.key)"></span>
+                  <button type="button" class="day-nav-btn" @click="stepExportMonth(f.key, 1)" aria-label="Next month">
+                    <svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"/></svg>
+                  </button>
+                </div>
+                <div class="day-dow">
+                  <template x-for="(d, i) in DOW_LIST" :key="i"><span x-text="d"></span></template>
+                </div>
+                <div class="day-grid">
+                  <template x-for="(day, i) in exportDayCells(f.key)" :key="i">
+                    <button type="button" class="day-cell" x-text="day || ''"
+                      @click="day && pickExportDay(f.key, day)"
+                      :disabled="!day || isExportDayDisabled(f.key, day)"
+                      :aria-pressed="!!day && isExportDaySelected(f.key, day)"
+                      :class="[!day ? 'is-blank' : '', day && isExportDaySelected(f.key, day) ? 'active' : '', day && isExportToday(f.key, day) ? 'is-today' : '']"></button>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </template>
         </div>
-        <div class="text-sm text-slate-500 mt-2" x-text="exportRangeLabel()"></div>
+
+        <div class="text-sm text-neutral-500 mt-2" x-text="exportRangeLabel()"></div>
       </div>
 
+      <!-- Fields -->
       <div class="mb-5">
         <div class="flex items-center justify-between mb-2">
-          <div class="text-sm font-medium text-slate-600">Fields</div>
-          <button @click="resetExportFields()"
-            class="text-xs text-slate-500 hover:text-slate-700 underline">Reset to defaults</button>
+          <div class="filter-heading">Fields</div>
+          <button type="button" @click="resetExportFields()"
+            class="text-[0.78rem] font-semibold text-neutral-500 hover:text-uj transition-colors">Reset to defaults</button>
         </div>
 
         <template x-for="group in exportGroups()" :key="group.name">
-          <div class="mb-3">
-            <div class="text-xs uppercase tracking-wide text-slate-400 mb-1.5 flex items-center gap-1.5">
-              <span x-text="group.name"></span>
-              <span x-show="group.pii" title="Manager password required">🔒</span>
+          <div class="section-card border rounded-xl px-3.5 py-3 mb-2.5">
+            <div class="flex items-center gap-1.5 mb-2">
+              <span class="filter-heading" x-text="group.name"></span>
+              <svg x-show="group.pii" class="w-3.5 h-3.5 text-uj shrink-0" viewBox="0 0 24 24"
+                fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"
+                role="img" aria-label="Manager password required"><title>Manager password required</title>
+                <rect x="4.5" y="10.5" width="15" height="10" rx="2"/><path d="M8 10.5V7a4 4 0 0 1 8 0v3.5"/></svg>
             </div>
-            <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+            <div class="flex flex-wrap gap-x-5 gap-y-2">
               <template x-for="f in group.fields" :key="f.key">
-                <label class="inline-flex items-center gap-1.5 text-sm text-slate-700">
+                <label class="inline-flex items-center gap-2 text-sm text-neutral-700 cursor-pointer">
                   <input type="checkbox"
                     x-model="exportFields[exportDataset][f.key]"
                     @change="persistExportFields()"
-                    class="rounded border-slate-300">
+                    class="rounded border-neutral-300 text-uj focus:ring-uj/20" />
                   <span x-text="f.label"></span>
                 </label>
               </template>
@@ -1651,26 +1697,29 @@
           </div>
         </template>
 
-        <div x-show="exportNeedsManager()" class="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-xl">
-          <label class="block text-sm font-medium text-amber-900 mb-1.5">
+        <div x-show="exportNeedsManager()" x-cloak class="section-card border rounded-xl px-3.5 py-3 mt-2.5">
+          <label class="block text-sm font-medium text-neutral-700 mb-1.5">
             Manager password — required for personal data fields
           </label>
           <input type="password" x-model="exportManagerSecret"
-            class="w-full sm:w-64 border border-amber-300 rounded-lg px-3 py-1.5 text-sm"
-            placeholder="Manager password">
+            class="w-full sm:w-64 border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:border-uj focus:ring-[3px] focus:ring-uj/[0.14]"
+            placeholder="Manager password" />
         </div>
       </div>
 
       <div class="flex items-center gap-3 flex-wrap">
-        <button @click="downloadExport()"
+        <button type="button" @click="downloadExport()"
           :disabled="exportLoading || !selectedExportKeys().length || !exportFrom || !exportTo"
-          class="px-5 py-2.5 rounded-xl bg-slate-800 text-white text-sm font-semibold transition-all hover:bg-slate-700 disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-2">
+          class="px-5 py-2.5 rounded-xl bg-uj hover:bg-uj-dark text-white text-sm font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-2">
           <span x-show="exportLoading" class="inline-block w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
           <span x-text="exportLoading ? 'Preparing…' : 'Download CSV'"></span>
         </button>
-        <span x-show="exportNotice" class="text-sm text-slate-600" x-text="exportNotice"></span>
-        <span x-show="exportError" class="text-sm text-red-600" x-text="exportError"></span>
+        <span x-show="exportNotice" class="text-sm text-neutral-600" x-text="exportNotice"></span>
+        <span x-show="exportError" class="text-sm text-uj font-medium" x-text="exportError"></span>
       </div>
+
+    </div>
+
     </div>
   </main>
 
@@ -2590,6 +2639,17 @@
       exportPeriod: 'lastMonth',
       exportFrom: '',
       exportTo: '',
+      // Own day-picker state, keyed the same way the search filters' is. Kept
+      // separate rather than shared so changing the export range can never
+      // disturb a search the user has already set up.
+      exportDayOpen: { from: false, to: false },
+      exportDayView: { from: '', to: '' },   // 'YYYY-MM' — month each panel shows
+      EXPORT_PERIODS: [
+        { key: 'thisMonth', label: 'This month' },
+        { key: 'lastMonth', label: 'Last month' },
+        { key: 'thisYear', label: 'This year' },
+        { key: 'custom', label: 'Custom' },
+      ],
       exportFields: {},        // { [dataset]: { [key]: boolean } }
       exportRegistry: null,    // fetched from the Worker on first open
       exportManagerSecret: '',
@@ -2953,12 +3013,99 @@
 
       exportRangeLabel() {
         if (!this.exportFrom || !this.exportTo) return '';
-        const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-        const fmt = (s) => {
-          const [yy, mm, dd] = s.split('-');
-          return `${Number(dd)} ${MONTHS[Number(mm) - 1]} ${yy}`;
-        };
-        return `${fmt(this.exportFrom)} – ${fmt(this.exportTo)}`;
+        return `${this.formatExportDay(this.exportFrom)} – ${this.formatExportDay(this.exportTo)}`;
+      },
+
+      formatExportDay(v) {
+        const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        const [y, m, d] = v.split('-');
+        return `${Number(d)} ${MONTHS[Number(m) - 1]} ${y}`;
+      },
+
+      setExportDataset(dataset) {
+        this.exportDataset = dataset;
+        this.restoreExportFields(dataset);
+        this.exportManagerSecret = '';
+        this.exportError = '';
+        this.exportNotice = '';
+      },
+
+      // ── Export day picker ────────────────────────────────────────────────
+      // Mirrors the search filters' picker (same combo/day-menu markup and CSS)
+      // but bound to exportFrom/exportTo. Native <input type="date"> is not an
+      // option here — see the .day-menu CSS note.
+      toggleExportDay(key) {
+        const wasOpen = this.exportDayOpen[key];
+        this.exportDayOpen.from = false;
+        this.exportDayOpen.to = false;
+        if (wasOpen) return;
+        const current = key === 'from' ? this.exportFrom : this.exportTo;
+        this.exportDayView[key] = (current || this.perthToday()).slice(0, 7);
+        this.exportDayOpen[key] = true;
+      },
+
+      exportDayNavLabel(key) {
+        const [y, m] = (this.exportDayView[key] || this.perthToday().slice(0, 7)).split('-');
+        const names = ['January', 'February', 'March', 'April', 'May', 'June',
+          'July', 'August', 'September', 'October', 'November', 'December'];
+        return `${names[Number(m) - 1]} ${y}`;
+      },
+
+      stepExportMonth(key, delta) {
+        const [y, m] = this.exportDayView[key].split('-').map(Number);
+        const d = new Date(y, m - 1 + delta, 1);
+        this.exportDayView[key] = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      },
+
+      // Leading blanks pad the grid so the 1st lands under its weekday. The week
+      // starts Monday; JS getDay() is Sunday-based, hence the (+6) % 7 shift.
+      exportDayCells(key) {
+        const [y, m] = this.exportDayView[key].split('-').map(Number);
+        const firstDow = (new Date(y, m - 1, 1).getDay() + 6) % 7;
+        const daysInMonth = new Date(y, m, 0).getDate();
+        const cells = [];
+        for (let i = 0; i < firstDow; i++) cells.push(null);
+        for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+        return cells;
+      },
+
+      exportDayValue(key, day) {
+        return `${this.exportDayView[key]}-${String(day).padStart(2, '0')}`;
+      },
+
+      pickExportDay(key, day) {
+        const v = this.exportDayValue(key, day);
+        if (key === 'from') this.exportFrom = v; else this.exportTo = v;
+        this.exportDayOpen[key] = false;
+        this.exportError = '';
+        this.exportNotice = '';
+      },
+
+      isExportDaySelected(key, day) {
+        const current = key === 'from' ? this.exportFrom : this.exportTo;
+        return !!current && current === this.exportDayValue(key, day);
+      },
+
+      isExportToday(key, day) {
+        return this.exportDayValue(key, day) === this.perthToday();
+      },
+
+      // A day that would put "from" after "to" is unpickable rather than
+      // pickable and then scolded.
+      isExportDayDisabled(key, day) {
+        const v = this.exportDayValue(key, day);
+        return key === 'from'
+          ? !!this.exportTo && v > this.exportTo
+          : !!this.exportFrom && v < this.exportFrom;
+      },
+
+      // Values are passed in rather than read off `this` so Alpine tracks the
+      // dependency from inside the x-for scope — same reason as dayFieldLabel.
+      exportDayFieldLabel(from, to, key) {
+        const v = key === 'from' ? from : to;
+        if (!v) return key === 'from' ? 'From' : 'To';
+        return this.formatExportDay(v);
       },
 
       async loadExportFields() {

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -628,6 +628,12 @@
           <span class="nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18M8 4v16"/></svg></span>
           Voucher Types
         </button>
+        <button @click="goExport()"
+          :class="view==='export' ? 'bg-white/[0.16] text-white font-semibold' : 'text-white/70 hover:text-white hover:bg-white/10'"
+          class="px-3 py-2 rounded-xl text-[0.84rem] font-medium transition-all inline-flex items-center gap-1.5">
+          <span class="nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="m8 11 4 4 4-4"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg></span>
+          Export
+        </button>
         <a href="/vouchers/stats.html"
           class="px-3 py-2 rounded-xl text-[0.84rem] font-medium transition-all inline-flex items-center gap-1.5 text-white/70 hover:text-white hover:bg-white/10">
           <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M4.5 19.5h15"/><path d="M8 16v-6"/><path d="M13 16V8"/><path d="M18 16v-4"/></svg></span>
@@ -1583,6 +1589,89 @@
       </div>
 
     </div>
+
+    <!-- ══ Export ═══════════════════════════════════════════════════════════ -->
+    <div x-show="view==='export'" x-cloak class="bg-white rounded-2xl shadow-sm p-5 sm:p-6">
+      <h2 class="text-lg font-semibold text-slate-800 mb-4">Export</h2>
+
+      <div class="mb-5">
+        <div class="text-sm font-medium text-slate-600 mb-2">Dataset</div>
+        <div class="flex gap-2 flex-wrap">
+          <template x-for="ds in [['purchases','Purchases'],['redemptions','Redemptions']]" :key="ds[0]">
+            <button @click="exportDataset = ds[0]; restoreExportFields(ds[0]); exportManagerSecret=''; exportError=''; exportNotice=''"
+              :class="exportDataset===ds[0] ? 'bg-slate-800 text-white border-slate-800' : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-50'"
+              class="px-4 py-2 rounded-xl border text-sm font-medium transition-all"
+              x-text="ds[1]"></button>
+          </template>
+        </div>
+      </div>
+
+      <div class="mb-5">
+        <div class="text-sm font-medium text-slate-600 mb-2">Period</div>
+        <div class="flex gap-2 flex-wrap">
+          <template x-for="p in [['thisMonth','This month'],['lastMonth','Last month'],['thisYear','This year'],['custom','Custom']]" :key="p[0]">
+            <button @click="exportPeriod = p[0]; applyExportPeriod()"
+              :class="exportPeriod===p[0] ? 'bg-slate-800 text-white border-slate-800' : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-50'"
+              class="px-3 py-1.5 rounded-lg border text-sm font-medium transition-all"
+              x-text="p[1]"></button>
+          </template>
+        </div>
+        <div x-show="exportPeriod==='custom'" class="flex gap-2 items-center mt-3">
+          <input type="date" x-model="exportFrom" class="border border-slate-300 rounded-lg px-3 py-1.5 text-sm">
+          <span class="text-slate-400 text-sm">to</span>
+          <input type="date" x-model="exportTo" class="border border-slate-300 rounded-lg px-3 py-1.5 text-sm">
+        </div>
+        <div class="text-sm text-slate-500 mt-2" x-text="exportRangeLabel()"></div>
+      </div>
+
+      <div class="mb-5">
+        <div class="flex items-center justify-between mb-2">
+          <div class="text-sm font-medium text-slate-600">Fields</div>
+          <button @click="resetExportFields()"
+            class="text-xs text-slate-500 hover:text-slate-700 underline">Reset to defaults</button>
+        </div>
+
+        <template x-for="group in exportGroups()" :key="group.name">
+          <div class="mb-3">
+            <div class="text-xs uppercase tracking-wide text-slate-400 mb-1.5 flex items-center gap-1.5">
+              <span x-text="group.name"></span>
+              <span x-show="group.pii" title="Manager password required">🔒</span>
+            </div>
+            <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+              <template x-for="f in group.fields" :key="f.key">
+                <label class="inline-flex items-center gap-1.5 text-sm text-slate-700">
+                  <input type="checkbox"
+                    x-model="exportFields[exportDataset][f.key]"
+                    @change="persistExportFields()"
+                    class="rounded border-slate-300">
+                  <span x-text="f.label"></span>
+                </label>
+              </template>
+            </div>
+          </div>
+        </template>
+
+        <div x-show="exportNeedsManager()" class="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-xl">
+          <label class="block text-sm font-medium text-amber-900 mb-1.5">
+            Manager password — required for personal data fields
+          </label>
+          <input type="password" x-model="exportManagerSecret"
+            class="w-full sm:w-64 border border-amber-300 rounded-lg px-3 py-1.5 text-sm"
+            placeholder="Manager password">
+        </div>
+      </div>
+
+      <div class="flex items-center gap-3 flex-wrap">
+        <button @click="downloadExport()"
+          :disabled="exportLoading || !selectedExportKeys().length || !exportFrom || !exportTo"
+          class="px-5 py-2.5 rounded-xl bg-slate-800 text-white text-sm font-semibold transition-all hover:bg-slate-700 disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-2">
+          <span x-show="exportLoading" class="inline-block w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
+          <span x-text="exportLoading ? 'Preparing…' : 'Download CSV'"></span>
+        </button>
+        <span x-show="exportNotice" class="text-sm text-slate-600" x-text="exportNotice"></span>
+        <span x-show="exportError" class="text-sm text-red-600" x-text="exportError"></span>
+      </div>
+    </div>
   </main>
 
   <!-- ── Redeem modal ──────────────────────────────────────────────────────── -->
@@ -2496,6 +2585,18 @@
       // Navigation
       view: 'search',
 
+      // Export
+      exportDataset: 'purchases',
+      exportPeriod: 'lastMonth',
+      exportFrom: '',
+      exportTo: '',
+      exportFields: {},        // { [dataset]: { [key]: boolean } }
+      exportRegistry: null,    // fetched from the Worker on first open
+      exportManagerSecret: '',
+      exportLoading: false,
+      exportError: '',
+      exportNotice: '',
+
       // Search
       q: '',
       statusFilter: '',
@@ -2794,6 +2895,184 @@
           throw err;
         }
         return data;
+      },
+
+      // Sibling to api() for non-JSON responses. api() always parses JSON, so it
+      // cannot carry a CSV body. Same Access-redirect handling, blob out.
+      async apiBlob(path, options = {}) {
+        const res = await fetch(this.WORKER + path, {
+          ...options,
+          redirect: 'manual',
+          headers: { ...this.authHeaders(), ...(options.headers || {}) },
+        });
+        if (res.type === 'opaqueredirect') {
+          throw Object.assign(
+            new Error('Your session expired — reload the page to sign in again.'),
+            { status: 401 },
+          );
+        }
+        if (!res.ok) {
+          // Errors still come back as JSON even from a CSV endpoint.
+          const data = await res.json().catch(() => ({}));
+          throw Object.assign(new Error(data.error || 'HTTP ' + res.status), { status: res.status });
+        }
+        const disposition = res.headers.get('Content-Disposition') || '';
+        const match = disposition.match(/filename="([^"]+)"/);
+        return { blob: await res.blob(), filename: match ? match[1] : 'export.csv' };
+      },
+
+      // ── Export ───────────────────────────────────────────────────────────
+      goExport() {
+        this.view = 'export';
+        this.stopScannerIfActive();
+        this.applyExportPeriod();
+        if (!this.exportRegistry) this.loadExportFields();
+      },
+
+      // "Last month" means the previous CALENDAR month — complete, stable, and
+      // reconcilable against a monthly P&L. Deliberately not a rolling 30 days,
+      // which is partial at both ends and answers differently every day.
+      applyExportPeriod() {
+        const now = new Date();
+        const y = now.getFullYear();
+        const m = now.getMonth();
+        const pad = (n) => String(n).padStart(2, '0');
+        const iso = (d) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+        if (this.exportPeriod === 'thisMonth') {
+          this.exportFrom = iso(new Date(y, m, 1));
+          this.exportTo = iso(new Date(y, m + 1, 0));
+        } else if (this.exportPeriod === 'lastMonth') {
+          this.exportFrom = iso(new Date(y, m - 1, 1));
+          this.exportTo = iso(new Date(y, m, 0));
+        } else if (this.exportPeriod === 'thisYear') {
+          this.exportFrom = iso(new Date(y, 0, 1));
+          this.exportTo = iso(new Date(y, 11, 31));
+        }
+        // 'custom' leaves whatever the date inputs hold.
+      },
+
+      exportRangeLabel() {
+        if (!this.exportFrom || !this.exportTo) return '';
+        const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        const fmt = (s) => {
+          const [yy, mm, dd] = s.split('-');
+          return `${Number(dd)} ${MONTHS[Number(mm) - 1]} ${yy}`;
+        };
+        return `${fmt(this.exportFrom)} – ${fmt(this.exportTo)}`;
+      },
+
+      async loadExportFields() {
+        try {
+          this.exportRegistry = await this.api('/v1/vouchers/export/fields');
+          for (const ds of Object.keys(this.exportRegistry)) {
+            if (!this.exportFields[ds]) this.restoreExportFields(ds);
+          }
+        } catch (e) {
+          this.exportError = e.message;
+        }
+      },
+
+      restoreExportFields(dataset) {
+        const registry = this.exportRegistry?.[dataset] || [];
+        const selection = {};
+        for (const f of registry) selection[f.key] = !!f.default;
+
+        const stored = localStorage.getItem('ujExportFields:' + dataset);
+        if (stored) {
+          try {
+            const parsed = JSON.parse(stored);
+            for (const f of registry) {
+              // PII is never restored from storage — see persistExportFields.
+              if (!f.pii && f.key in parsed) selection[f.key] = !!parsed[f.key];
+            }
+          } catch { /* corrupt entry — fall back to defaults */ }
+        }
+        this.exportFields[dataset] = selection;
+      },
+
+      // PII selections are deliberately NOT persisted: on a shared front-desk
+      // terminal a manager's unlock must not linger into the next staff member's
+      // session.
+      persistExportFields() {
+        const ds = this.exportDataset;
+        const selection = this.exportFields[ds] || {};
+        const safe = {};
+        for (const f of (this.exportRegistry?.[ds] || [])) {
+          if (!f.pii) safe[f.key] = !!selection[f.key];
+        }
+        localStorage.setItem('ujExportFields:' + ds, JSON.stringify(safe));
+      },
+
+      resetExportFields() {
+        localStorage.removeItem('ujExportFields:' + this.exportDataset);
+        this.restoreExportFields(this.exportDataset);
+      },
+
+      exportGroups() {
+        const groups = [];
+        for (const f of (this.exportRegistry?.[this.exportDataset] || [])) {
+          let g = groups.find((x) => x.name === f.group);
+          if (!g) { g = { name: f.group, pii: !!f.pii, fields: [] }; groups.push(g); }
+          g.fields.push(f);
+        }
+        return groups;
+      },
+
+      selectedExportKeys() {
+        const selection = this.exportFields[this.exportDataset] || {};
+        return Object.keys(selection).filter((k) => selection[k]);
+      },
+
+      exportNeedsManager() {
+        const selected = new Set(this.selectedExportKeys());
+        return (this.exportRegistry?.[this.exportDataset] || [])
+          .some((f) => f.pii && selected.has(f.key));
+      },
+
+      async downloadExport() {
+        const keys = this.selectedExportKeys();
+        if (!keys.length) return;
+        this.exportLoading = true;
+        this.exportError = '';
+        this.exportNotice = '';
+        try {
+          const params = new URLSearchParams({
+            dataset: this.exportDataset,
+            from: this.exportFrom,
+            to: this.exportTo,
+            fields: keys.join(','),
+          });
+          const headers = this.exportNeedsManager()
+            ? { 'X-Manager-Secret': this.exportManagerSecret }
+            : {};
+          const { blob, filename } = await this.apiBlob(
+            '/v1/vouchers/export?' + params.toString(), { headers },
+          );
+
+          // Count before the blob is consumed by the download.
+          const rows = (await blob.text()).trim().split('\r\n').length - 1;
+
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = filename;
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(url);
+
+          // A header-only file is honest about an empty period, but say so —
+          // otherwise it reads as a broken button.
+          this.exportNotice = rows === 0
+            ? 'Downloaded — no rows for this period.'
+            : `Downloaded ${rows} row${rows === 1 ? '' : 's'}.`;
+        } catch (e) {
+          this.exportError = e.status === 403
+            ? 'Manager password required for personal data fields.'
+            : e.message;
+        } finally {
+          this.exportLoading = false;
+        }
       },
 
       // ── Toast ────────────────────────────────────────────────────────────

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -482,6 +482,53 @@
       border-radius: 8px;
     }
     .day-clear:hover { color: var(--uj); }
+    /* Tick control. The native checkbox is kept — it carries the label
+       association, the x-model binding and all keyboard behaviour — but is
+       sized to nothing and painted over by the .tick box next to it. Zero-size
+       rather than absolutely positioned: several of these live inside modals
+       with no positioned ancestor, where an absolute input would drift. */
+    .tick-input {
+      appearance: none;
+      -webkit-appearance: none;
+      width: 0;
+      height: 0;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      opacity: 0;
+      flex-shrink: 0;
+    }
+    .tick {
+      display: grid;
+      place-items: center;
+      width: 18px;
+      height: 18px;
+      flex-shrink: 0;
+      border-radius: 6px;
+      border: 1.5px solid rgba(31, 41, 55, 0.22);
+      background: #fff;
+      color: #fff;
+      cursor: pointer;
+      transition: background-color 120ms ease, border-color 120ms ease;
+    }
+    .tick:hover { border-color: rgba(139, 28, 35, 0.45); }
+    .tick-input:checked + .tick { background: var(--uj); border-color: var(--uj); }
+    .tick-input:focus-visible + .tick { outline: 2px solid var(--uj); outline-offset: 2px; }
+    .tick-mark {
+      width: 13px;
+      height: 13px;
+      fill: none;
+      stroke: currentColor;
+      /* Heavier than the 2 the other icons use — at 13px a hairline tick reads
+         as a smudge against the filled accent. */
+      stroke-width: 3;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.6);
+      transition: opacity 120ms ease, transform 120ms ease;
+    }
+    .tick-input:checked + .tick .tick-mark { opacity: 1; transform: none; }
     .empty-icon {
       margin: 0 auto 12px;
       opacity: 0.75;
@@ -1658,6 +1705,7 @@
                       :class="[!day ? 'is-blank' : '', day && isExportDaySelected(f.key, day) ? 'active' : '', day && isExportToday(f.key, day) ? 'is-today' : '']"></button>
                   </template>
                 </div>
+                <button type="button" class="day-clear" @click="clearExportDay(f.key)">Clear</button>
               </div>
             </div>
           </template>
@@ -1689,7 +1737,8 @@
                   <input type="checkbox"
                     x-model="exportFields[exportDataset][f.key]"
                     @change="persistExportFields()"
-                    class="rounded border-neutral-300 text-uj focus:ring-uj/20" />
+                    class="tick-input" />
+                  <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
                   <span x-text="f.label"></span>
                 </label>
               </template>
@@ -2029,15 +2078,15 @@
 
           <!-- Physical voucher -->
           <label class="flex items-center gap-2.5 text-sm text-neutral-700">
-            <input type="checkbox" x-model="typeForm.is_physical"
-              class="rounded border-neutral-300 text-uj focus:ring-uj/20" />
+            <input type="checkbox" x-model="typeForm.is_physical" class="tick-input" />
+            <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
             Physical voucher<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">No email is sent — vouchers of this type are physical cards, and are flagged 'Physical' in staff views.</span></span>
           </label>
 
           <!-- Active -->
           <label class="flex items-center gap-2.5 text-sm text-neutral-700">
-            <input type="checkbox" x-model="typeForm.is_active"
-              class="rounded border-neutral-300 text-uj focus:ring-uj/20" />
+            <input type="checkbox" x-model="typeForm.is_active" class="tick-input" />
+            <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
             Active<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Turns this type on or off. Inactive types are hidden from customers and the staff Create dropdown.</span></span>
           </label>
         </fieldset>
@@ -2120,15 +2169,15 @@
 
           <!-- Show QR code -->
           <label class="flex items-center gap-2.5 text-sm text-neutral-700">
-            <input type="checkbox" x-model="typeForm.show_qr"
-              class="rounded border-neutral-300 text-uj focus:ring-uj/20" />
+            <input type="checkbox" x-model="typeForm.show_qr" class="tick-input" />
+            <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
             Show QR code<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Show the scannable QR code on the voucher email. Turn off for types redeemed by hand.</span></span>
           </label>
 
           <!-- Show value -->
           <label class="flex items-center gap-2.5 text-sm text-neutral-700">
-            <input type="checkbox" x-model="typeForm.show_value"
-              class="rounded border-neutral-300 text-uj focus:ring-uj/20" />
+            <input type="checkbox" x-model="typeForm.show_value" class="tick-input" />
+            <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
             Show value<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Show the dollar value + expiry box on the voucher email. Turn off to hide the amount.</span></span>
           </label>
         </fieldset>
@@ -2334,7 +2383,8 @@
               </div>
               <div class="flex items-end pb-2">
                 <label class="flex items-center gap-2 text-sm text-neutral-700 cursor-pointer">
-                  <input type="checkbox" x-model="itemForm.is_active" class="rounded" />
+                  <input type="checkbox" x-model="itemForm.is_active" class="tick-input" />
+                  <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
                   Active<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Whether this item can be purchased. Inactive items are hidden from customers but kept for records.</span></span>
                 </label>
               </div>
@@ -2589,7 +2639,10 @@
 
       <!-- Second confirmation gate -->
       <label class="flex items-start gap-2.5 text-sm text-neutral-700 mb-6 cursor-pointer">
-        <input type="checkbox" x-model="deleteItemConfirmed" class="mt-0.5 rounded border-neutral-300 text-uj focus:ring-uj/20" />
+        <input type="checkbox" x-model="deleteItemConfirmed" class="tick-input" />
+        <!-- mt-0.5 sits on the box, not the input: the label wraps, so the tick
+             aligns to the first line rather than the centre of the block. -->
+        <span class="tick mt-0.5"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
         Yes, I'm sure — permanently delete this item.
       </label>
 
@@ -3012,7 +3065,12 @@
       },
 
       exportRangeLabel() {
-        if (!this.exportFrom || !this.exportTo) return '';
+        // A half-cleared range is a state the Clear button can reach, and the
+        // disabled Download button needs explaining — so name the missing
+        // bound rather than going blank and looking broken.
+        if (!this.exportFrom && !this.exportTo) return 'Choose a start and end date.';
+        if (!this.exportFrom) return 'Choose a start date.';
+        if (!this.exportTo) return 'Choose an end date.';
         return `${this.formatExportDay(this.exportFrom)} – ${this.formatExportDay(this.exportTo)}`;
       },
 
@@ -3077,6 +3135,13 @@
       pickExportDay(key, day) {
         const v = this.exportDayValue(key, day);
         if (key === 'from') this.exportFrom = v; else this.exportTo = v;
+        this.exportDayOpen[key] = false;
+        this.exportError = '';
+        this.exportNotice = '';
+      },
+
+      clearExportDay(key) {
+        if (key === 'from') this.exportFrom = ''; else this.exportTo = '';
         this.exportDayOpen[key] = false;
         this.exportError = '';
         this.exportNotice = '';


### PR DESCRIPTION
UI half of the staff CSV export. Adds an **Export** tab to the voucher staff hub.

Pairs with **urbanjungleirc/vouchers#4**, which adds the Worker endpoint.
Neither half is usable alone — **deploy the Worker first**, or this panel calls a 404 route.

## What it does

- Dataset selector: Purchases / Redemptions (different row grains, so separate exports)
- Period presets — This month / Last month (default) / This year / Custom — where
  "last month" is the previous **calendar** month, so it reconciles against a monthly P&L
- Field checkboxes rendered from `GET /v1/vouchers/export/fields`, so the column list
  lives in one place and the UI cannot drift from the Worker
- Selection persists per-dataset in `localStorage`
- Personal-data fields gated behind a manager password, and **never persisted** — on a
  shared front-desk terminal a manager unlock must not carry into the next staff member's session

## Custom tick control

The portal builds its own `.combo`, `.day-menu` and `.day-cell` controls, but checkboxes
were still native `<input type="checkbox">` tinted with Tailwind classes — which renders
inconsistently across platforms and does not match the rest of the design.

Adds a `.tick` control next to the existing control CSS and applies it to **all seven**
checkboxes in the file, not just the new export ones: the four type-editor toggles, the
item-editor active toggle, the delete-confirmation gate, and the export field grid.

- The native input stays underneath, so label association, `x-model`, `@change`
  (`persistExportFields()`), and keyboard behaviour are unchanged.
- It is zero-sized rather than absolutely positioned — several of these live in modals with
  no positioned ancestor, where an absolute input would drift.
- Focus ring is painted on the `.tick` via `:focus-visible`.
- Both outlier layouts are preserved: `items-start` + `mt-0.5` on the wrapping delete
  confirmation (the offset moved onto the box, where it belongs), and the dense
  `inline-flex` export grid.

## Export day picker: Clear

The export picker now has the same `.day-clear` button as the search filters (CSS reused
unchanged), backed by a new `clearExportDay()`.

Clearing one bound leaves the range incomplete, which correctly disables **Download CSV**.
To stop that reading as a broken button, `exportRangeLabel()` now names the missing bound
("Choose a start date.") instead of going blank. This state is only reachable via Clear —
init runs `applyExportPeriod()`, so a preset always has both bounds.

## Notes

- New `apiBlob()` helper: the existing `api()` always calls `res.json()`, so it cannot carry
  a CSV body. Same Cloudflare Access redirect handling.
- Empty period still downloads a header-only CSV plus a "no rows" note — a silent no-op reads
  as a broken button.
- No new dependencies; no build step.

## Verification

- **Logic harness** against the real `staffApp()` object — now **23 checks**, up from 15.
  Adds the January year-rollover and leap-year February cases, the PII-not-persisted rule in
  both directions, and the new Clear behaviour (each bound clears independently, the menu
  closes, the label names the missing bound, and days become re-pickable once the opposing
  bound is gone). All pass.
- **Browser click-through** driven headlessly against the local Worker with stubbed data:
  Export panel renders, `Clear` flips the label to "Choose a start date." and disables
  Download, and the picker closes. No page errors.
- **Every tick instance checked in situ**, not just the export ones — the four type-editor
  toggles bind and reflect real values, `Space` toggles via keyboard, computed styles confirm
  `#8b1c23` fill + white mark when checked and white + soft border when unchecked, the focus
  ring lands on the box, and the delete confirmation keeps `flex-start` with a 2px tick offset.

Still outstanding: click-through against the **deployed** Worker (local run used a stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)