### PR TITLE
feat(vouchers): client image pipeline for the type editor

### DIFF
--- a/vouchers/.gitignore
+++ b/vouchers/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/vouchers/image-pipeline.js
+++ b/vouchers/image-pipeline.js
@@ -1,0 +1,108 @@
+// Client-side image pipeline for the voucher type editor.
+//
+// The size cap bounds the STORED RESULT, not the upload: a 4000 px image
+// destined for a 576 px box is downscaled automatically, with no prompt,
+// because there is no judgement call in shrinking it. The one place human
+// judgement earns an interruption is format conversion — auto-converting
+// everything to JPEG would wreck flat-colour graphics and transparency.
+//
+// These decisions are separated from the canvas work so they are testable
+// without a DOM. See
+// voucher-app/docs/superpowers/specs/2026-08-03-staff-uploadable-voucher-type-images-design.md
+
+const KB = 1024;
+const MB = 1024 * 1024;
+
+// Targets derived from the customer page CSS. The hero's largest rendered
+// size is 576 CSS px ON MOBILE (max-w-xl); desktop is smaller (w-[30rem] /
+// w-[34rem]). 1200 is just over 2x, so it stays crisp on retina.
+//
+// The hero is cropped to TWO shapes — aspect-[21/9] on mobile, aspect-[4/3]
+// on desktop. Supplying the taller 4:3 means object-cover matches width and
+// crops height for the mobile box, so neither breakpoint upscales.
+export const ROLE_TARGETS = {
+  hero:       { width: 1200, height: 900,  minWidth: 1000 },
+  background: { width: 1920, height: 1080, minWidth: 1400 },
+};
+
+export const ABSURD_BYTES = 20 * MB;
+export const SOFT_BUDGET_BYTES = 400 * KB;
+export const HARD_CAP_BYTES = 2 * MB;
+
+// PNG, JPEG and WebP only, matching the Worker's magic-byte sniffer. SVG is
+// refused on security grounds (it can carry <script> and would be served
+// same-origin from the Worker that also serves staff endpoints); GIF on
+// taste. Keep this list in step with the Worker — it ships to a different
+// repo, so it cannot be imported.
+export const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+
+// null means "already small enough — leave it alone".
+export function planResize({ role, width, height }) {
+  const target = ROLE_TARGETS[role];
+  if (!target || !width || !height) return null;
+  if (width <= target.width && height <= target.height) return null;
+
+  const scale = Math.min(target.width / width, target.height / height);
+  return {
+    width: Math.round(width * scale),
+    height: Math.round(height * scale),
+  };
+}
+
+export function tooLargeToProcess(bytes) { return bytes > ABSURD_BYTES; }
+export function overSoftBudget(bytes)    { return bytes > SOFT_BUDGET_BYTES; }
+export function overHardCap(bytes)       { return bytes > HARD_CAP_BYTES; }
+
+export function isTooSmall({ role, width }) {
+  const target = ROLE_TARGETS[role];
+  return Boolean(target) && width < target.minWidth;
+}
+
+// Format is the one thing that IS a hard reject — unlike dimensions, an
+// unsupported type cannot be salvaged, and the Worker would refuse it after
+// a pointless round trip.
+export function isAcceptedType(type) {
+  return ACCEPTED_TYPES.includes(String(type || '').toLowerCase().trim());
+}
+
+export function formatBytes(bytes) {
+  if (bytes >= MB) return `${(bytes / MB).toFixed(1)} MB`;
+  return `${Math.round(bytes / KB)} KB`;
+}
+
+// ── Canvas glue (browser only) ──────────────────────────────────────────────
+
+// Decodes, downscales if needed, and re-encodes. Format is PRESERVED by
+// default; pass mimeType to convert (that is the soft-budget prompt's job).
+//
+// The format guard lives here rather than only in the caller because the
+// file input's `accept` attribute does not apply to drag-and-drop, and the
+// no-resize-no-convert path below hands back the ORIGINAL bytes — so without
+// this, a dropped SVG would sail through to the Worker untouched.
+export async function resizeImage(file, { role, mimeType = null, quality = 0.85 } = {}) {
+  if (!isAcceptedType(file?.type)) {
+    throw new Error('That file type is not supported. Please use a PNG, JPEG or WebP image.');
+  }
+
+  const bitmap = await createImageBitmap(file);
+  const plan = planResize({ role, width: bitmap.width, height: bitmap.height });
+  const width = plan ? plan.width : bitmap.width;
+  const height = plan ? plan.height : bitmap.height;
+
+  // No resize and no conversion asked for: hand back the original bytes
+  // untouched rather than round-tripping them through a canvas.
+  if (!plan && !mimeType) {
+    bitmap.close?.();
+    return { blob: file, width, height };
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  canvas.getContext('2d').drawImage(bitmap, 0, 0, width, height);
+  bitmap.close?.();
+
+  const type = mimeType || file.type || 'image/png';
+  const blob = await new Promise(r => canvas.toBlob(r, type, quality));
+  return { blob, width, height };
+}

--- a/vouchers/package.json
+++ b/vouchers/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "uj-voucher-editor",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.0"
+  }
+}

