### PR TITLE
feat(vouchers): restructure voucher-type editor into distinct section cards

### DIFF
--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -1966,12 +1966,13 @@
           <div class="grid gap-5">
 
         <!-- Identity & rules -->
-        <fieldset class="grid sm:grid-cols-2 gap-x-4 gap-y-3">
-          <div class="col-span-full flex items-center gap-2.5 pb-2 mb-1 border-b border-neutral-200">
+        <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-x-4 gap-y-3.5">
+          <div class="col-span-full flex items-center gap-2.5 pb-2.5 mb-0.5 border-b border-neutral-200/80">
             <div class="section-icon"><svg viewBox="0 0 24 24"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></div>
             <span class="text-xs font-semibold text-neutral-600 uppercase tracking-wider">Identity &amp; rules</span>
           </div>
 
+          <!-- Row 1: what it is — Type ID · Display name · Revenue class -->
           <!-- Type ID (immutable once created) -->
           <div>
             <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">
@@ -1992,29 +1993,6 @@
               class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
           </div>
 
-          <!-- Description -->
-          <div class="sm:col-span-2">
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Description<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Internal note for staff only. Never shown to customers.</span></span></label>
-            <textarea x-model="typeForm.description" rows="2"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj"></textarea>
-          </div>
-
-          <!-- Availability -->
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Availability<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Where this type can be sold — both (customer page + staff), online (customer page only), or staff_only (staff Create flow only).</span></span></label>
-            <div class="combo" @click.outside="availabilityOpen = false" @keydown.escape.window="availabilityOpen = false">
-              <button type="button" @click="availabilityOpen = !availabilityOpen" :aria-expanded="availabilityOpen.toString()" class="combo-trigger">
-                <span x-text="typeForm.availability"></span>
-                <svg class="combo-chevron" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"/></svg>
-              </button>
-              <div x-show="availabilityOpen" x-transition.origin.top x-cloak class="combo-menu">
-                <button type="button" @click="typeForm.availability = 'both'; availabilityOpen = false; refreshPreview()" :class="typeForm.availability === 'both' ? 'active' : ''" class="combo-option">both</button>
-                <button type="button" @click="typeForm.availability = 'online'; availabilityOpen = false; refreshPreview()" :class="typeForm.availability === 'online' ? 'active' : ''" class="combo-option">online</button>
-                <button type="button" @click="typeForm.availability = 'staff_only'; availabilityOpen = false; refreshPreview()" :class="typeForm.availability === 'staff_only' ? 'active' : ''" class="combo-option">staff_only</button>
-              </div>
-            </div>
-          </div>
-
           <!-- Revenue class -->
           <div>
             <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Revenue class<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">What this type is, economically. sale — sold at full price. promo_sale — sold at a promotional price. credit — account credit, no money in. comp — given away. Only sale and promo_sale count as revenue in the stats.</span></span></label>
@@ -2032,6 +2010,45 @@
             </div>
           </div>
 
+          <!-- Row 2: where &amp; to whom it shows — Availability · Promo ID · Sort order -->
+          <!-- Availability -->
+          <div>
+            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Availability<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Where this type can be sold — both (customer page + staff), online (customer page only), or staff_only (staff Create flow only).</span></span></label>
+            <div class="combo" @click.outside="availabilityOpen = false" @keydown.escape.window="availabilityOpen = false">
+              <button type="button" @click="availabilityOpen = !availabilityOpen" :aria-expanded="availabilityOpen.toString()" class="combo-trigger">
+                <span x-text="typeForm.availability"></span>
+                <svg class="combo-chevron" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+              <div x-show="availabilityOpen" x-transition.origin.top x-cloak class="combo-menu">
+                <button type="button" @click="typeForm.availability = 'both'; availabilityOpen = false; refreshPreview()" :class="typeForm.availability === 'both' ? 'active' : ''" class="combo-option">both</button>
+                <button type="button" @click="typeForm.availability = 'online'; availabilityOpen = false; refreshPreview()" :class="typeForm.availability === 'online' ? 'active' : ''" class="combo-option">online</button>
+                <button type="button" @click="typeForm.availability = 'staff_only'; availabilityOpen = false; refreshPreview()" :class="typeForm.availability === 'staff_only' ? 'active' : ''" class="combo-option">staff_only</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Promo ID -->
+          <div>
+            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Promo ID<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Restricts this type to a promo link (…?promo=ID). Blank = shown to everyone. Not shown publicly.</span></span></label>
+            <input type="text" x-model="typeForm.promo_id" placeholder="blank = none"
+              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+          </div>
+
+          <!-- Sort order -->
+          <div>
+            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Sort order<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Lower numbers appear first in the customer purchase list and staff dropdowns. You can also drag to reorder on the Voucher Types list.</span></span></label>
+            <input type="number" x-model="typeForm.sort_order"
+              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+          </div>
+
+          <!-- Description (internal, full width) -->
+          <div class="col-span-full">
+            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Description<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Internal note for staff only. Never shown to customers.</span></span></label>
+            <textarea x-model="typeForm.description" rows="2"
+              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj"></textarea>
+          </div>
+
+          <!-- Row 3: the rules — Expiry months · Max per customer · Limit period (cap pair kept together) -->
           <!-- Expiry months -->
           <div>
             <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Expiry months<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Months until an issued voucher expires. Blank = never. Drives the expiry date printed on the voucher.</span></span></label>
