### PR TITLE
fix(roster): narrow Deputy window to ±30 days

### DIFF
--- a/cloudflare-worker/src/index.js
+++ b/cloudflare-worker/src/index.js
@@ -58,7 +58,7 @@ export default {
         }
 
         const nowMs = Date.now();
-        const pastDays  = parseInt(env.DEPUTY_WINDOW_PAST_DAYS   ?? "60", 10);
+        const pastDays  = parseInt(env.DEPUTY_WINDOW_PAST_DAYS   ?? "30", 10);
         const futureDays = parseInt(env.DEPUTY_WINDOW_FUTURE_DAYS ?? "30", 10);
         const fromTs = Math.floor((nowMs - pastDays   * 86400000) / 1000);
         const toTs   = Math.floor((nowMs + futureDays * 86400000) / 1000);

--- a/cloudflare-worker/test/roster.test.js
+++ b/cloudflare-worker/test/roster.test.js
@@ -66,14 +66,14 @@ afterEach(() => {
 });
 
 describe('/api/roster Deputy window', () => {
-  it('queries 60 days back and 30 days forward by default', async () => {
+  it('queries 30 days back and 30 days forward by default', async () => {
     const deputy = stubDeputy({ parents: [parent(1, NOW / 1000)] });
 
     const res = await call();
 
     expect(res.status).toBe(200);
     const { search } = deputy.parentCalls()[0];
-    expect(search.s1).toMatchObject({ field: 'StartTime', type: 'ge', data: (NOW - 60 * DAY) / 1000 });
+    expect(search.s1).toMatchObject({ field: 'StartTime', type: 'ge', data: (NOW - 30 * DAY) / 1000 });
     expect(search.s2).toMatchObject({ field: 'StartTime', type: 'le', data: (NOW + 30 * DAY) / 1000 });
   });
 
@@ -90,7 +90,7 @@ describe('/api/roster Deputy window', () => {
 
 describe('/api/roster pagination past the 500-record cap', () => {
   it('pages the parent query until Deputy returns a short page', async () => {
-    // 620 records over the 90-day window: one full page plus a remainder.
+    // 620 records over the window: one full page plus a remainder.
     const parents = Array.from({ length: 620 }, (_, i) => parent(i + 1, NOW / 1000 + i * 60));
     const deputy = stubDeputy({ parents });
 

--- a/cloudflare-worker/test/worker.test.js
+++ b/cloudflare-worker/test/worker.test.js
@@ -110,7 +110,7 @@ describe('/api/roster', () => {
     ]);
   });
 
-  it('asks Deputy for a 60-day-past / 30-day-future window by default', async () => {
+  it('asks Deputy for a 30-day-past / 30-day-future window by default', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(NOW_MS);
     const upstream = stubFetch(jsonResponse([]), jsonResponse([]));
 
@@ -125,7 +125,7 @@ describe('/api/roster', () => {
     expect(search.s1).toEqual({
       field: 'StartTime',
       type: 'ge',
-      data: Math.floor((NOW_MS - 60 * DAY_MS) / 1000),
+      data: Math.floor((NOW_MS - 30 * DAY_MS) / 1000),
     });
     expect(search.s2).toEqual({
       field: 'StartTime',

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -30,7 +30,7 @@ COMMITTER_EMAIL = "devnull+uj-tools@happyk.au"
 DEPUTY_URL = "https://8fbf4e19073503.au.deputy.com/api/v1"
 
 # How many days before/after today to fetch from Deputy
-DEPUTY_WINDOW_PAST_DAYS = "60"
+DEPUTY_WINDOW_PAST_DAYS = "30"
 DEPUTY_WINDOW_FUTURE_DAYS = "30"
 
 # Secrets (set via `wrangler secret put`):


### PR DESCRIPTION
Closes #17. Follow-up to #9.

Narrows the past leg from 60 to 30 days; future leg unchanged at 30.

At the measured ~12 shifts/day, the 90-day window pulled ~1,080 Deputy records — past the 500-record page cap, so every roster load depended on the paging loop. This brings it to ~720 and buys headroom, without touching what staff actually use.

## Changes

- `DEPUTY_WINDOW_PAST_DAYS` 60 → 30 in `wrangler.toml` and the matching code default
- Default-window assertions retargeted in both suites

## Verification

- 28 tests pass (22 characterisation, 6 paging)
- Override tests still use values distinct from the new default (5/3 and 7/14), so they continue to prove config wins rather than coincidentally matching

## Not addressed

The all-or-nothing failure mode is unchanged — see #17. If a Deputy query fails or trips the page ceiling, the whole roster 502s including today. That needs a near-window-first fetch, not a smaller window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)