--- a/vouchers/test/image-pipeline.test.js
+++ b/vouchers/test/image-pipeline.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ROLE_TARGETS, ABSURD_BYTES, SOFT_BUDGET_BYTES, HARD_CAP_BYTES, ACCEPTED_TYPES,
+  planResize, tooLargeToProcess, isTooSmall, overSoftBudget, overHardCap, formatBytes,
+  isAcceptedType, resizeImage,
+} from '../image-pipeline.js';
+
+const KB = 1024;
+const MB = 1024 * 1024;
+
+describe('ROLE_TARGETS', () => {
+  // Derived from the customer page CSS, not guessed: the hero's largest
+  // rendered size is 576 CSS px on MOBILE (max-w-xl); desktop is smaller.
+  // 1200 is just over 2x for retina.
+  it('targets 1200x900 for hero and 1920x1080 for background', () => {
+    expect(ROLE_TARGETS.hero).toMatchObject({ width: 1200, height: 900 });
+    expect(ROLE_TARGETS.background).toMatchObject({ width: 1920, height: 1080 });
+  });
+});
+
+describe('planResize', () => {
+  it('returns null when the image is already at or under target', () => {
+    expect(planResize({ role: 'hero', width: 1200, height: 900 })).toBe(null);
+    expect(planResize({ role: 'hero', width: 800, height: 600 })).toBe(null);
+  });
+
+  it('scales a large image down to fit the target box, preserving aspect', () => {
+    expect(planResize({ role: 'hero', width: 4000, height: 3000 }))
+      .toEqual({ width: 1200, height: 900 });
+  });
+
+  it('fits by the constraining dimension for a wide image', () => {
+    // 4000x1000 (4:1) into a 1200x900 box -> width binds.
+    expect(planResize({ role: 'hero', width: 4000, height: 1000 }))
+      .toEqual({ width: 1200, height: 300 });
+  });
+
+  it('fits by height for a tall image', () => {
+    // 1000x4000 into 1200x900 -> height binds.
+    expect(planResize({ role: 'hero', width: 1000, height: 4000 }))
+      .toEqual({ width: 225, height: 900 });
+  });
+
+  it('uses the background target for the background role', () => {
+    expect(planResize({ role: 'background', width: 3840, height: 2160 }))
+      .toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('rounds to whole pixels', () => {
+    const out = planResize({ role: 'hero', width: 3333, height: 2222 });
+    expect(Number.isInteger(out.width)).toBe(true);
+    expect(Number.isInteger(out.height)).toBe(true);
+  });
+});
+
+describe('thresholds', () => {
+  it('flags absurd inputs at 20 MB so a browser tab does not fall over', () => {
+    expect(ABSURD_BYTES).toBe(20 * MB);
+    expect(tooLargeToProcess(21 * MB)).toBe(true);
+    expect(tooLargeToProcess(5 * MB)).toBe(false);
+  });
+
+  it('sets the soft conversion budget at 400 KB', () => {
+    expect(SOFT_BUDGET_BYTES).toBe(400 * KB);
+    expect(overSoftBudget(880 * KB)).toBe(true);
+    expect(overSoftBudget(110 * KB)).toBe(false);
+  });
+
+  it('sets the hard cap at 2 MB, matching the Worker', () => {
+    expect(HARD_CAP_BYTES).toBe(2 * MB);
+    expect(overHardCap(2 * MB + 1)).toBe(true);
+    expect(overHardCap(2 * MB)).toBe(false);
+  });
+
+  // Staff cannot perceive softness on a desktop preview, but every phone
+  // user will — hence a warning rather than silence.
+  it('warns below 1000 px wide for hero and 1400 px for background', () => {
+    expect(isTooSmall({ role: 'hero', width: 640 })).toBe(true);
+    expect(isTooSmall({ role: 'hero', width: 1200 })).toBe(false);
+    expect(isTooSmall({ role: 'background', width: 1200 })).toBe(true);
+    expect(isTooSmall({ role: 'background', width: 1920 })).toBe(false);
+  });
+
+  // Dimensions are NEVER a hard reject — object-cover copes with any aspect,
+  // so a wrong shape is an aesthetic problem, not a broken page.
+  it('has no function that rejects on dimensions', async () => {
+    const mod = await import('../image-pipeline.js');
+    expect(Object.keys(mod)).not.toContain('rejectOnDimensions');
+  });
+});
+
+// Format IS a hard reject, unlike dimensions. The file input's `accept`
+// attribute does not apply to drag-and-drop, and resizeImage hands back the
+// original bytes when nothing needs doing — so without a guard here a dropped
+// SVG would reach the Worker untouched and fail there instead.
+describe('isAcceptedType', () => {
+  it('accepts exactly PNG, JPEG and WebP', () => {
+    expect(ACCEPTED_TYPES).toEqual(['image/png', 'image/jpeg', 'image/webp']);
+    expect(isAcceptedType('image/png')).toBe(true);
+    expect(isAcceptedType('image/jpeg')).toBe(true);
+    expect(isAcceptedType('image/webp')).toBe(true);
+  });
+
+  // SVG on security grounds (it can carry <script>, served same-origin from
+  // the Worker that also serves staff endpoints), GIF on taste.
+  it('refuses SVG and GIF', () => {
+    expect(isAcceptedType('image/svg+xml')).toBe(false);
+    expect(isAcceptedType('image/gif')).toBe(false);
+  });
+
+  it('refuses non-images and a missing type', () => {
+    expect(isAcceptedType('application/pdf')).toBe(false);
+    expect(isAcceptedType('')).toBe(false);
+    expect(isAcceptedType(undefined)).toBe(false);
+    expect(isAcceptedType(null)).toBe(false);
+  });
+
+  // Browsers are inconsistent about case; a file is not unsupported merely
+  // because its type arrived shouted.
+  it('is case- and whitespace-insensitive', () => {
+    expect(isAcceptedType('IMAGE/PNG')).toBe(true);
+    expect(isAcceptedType(' image/jpeg ')).toBe(true);
+  });
+});
+
+describe('resizeImage refuses unsupported formats before touching the file', () => {
+  // This test runs with no DOM at all. That it rejects with the copy below
+  // rather than a canvas/createImageBitmap error is the proof that the guard
+  // fires before any decode or upload work happens.
+  it('rejects an SVG with advisory Australian English copy', async () => {
+    await expect(resizeImage({ type: 'image/svg+xml', size: 1024 }, { role: 'hero' }))
+      .rejects.toThrow('That file type is not supported. Please use a PNG, JPEG or WebP image.');
+  });
+
+  it('rejects a file with no type at all', async () => {
+    await expect(resizeImage({ size: 1024 }, { role: 'hero' }))
+      .rejects.toThrow(/not supported/);
+  });
+
+  it('lets an accepted type past the guard', async () => {
+    // No DOM here, so it must fail LATER, at decode — not at the guard.
+    await expect(resizeImage({ type: 'image/png', size: 1024 }, { role: 'hero' }))
+      .rejects.not.toThrow(/not supported/);
+  });
+});
+
+describe('formatBytes', () => {
+  it('renders KB below a megabyte and MB above', () => {
+    expect(formatBytes(880 * KB)).toBe('880 KB');
+    expect(formatBytes(2.4 * MB)).toBe('2.4 MB');
+  });
+});


### PR DESCRIPTION
Task 8 of the staff-uploadable voucher type images plan. Enabler ticket — a module with unit tests, no user-visible slice yet; the editor UI that consumes it is Task 9.

Tracked as ujFront/vouchers#26.

## What this adds

- `vouchers/image-pipeline.js` — pure resize/convert decisions (`planResize`, `isTooSmall`, `overSoftBudget`, `overHardCap`, `tooLargeToProcess`, `formatBytes`, `ROLE_TARGETS`) plus thin canvas glue (`resizeImage`). The decisions are separated so they are testable without a DOM.
- `vouchers/test/image-pipeline.test.js` — 20 tests.
- `vouchers/package.json`, `vouchers/.gitignore` — minimal vitest harness; this directory had no test runner. `node_modules/` and `package-lock.json` are ignored, matching `cloudflare-payments-proxy/.gitignore`.

Nothing imports this module yet, so merging changes no behaviour on the live site.

## One addition beyond the plan

The plan's Task 8 interface list has no format check, and Task 9's only defence is `<input accept="image/png,image/jpeg,image/webp">` — which browsers **do not apply to drag-and-drop**. Combined with `resizeImage` handing back the original bytes when no resize or conversion is needed, a dropped SVG would have reached the Worker untouched.

The Worker sniffs magic bytes so this was never a security hole, but issue #26 requires unsupported formats be "refused **before any upload is attempted**". So this adds `ACCEPTED_TYPES` / `isAcceptedType()` and a guard that throws inside `resizeImage`, keeping the refusal true regardless of what Task 9 does. The thrown error lands in Task 9's existing `catch` and renders through the same channel as the Worker's error copy.

## Verification

- `npm test` — 20/20 pass. Guard tests confirmed to bite under mutation.
- Canvas glue driven in real Chromium via a scratch harness kept outside this repo (public repo, Pages serves every path): 4000x3000 hero downscales to 1200x900 and 11.4 MB to 699 KB, well under the 2 MB cap; 3840x2160 background to 1920x1080; already-small images pass through byte-identical; PNG to JPEG conversion 1.5 MB to 136 KB; SVG and GIF refused; WebP accepted. 10/10, no console errors.
- Two-axis review (standards + spec) run before merge; the lockfile finding is fixed in this branch.

## Known, by design

AC "output stays under the hard stored cap" is met by this module plus Task 9's `overHardCap` gate, not by the pipeline alone — `resizeImage` returns original bytes for an already-small-but-heavy source. That split is the plan's design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)