@@ -2062,38 +2079,27 @@
             </div>
           </div>
 
-          <!-- Promo ID -->
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Promo ID<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Restricts this type to a promo link (…?promo=ID). Blank = shown to everyone. Not shown publicly.</span></span></label>
-            <input type="text" x-model="typeForm.promo_id" placeholder="blank = none"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+          <!-- Flags -->
+          <div class="col-span-full flex flex-wrap items-center gap-x-8 gap-y-2.5 pt-2 mt-0.5 border-t border-neutral-200/80">
+            <!-- Physical voucher -->
+            <label class="flex items-center gap-2.5 text-sm text-neutral-700">
+              <input type="checkbox" x-model="typeForm.is_physical" class="tick-input" />
+              <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
+              Physical voucher<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">No email is sent — vouchers of this type are physical cards, and are flagged 'Physical' in staff views.</span></span>
+            </label>
+
+            <!-- Active -->
+            <label class="flex items-center gap-2.5 text-sm text-neutral-700">
+              <input type="checkbox" x-model="typeForm.is_active" class="tick-input" />
+              <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
+              Active<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Turns this type on or off. Inactive types are hidden from customers and the staff Create dropdown.</span></span>
+            </label>
           </div>
-
-          <!-- Sort order -->
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Sort order<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Lower numbers appear first in the customer purchase list and staff dropdowns. You can also drag to reorder on the Voucher Types list.</span></span></label>
-            <input type="number" x-model="typeForm.sort_order"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
-          </div>
-
-          <!-- Physical voucher -->
-          <label class="flex items-center gap-2.5 text-sm text-neutral-700">
-            <input type="checkbox" x-model="typeForm.is_physical" class="tick-input" />
-            <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
-            Physical voucher<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">No email is sent — vouchers of this type are physical cards, and are flagged 'Physical' in staff views.</span></span>
-          </label>
-
-          <!-- Active -->
-          <label class="flex items-center gap-2.5 text-sm text-neutral-700">
-            <input type="checkbox" x-model="typeForm.is_active" class="tick-input" />
-            <span class="tick"><svg class="tick-mark" viewBox="0 0 24 24"><path d="M5 12.5 9.5 17 19 7"/></svg></span>
-            Active<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Turns this type on or off. Inactive types are hidden from customers and the staff Create dropdown.</span></span>
-          </label>
         </fieldset>
 
         <!-- Email content -->
-        <fieldset class="grid gap-3">
-          <div class="col-span-full flex items-center gap-2.5 pb-2 mb-1 border-b border-neutral-200">
+        <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid gap-3">
+          <div class="col-span-full flex items-center gap-2.5 pb-2.5 mb-0.5 border-b border-neutral-200/80">
             <div class="section-icon"><svg viewBox="0 0 24 24"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg></div>
             <span class="text-xs font-semibold text-neutral-600 uppercase tracking-wider">Email content</span>
             <div class="ml-auto flex items-center gap-1.5">
@@ -2147,8 +2153,8 @@
         </fieldset>
 
         <!-- Branding -->
-        <fieldset class="grid sm:grid-cols-2 gap-x-4 gap-y-3 content-start">
-          <div class="col-span-full flex items-center gap-2.5 pb-2 mb-1 border-b border-neutral-200">
+        <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3.5 content-start">
+          <div class="col-span-full flex items-center gap-2.5 pb-2.5 mb-0.5 border-b border-neutral-200/80">
             <div class="section-icon"><svg viewBox="0 0 24 24"><path d="M9.06 11.9l8.07-8.06a2.85 2.85 0 1 1 4.03 4.03l-8.06 8.08"/><path d="M7.07 14.94c-1.66 0-3 1.35-3 3.02 0 1.33-2.5 1.52-2 2.02 1 1 2.48 1.02 3 1.02 2.2 0 4-1.8 4-4.04a3.01 3.01 0 0 0-2-2.02z"/></svg></div>
             <span class="text-xs font-semibold text-neutral-600 uppercase tracking-wider">Branding</span>
           </div>
@@ -2183,77 +2189,16 @@
         </fieldset>
 
         <!-- Public page -->
-        <fieldset class="grid sm:grid-cols-2 gap-x-4 gap-y-3 content-start">
-          <div class="col-span-full flex items-center gap-2.5 pb-2 mb-1 border-b border-neutral-200">
+        <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid gap-4">
+          <div class="col-span-full flex items-center gap-2.5 pb-2.5 mb-0.5 border-b border-neutral-200/80">
             <div class="section-icon"><svg viewBox="0 0 24 24"><path d="M3 9h18M9 21V9M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"/></svg></div>
             <span class="text-xs font-semibold text-neutral-600 uppercase tracking-wider">Public page</span>
             <span class="text-[0.67rem] text-neutral-400 normal-case tracking-normal">Leave any field blank to use the Gift Certificate's</span>
           </div>
 
-          <!-- Hero headline -->
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero headline<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Main heading on the public voucher page. Leave blank to use the Gift Certificate's.</span></span></label>
-            <input type="text" x-model="typeForm.hero_headline"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
-          </div>
+          <!-- Layout mirrors the live page: full-width backdrop, then hero copy beside artwork, then the features block. -->
 
-          <!-- Hero subheadline -->
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero subheadline<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Supporting line under the headline. Leave blank to use the Gift Certificate's.</span></span></label>
-            <input type="text" x-model="typeForm.hero_subheadline"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
-          </div>
-
-          <!-- Call-to-action label -->
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Button label<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Text on the hero button that scrolls down to the purchase options.</span></span></label>
-            <input type="text" x-model="typeForm.cta_label"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
-          </div>
-
-          <!-- Features heading -->
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Feature section heading<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Heading above the feature cards.</span></span></label>
-            <input type="text" x-model="typeForm.features_heading"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
-          </div>
-
-          <!-- Features subheading -->
-          <div class="col-span-full">
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Feature section subheading<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Smaller line under the feature section heading.</span></span></label>
-            <input type="text" x-model="typeForm.features_subheading"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
-          </div>
-
-          <!-- Hero description -->
-          <div class="col-span-full">
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero description (Markdown)<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Optional intro paragraph under the subheadline. Supports the same Markdown as the terms. Leave blank to show nothing.</span></span></label>
-            <textarea x-model="typeForm.hero_description" rows="3"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj"></textarea>
-          </div>
-
-          <!-- Feature cards -->
-          <div class="col-span-full">
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Feature cards (Markdown)<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">'## Heading' starts a card; the text under it is the card body. Leave blank to hide the section.</span></span></label>
-            <textarea x-model="typeForm.features_md" rows="6"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj"></textarea>
-          </div>
-
-          <!-- Hero artwork -->
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero artwork URL<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Artwork shown beside the hero copy. Leave blank for the default voucher image.</span></span></label>
-            <input type="url" x-model="typeForm.hero_image_url" placeholder="https://tools.urbanjungleirc.com/assets/img/…"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
-            <div x-show="typeForm.hero_image_url" class="mt-2">
-              <img :src="typeForm.hero_image_url" alt=""
-                class="w-full h-24 object-cover rounded-lg border border-neutral-200"
-                x-on:load="$el.nextElementSibling.style.display = 'none'; $el.style.display = ''"
-                x-on:error="$el.style.display = 'none'; $el.nextElementSibling.style.display = ''" />
-              <p style="display:none" class="text-xs text-red-600 mt-1">Image didn't load — check the URL is public and points directly at an image file.</p>
-            </div>
-          </div>
-
-          <!-- Hero background image -->
+          <!-- Hero backdrop (full-width band behind everything) -->
           <div>
             <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero background URL<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Photo behind the hero. Leave blank to use the accent colour gradient. Text sits over this — pick something that keeps white type readable.</span></span></label>
             <input type="url" x-model="typeForm.hero_background_url" placeholder="https://tools.urbanjungleirc.com/assets/img/…"
@@ -2266,11 +2211,85 @@
               <p style="display:none" class="text-xs text-red-600 mt-1">Image didn't load — check the URL is public and points directly at an image file.</p>
             </div>
           </div>
+
+          <!-- Hero row: copy (left) beside artwork (right), as they sit on the page -->
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-4 gap-y-4 items-start">
+            <!-- Hero copy stack -->
+            <div class="grid gap-3">
+              <!-- Hero headline -->
+              <div>
+                <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero headline<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Main heading on the public voucher page. Leave blank to use the Gift Certificate's.</span></span></label>
+                <input type="text" x-model="typeForm.hero_headline"
+                  class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+              </div>
+
+              <!-- Hero subheadline -->
+              <div>
+                <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero subheadline<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Supporting line under the headline. Leave blank to use the Gift Certificate's.</span></span></label>
+                <input type="text" x-model="typeForm.hero_subheadline"
+                  class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+              </div>
+
+              <!-- Hero description -->
+              <div>
+                <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero description (Markdown)<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Optional intro paragraph under the subheadline. Supports the same Markdown as the terms. Leave blank to show nothing.</span></span></label>
+                <textarea x-model="typeForm.hero_description" rows="3"
+                  class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj"></textarea>
+              </div>
+
+              <!-- Call-to-action label -->
+              <div>
+                <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Button label<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Text on the hero button that scrolls down to the purchase options.</span></span></label>
+                <input type="text" x-model="typeForm.cta_label"
+                  class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+              </div>
+            </div>
+
+            <!-- Hero artwork (sits beside the copy) -->
+            <div>
+              <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero artwork URL<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Artwork shown beside the hero copy. Leave blank for the default voucher image.</span></span></label>
+              <input type="url" x-model="typeForm.hero_image_url" placeholder="https://tools.urbanjungleirc.com/assets/img/…"
+                class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+              <div x-show="typeForm.hero_image_url" class="mt-2">
+                <img :src="typeForm.hero_image_url" alt=""
+                  class="w-full h-40 object-cover rounded-lg border border-neutral-200"
+                  x-on:load="$el.nextElementSibling.style.display = 'none'; $el.style.display = ''"
+                  x-on:error="$el.style.display = 'none'; $el.nextElementSibling.style.display = ''" />
+                <p style="display:none" class="text-xs text-red-600 mt-1">Image didn't load — check the URL is public and points directly at an image file.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Features block -->
+          <div class="grid gap-3 pt-3.5 mt-0.5 border-t border-neutral-200/80">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
+              <!-- Features heading -->
+              <div>
+                <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Feature section heading<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Heading above the feature cards.</span></span></label>
+                <input type="text" x-model="typeForm.features_heading"
+                  class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+              </div>
+
+              <!-- Features subheading -->
+              <div>
+                <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Feature section subheading<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Smaller line under the feature section heading.</span></span></label>
+                <input type="text" x-model="typeForm.features_subheading"
+                  class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
+              </div>
+            </div>
+
+            <!-- Feature cards -->
+            <div>
+              <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Feature cards (Markdown)<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">'## Heading' starts a card; the text under it is the card body. Leave blank to hide the section.</span></span></label>
+              <textarea x-model="typeForm.features_md" rows="6"
+                class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj"></textarea>
+            </div>
+          </div>
         </fieldset>
 
         <!-- Staff -->
-        <fieldset class="grid gap-3">
-          <div class="col-span-full flex items-center gap-2.5 pb-2 mb-1 border-b border-neutral-200">
+        <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid gap-3">
+          <div class="col-span-full flex items-center gap-2.5 pb-2.5 mb-0.5 border-b border-neutral-200/80">
             <div class="section-icon"><svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></div>
             <span class="text-xs font-semibold text-neutral-600 uppercase tracking-wider">Staff</span>
           </div>


### PR DESCRIPTION
Reorganises the voucher-type editor so the sections are visually distinct and the fields sit in a sensible order.

## Changes
- **Section cards** — each section (Identity & rules, Email content, Branding, Public page, Staff) now sits in its own brand-tinted `.section-card` instead of blending into the white modal.
- **Identity & rules** — 3-column grid; fields reordered by meaning (identity → visibility/exposure → rules), with the max-per-customer / limit-period cap pair kept adjacent.
- **Public page** — reflowed to mirror the live site: full-width hero background, hero copy beside artwork, then the features block.
- **Email / Branding / Staff** — same card treatment, field order unchanged.

Pure markup restructure: all 27 `typeForm` bindings preserved, no JS changes, live email preview and save logic untouched. Verified balanced (5/5 fieldsets, 395/395 divs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)