### PR TITLE
feat(roster): term week and school break context on the roster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ The main roster settings live in the `CONFIG` block near the top of the script i
 Important fields:
 
 - `rosterUrl` - `/api/roster` in production, `localhost:8787/api/roster` in local/dev
+- `calendarUrl` - `/api/calendar` in production; term week / school break context
 - `dayWindowDays` - fallback date nav range before roster data loads
 - `refreshIntervalMs` - background refresh interval
 - `roleOrder` - display order for known role groups
@@ -89,6 +90,27 @@ ADMIN:   '#374151'
 ```
 
 Keep these synced with Deputy area colors where practical. Green is reserved for the `on-now` state, so avoid using green for normal role colors.
+
+### Roster Day Context
+
+Under the day nav, `roster.html` shows one line describing the **selected**
+date — `Term 3 · Week 3 of 10`, or `School holidays · Term 4 starts Mon 12 Oct`.
+It is present in all three view modes.
+
+The data comes from `/api/calendar`, a route deliberately separate from
+`/api/roster` so a Deputy outage cannot remove term context. The Worker returns
+a per-date map spanning −30/+90 days, so navigating dates is a lookup and never
+a refetch. The two fetches are independent: either can fail without taking out
+the other.
+
+A **UJ term week** is a whole Mon–Sun week, snapped outward from the official WA
+term dates. This deliberately deviates from education.wa.edu.au — read
+`docs/adr/0002-uj-term-weeks-are-snapped.md` before touching the term table or
+the snapping logic. Definitions are in `CONTEXT.md`.
+
+The term table in `cloudflare-worker/src/calendar.js` is hardcoded through 2031
+and must be extended before then; the UI warns as it approaches expiry. Public
+holidays are not implemented yet — `publicHoliday` is always `null`.
 
 ### Deputy Worker Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ The main roster settings live in the `CONFIG` block near the top of the script i
 Important fields:
 
 - `rosterUrl` - `/api/roster` in production, `localhost:8787/api/roster` in local/dev
+- `calendarUrl` - `/api/calendar` in production; term week / school break context
 - `dayWindowDays` - fallback date nav range before roster data loads
 - `refreshIntervalMs` - background refresh interval
 - `roleOrder` - display order for known role groups
@@ -92,6 +93,27 @@ ADMIN:   '#374151'
 ```
 
 Keep these synced with Deputy area colors where practical. Green is reserved for the `on-now` state, so avoid using green for normal role colors.
+
+### Roster Day Context
+
+Under the day nav, `roster.html` shows one line describing the **selected**
+date — `Term 3 · Week 3 of 10`, or `School holidays · Term 4 starts Mon 12 Oct`.
+It is present in all three view modes.
+
+The data comes from `/api/calendar`, a route deliberately separate from
+`/api/roster` so a Deputy outage cannot remove term context. The Worker returns
+a per-date map spanning −30/+90 days, so navigating dates is a lookup and never
+a refetch. The two fetches are independent: either can fail without taking out
+the other.
+
+A **UJ term week** is a whole Mon–Sun week, snapped outward from the official WA
+term dates. This deliberately deviates from education.wa.edu.au — read
+`docs/adr/0002-uj-term-weeks-are-snapped.md` before touching the term table or
+the snapping logic. Definitions are in `CONTEXT.md`.
+
+The term table in `cloudflare-worker/src/calendar.js` is hardcoded through 2031
+and must be extended before then; the UI warns as it approaches expiry. Public
+holidays are not implemented yet — `publicHoliday` is always `null`.
 
 ### Deputy Worker Configuration
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,72 @@
+# Domain glossary — staff-site
+
+The language this repo uses for its own concepts. When naming things in code,
+issues, tests or commits, use the term as defined here rather than a synonym.
+
+Architectural decisions live in [`docs/adr/`](docs/adr/).
+
+## Roster calendar context
+
+Terms describing what kind of day a roster date is. Implemented in
+`cloudflare-worker/src/calendar.js` and served by `/api/calendar`.
+
+### UJ term week
+
+A Monday–Sunday calendar week within a school term. Week 1 begins the **Monday
+of the week containing the official term start**, even when school starts
+mid-week. Sunday closes the week.
+
+Terms run 9, 10 or 11 UJ term weeks. Never assume 10 — 2026 has one of each of
+the first two.
+
+*Avoid*: "school week", "teaching week". Those imply the official WA definition,
+which is not what we compute.
+
+### Term snapping
+
+Expanding the official WA term dates outward to whole UJ term weeks: the start
+back to its Monday, the end forward to its Sunday.
+
+UJ classes run Monday–Saturday regardless of where the official dates fall, so
+the first Saturday after school finishes is still term for us. This deliberately
+deviates from the official definition — see
+[ADR 0002](docs/adr/0002-uj-term-weeks-are-snapped.md) before changing it.
+
+### School break
+
+The period between two snapped terms. Because snapping always ends a term on a
+Sunday and starts the next on a Monday, a school break is **always exactly 14
+days, or 42 across summer**. That invariant is asserted across the whole term
+table in `cloudflare-worker/test/calendar.test.js`.
+
+A school break advertises the date the next term starts. That is the *snapped*
+Monday — the first day we ourselves call term — not the official start date.
+
+*Avoid*: "school holidays" as a code identifier. It is the right phrase in the
+UI, but "break" is the term in the data.
+
+### Public holiday
+
+A WA-gazetted holiday, including substitute days. Substitute days are distinct
+dates, not annotations: Anzac Day 2026 legitimately occupies both Saturday 25
+and Monday 27 April.
+
+Not implemented yet — `/api/calendar` returns `publicHoliday: null` for every
+date until the holiday feed lands.
+
+### Calendar staleness
+
+Two distinct conditions, deliberately shown differently:
+
+- **Broken** — the term table does not cover the date being viewed. Amber and
+  visible, because the answer is missing.
+- **Ageing** — the term table is within six months of running out. Muted grey,
+  because only the maintainer can act on it and staff should not be trained to
+  ignore warnings.
+
+These name the *warning tiers*, not the wire format. A day whose state the table
+cannot determine is `state: "unknown"` on the wire; **broken** is the tier that
+state puts the display into. The CSS class is `is-broken` for that reason.
+
+Green is reserved for the "on now" shift state and is never used for calendar
+states.

--- a/cloudflare-worker/src/calendar.js
+++ b/cloudflare-worker/src/calendar.js
@@ -1,0 +1,213 @@
+/**
+ * WA school term data and UJ term-week classification.
+ *
+ * This module is an implementation detail of the `/api/calendar` route. It is
+ * not a test seam — everything here is observable through that route, and the
+ * tests go through it. See docs/adr/0002-uj-term-weeks-are-snapped.md.
+ *
+ * Every date in here is a plain `YYYY-MM-DD` calendar date in Australia/Perth.
+ * There are no UTC instants in the classification path; `Date.UTC` appears only
+ * as fixed-size civil-day arithmetic, never to convert a moment in time.
+ */
+
+/**
+ * WA public school term dates, as published in the Government Gazette.
+ *
+ * Source: https://www.education.wa.edu.au/future-term-dates
+ * Last verified: 2026-08-05, by re-reading the page rather than trusting a parse.
+ *
+ * 2029 onward are published as "Preliminary dates only, to be confirmed" and
+ * may move. When they do, the tests will not notice — re-read the page.
+ *
+ * No machine-readable source for these exists: they are absent from both
+ * data.wa.gov.au and data.gov.au, and the public-holiday feed's school-holiday
+ * data stops in December 2026. Hence the hardcoded table.
+ *
+ * Deliberately duplicated from the UJ customer tools site
+ * (`tools-site/gas/ClubworxAPI/Code.js`), which keeps its own copy for a
+ * different consumer. That repository is not to be modified from here; the two
+ * copies were verified identical on 2026-08-05.
+ */
+const WA_SCHOOL_TERMS = {
+  2025: [
+    { start: "2025-02-05", end: "2025-04-11" },
+    { start: "2025-04-28", end: "2025-07-04" },
+    { start: "2025-07-21", end: "2025-09-26" },
+    { start: "2025-10-13", end: "2025-12-18" },
+  ],
+  2026: [
+    { start: "2026-02-02", end: "2026-04-02" },
+    { start: "2026-04-20", end: "2026-07-03" },
+    { start: "2026-07-20", end: "2026-09-25" },
+    { start: "2026-10-12", end: "2026-12-17" },
+  ],
+  2027: [
+    { start: "2027-02-01", end: "2027-04-09" },
+    { start: "2027-04-26", end: "2027-07-02" },
+    { start: "2027-07-19", end: "2027-09-24" },
+    { start: "2027-10-11", end: "2027-12-16" },
+  ],
+  2028: [
+    { start: "2028-02-02", end: "2028-04-07" },
+    { start: "2028-04-24", end: "2028-06-30" },
+    { start: "2028-07-17", end: "2028-09-22" },
+    { start: "2028-10-09", end: "2028-12-14" },
+  ],
+  // Preliminary dates only, to be confirmed.
+  2029: [
+    { start: "2029-01-31", end: "2029-03-29" },
+    { start: "2029-04-16", end: "2029-06-29" },
+    { start: "2029-07-16", end: "2029-09-21" },
+    { start: "2029-10-08", end: "2029-12-19" },
+  ],
+  // Preliminary dates only, to be confirmed.
+  2030: [
+    { start: "2030-02-04", end: "2030-04-12" },
+    { start: "2030-04-29", end: "2030-07-05" },
+    { start: "2030-07-22", end: "2030-09-27" },
+    { start: "2030-10-14", end: "2030-12-19" },
+  ],
+  // Preliminary dates only, to be confirmed.
+  2031: [
+    { start: "2031-02-03", end: "2031-04-10" },
+    { start: "2031-04-28", end: "2031-07-04" },
+    { start: "2031-07-21", end: "2031-09-26" },
+    { start: "2031-10-13", end: "2031-12-17" },
+  ],
+};
+
+// How far either side of today the per-date map reaches.
+const WINDOW_PAST_DAYS = 30;
+const WINDOW_FUTURE_DAYS = 90;
+
+// How close to the end of the table counts as ageing.
+const AGEING_MONTHS = 6;
+
+const MS_PER_DAY = 86400000;
+
+const pad = n => String(n).padStart(2, "0");
+
+/** Civil date → whole days since 1970-01-01. Not an instant. */
+function toDayNumber(ymd) {
+  const [y, m, d] = ymd.split("-").map(Number);
+  return Date.UTC(y, m - 1, d) / MS_PER_DAY;
+}
+
+/** Whole days since 1970-01-01 → civil date. */
+function toYmd(dayNumber) {
+  const d = new Date(dayNumber * MS_PER_DAY);
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+}
+
+/** 0 = Monday … 6 = Sunday. 1970-01-01 was a Thursday. */
+const weekdayFromMonday = dayNumber => (dayNumber + 3) % 7;
+
+/** Add calendar months, clamping to the length of the target month. */
+function addMonths(ymd, months) {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const total = y * 12 + (m - 1) + months;
+  const year = Math.floor(total / 12);
+  const month = (total % 12) + 1;
+  const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return `${year}-${pad(month)}-${pad(Math.min(d, lastDay))}`;
+}
+
+/**
+ * Term snapping: expand each official term outward to whole UJ term weeks.
+ *
+ * Week 1 begins the Monday of the week containing the official start, even when
+ * school starts mid-week; the final week runs through the Sunday of the week
+ * containing the official end. UJ classes run Mon–Sat regardless of where the
+ * official dates fall, so the first Saturday after school finishes is still
+ * term for us. This deliberately deviates from the official WA definition,
+ * which runs breaks Saturday→Sunday. Do not "correct" it — the week numbers
+ * depend on it. ADR 0002 records why.
+ */
+const SNAPPED_TERMS = Object.keys(WA_SCHOOL_TERMS)
+  .map(Number)
+  .sort((a, b) => a - b)
+  .flatMap(year =>
+    WA_SCHOOL_TERMS[year].map((official, index) => {
+      const start = toDayNumber(official.start) - weekdayFromMonday(toDayNumber(official.start));
+      const end = toDayNumber(official.end) + (6 - weekdayFromMonday(toDayNumber(official.end)));
+      return {
+        year,
+        term: index + 1,
+        start,
+        end,
+        weeks: (end - start + 1) / 7,
+      };
+    })
+  );
+
+const TABLE_STARTS = SNAPPED_TERMS[0].start;
+const TABLE_ENDS = SNAPPED_TERMS[SNAPPED_TERMS.length - 1].end;
+
+// The last date the table can classify.
+const TERM_TABLE_COVERS_TO = toYmd(TABLE_ENDS);
+
+/**
+ * Describe a single day.
+ *
+ * A break advertises the first day the table will itself call term — the
+ * snapped Monday, not the official start — so the endpoint never contradicts
+ * itself the following day.
+ */
+function classify(dayNumber) {
+  if (dayNumber < TABLE_STARTS || dayNumber > TABLE_ENDS) {
+    return { state: "unknown", publicHoliday: null };
+  }
+
+  // Guaranteed to find one: the guard above put dayNumber inside the table.
+  const term = SNAPPED_TERMS.find(candidate => dayNumber <= candidate.end);
+
+  if (dayNumber < term.start) {
+    // After the previous term's Sunday, before this one's Monday.
+    return {
+      state: "break",
+      nextTerm: term.term,
+      nextTermStart: toYmd(term.start),
+      publicHoliday: null,
+    };
+  }
+
+  return {
+    state: "term",
+    term: term.term,
+    week: Math.floor((dayNumber - term.start) / 7) + 1,
+    weeksInTerm: term.weeks,
+    publicHoliday: null,
+  };
+}
+
+/**
+ * Build the per-date calendar map for a window around the given Perth date.
+ * The client looks a date up and renders it; it computes nothing.
+ */
+export function buildCalendar(todayYmd) {
+  const today = toDayNumber(todayYmd);
+  const calendar = {};
+  for (let offset = -WINDOW_PAST_DAYS; offset <= WINDOW_FUTURE_DAYS; offset++) {
+    calendar[toYmd(today + offset)] = classify(today + offset);
+  }
+
+  return {
+    calendar,
+    meta: {
+      termTableCoversTo: TERM_TABLE_COVERS_TO,
+      // The only thing standing between the table expiring and staff silently
+      // losing term context. Load-bearing, not decoration.
+      termTableAgeing: addMonths(todayYmd, AGEING_MONTHS) >= TERM_TABLE_COVERS_TO,
+    },
+  };
+}
+
+/** Today's calendar date in Perth. The gym has one timezone and no DST. */
+export function perthToday() {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Australia/Perth",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date());
+}

--- a/cloudflare-worker/src/index.js
+++ b/cloudflare-worker/src/index.js
@@ -8,6 +8,8 @@
  * - COMMITTER_NAME, COMMITTER_EMAIL (optional)
  */
 
+import { buildCalendar, perthToday } from "./calendar.js";
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -47,6 +49,16 @@ export default {
             "Cache-Control": "max-age=120",
           },
         });
+      }
+
+      // Deliberately separate from /api/roster: a Deputy outage must not take
+      // the term context off the page with it.
+      if (url.pathname === "/api/calendar") {
+        if (request.method !== "GET") {
+          return json({ error: "Method not allowed" }, 405, allowedOrigin, { Allow: "GET, OPTIONS" });
+        }
+        // Caching is ticket #11's call, along with the holiday feed it protects.
+        return json(buildCalendar(perthToday()), 200, allowedOrigin);
       }
 
       if (url.pathname === "/api/roster") {

--- a/cloudflare-worker/test/calendar.test.js
+++ b/cloudflare-worker/test/calendar.test.js
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import worker from '../src/index.js';
+
+// The calendar route needs no Deputy or GitHub configuration — that independence
+// is itself part of the contract and is asserted below.
+const env = { ALLOWED_ORIGIN: 'https://ujstaff.happyk.au' };
+
+const DAY = 86400000;
+
+/** Midday in Perth on `ymd`, so the Perth civil date is unambiguous. */
+const atPerth = ymd => Date.parse(`${ymd}T12:00:00+08:00`);
+
+async function get(url = 'https://ujstaff.happyk.au/api/calendar', extraEnv = {}, init) {
+  return worker.fetch(new Request(url, init), { ...env, ...extraEnv });
+}
+
+/** Fetch the calendar as it would be served on the Perth date `ymd`. */
+async function calendarOn(ymd, extraEnv = {}) {
+  vi.setSystemTime(atPerth(ymd));
+  const res = await get(undefined, extraEnv);
+  return { res, body: await res.json() };
+}
+
+/** How a given date is described when viewed from `viewedFrom`. */
+async function dayOn(viewedFrom, date) {
+  const { body } = await calendarOn(viewedFrom);
+  return body.calendar[date];
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('/api/calendar response shape', () => {
+  it('serves a per-date map spanning 30 days back and 90 forward', async () => {
+    const { res, body } = await calendarOn('2026-08-05');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toMatch(/application\/json/);
+    const keys = Object.keys(body.calendar).sort();
+    expect(keys[0]).toBe('2026-07-06'); // 30 days back
+    expect(keys[keys.length - 1]).toBe('2026-11-03'); // 90 days forward
+    expect(keys).toHaveLength(121);
+  });
+
+  it('leaves the public holiday field empty for every date', async () => {
+    const { body } = await calendarOn('2026-08-05');
+
+    expect(Object.values(body.calendar).every(d => d.publicHoliday === null)).toBe(true);
+  });
+
+  it('reports how far the term table reaches', async () => {
+    const { body } = await calendarOn('2026-08-05');
+
+    // Last snapped day of 2031 term 4 (official end Wed 17 Dec, snapped to Sunday).
+    expect(body.meta.termTableCoversTo).toBe('2031-12-21');
+  });
+
+  it('does not need Deputy configured — a rostering outage must not hide term context', async () => {
+    // `env` deliberately carries no DEPUTY_URL or DEPUTY_TOKEN.
+    const { res, body } = await calendarOn('2026-08-05');
+
+    expect(res.status).toBe(200);
+    expect(body.calendar['2026-08-05'].state).toBe('term');
+  });
+
+  it('rejects non-GET methods', async () => {
+    vi.setSystemTime(atPerth('2026-08-05'));
+
+    const res = await get(undefined, {}, { method: 'POST' });
+
+    expect(res.status).toBe(405);
+  });
+});
+
+describe('term classification', () => {
+  // The worked examples agreed in the design record (issue #8).
+  it.each([
+    ['2026-04-02', 'Thu', { state: 'term', term: 1, week: 9, weeksInTerm: 9 }],
+    ['2026-04-03', 'Fri', { state: 'term', term: 1, week: 9, weeksInTerm: 9 }],
+    ['2026-04-05', 'Sun', { state: 'term', term: 1, week: 9, weeksInTerm: 9 }],
+    ['2026-04-06', 'Mon', { state: 'break' }],
+    ['2026-08-05', 'Wed', { state: 'term', term: 3, week: 3, weeksInTerm: 10 }],
+    ['2026-09-25', 'Fri', { state: 'term', term: 3, week: 10, weeksInTerm: 10 }],
+    ['2026-09-27', 'Sun', { state: 'term', term: 3, week: 10, weeksInTerm: 10 }],
+    ['2026-09-28', 'Mon', { state: 'break' }],
+  ])('describes %s (%s) as agreed', async (date, _dow, expected) => {
+    expect(await dayOn(date, date)).toMatchObject(expected);
+  });
+
+  it('starts week 1 on the Monday before a mid-week term start', async () => {
+    // 2028 term 1 officially starts Wednesday 2 February.
+    const { body } = await calendarOn('2028-02-02');
+
+    expect(body.calendar['2028-01-30']).toMatchObject({ state: 'break' }); // Sunday
+    expect(body.calendar['2028-01-31']).toMatchObject({ state: 'term', term: 1, week: 1 }); // Monday
+    expect(body.calendar['2028-02-02']).toMatchObject({ state: 'term', term: 1, week: 1 }); // official start
+    expect(body.calendar['2028-02-07']).toMatchObject({ state: 'term', term: 1, week: 2 });
+  });
+
+  it('runs the final week through Sunday when a term ends on a Thursday', async () => {
+    // 2026 term 1 officially ends Thursday 2 April.
+    const { body } = await calendarOn('2026-04-02');
+
+    expect(body.calendar['2026-04-04']).toMatchObject({ state: 'term', term: 1, week: 9, weeksInTerm: 9 }); // Sat
+    expect(body.calendar['2026-04-05']).toMatchObject({ state: 'term', term: 1, week: 9, weeksInTerm: 9 }); // Sun
+    expect(body.calendar['2026-04-06']).toMatchObject({ state: 'break' }); // Mon
+  });
+
+  it('runs the final week through Sunday when a term ends on a Friday', async () => {
+    // 2026 term 3 officially ends Friday 25 September; the Saturday is still term.
+    const { body } = await calendarOn('2026-09-25');
+
+    expect(body.calendar['2026-09-26']).toMatchObject({ state: 'term', term: 3, week: 10 }); // Sat
+    expect(body.calendar['2026-09-27']).toMatchObject({ state: 'term', term: 3, week: 10 }); // Sun
+    expect(body.calendar['2026-09-28']).toMatchObject({ state: 'break' }); // Mon
+  });
+
+  it.each([
+    ['a 9-week term', '2026-02-02', { term: 1, weeksInTerm: 9 }],
+    ['a 10-week term', '2026-07-20', { term: 3, weeksInTerm: 10 }],
+    ['an 11-week term', '2026-04-20', { term: 2, weeksInTerm: 11 }],
+  ])('reports the true length of %s', async (_label, date, expected) => {
+    expect(await dayOn(date, date)).toMatchObject({ state: 'term', ...expected });
+  });
+
+  it('numbers weeks from 1 to the term length with no gaps', async () => {
+    // 2026 term 1 — the 9-week case, viewed whole.
+    const { body } = await calendarOn('2026-03-01');
+    const weeks = Object.entries(body.calendar)
+      .filter(([, d]) => d.state === 'term' && d.term === 1)
+      .map(([, d]) => d.week);
+
+    expect(new Set(weeks)).toEqual(new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]));
+  });
+});
+
+describe('school breaks', () => {
+  it('names the next term and the date it starts', async () => {
+    const { body } = await calendarOn('2026-09-28');
+
+    expect(body.calendar['2026-09-28']).toMatchObject({
+      state: 'break',
+      nextTerm: 4,
+      nextTermStart: '2026-10-12',
+    });
+  });
+
+  it('points at the first day it will itself call term, not the official start', async () => {
+    // 2028 term 1 officially starts Wednesday 2 February, but UJ week 1 opens
+    // Monday 31 January — so that is the date the break must advertise.
+    const { body } = await calendarOn('2028-01-20');
+
+    expect(body.calendar['2028-01-20']).toMatchObject({ state: 'break', nextTerm: 1, nextTermStart: '2028-01-31' });
+    expect(body.calendar['2028-01-31'].state).toBe('term');
+  });
+
+  it('is exactly 14 days, or 42 across summer, everywhere in the table', async () => {
+    // Harvested through the HTTP boundary a window at a time, then stitched.
+    const seen = new Map();
+    for (let t = atPerth('2025-03-01'); t <= atPerth('2031-11-01'); t += 90 * DAY) {
+      vi.setSystemTime(t);
+      const { calendar } = await (await get()).json();
+      for (const [date, day] of Object.entries(calendar)) seen.set(date, day.state);
+    }
+
+    const states = [...seen.keys()].sort().map(date => seen.get(date));
+    const runs = [];
+    for (let i = 0; i < states.length; ) {
+      if (states[i] !== 'break') { i++; continue; }
+      let end = i;
+      while (end < states.length && states[end] === 'break') end++;
+      // Only a run with term on both sides is a whole break; one touching the
+      // harvest edge is truncated and proves nothing.
+      if (states[i - 1] === 'term' && states[end] === 'term') runs.push(end - i);
+      i = end;
+    }
+
+    expect(runs.length).toBeGreaterThanOrEqual(27); // 4 terms × 7 years, less the open ends
+    expect(runs.filter(n => n === 42)).not.toHaveLength(0); // the summer breaks
+    for (const length of runs) expect([14, 42]).toContain(length);
+  });
+});
+
+describe('staleness', () => {
+  it('marks a date past the end of the term table unknown rather than guessing', async () => {
+    const { res, body } = await calendarOn('2032-01-05');
+
+    expect(res.status).toBe(200);
+    expect(body.calendar['2032-01-05']).toMatchObject({ state: 'unknown', publicHoliday: null });
+    expect(body.calendar['2032-01-05'].term).toBeUndefined();
+  });
+
+  it('marks a date before the start of the term table unknown', async () => {
+    const { res, body } = await calendarOn('2025-01-15');
+
+    expect(res.status).toBe(200);
+    expect(body.calendar['2024-12-20'].state).toBe('unknown');
+  });
+
+  it('flags the table as ageing once it is within six months of running out', async () => {
+    // The table covers to 2031-12-21.
+    expect((await calendarOn('2031-06-20')).body.meta.termTableAgeing).toBe(false);
+    expect((await calendarOn('2031-06-21')).body.meta.termTableAgeing).toBe(true);
+  });
+
+  it('does not flag ageing while the table has years left', async () => {
+    const { body } = await calendarOn('2026-08-05');
+
+    expect(body.meta.termTableAgeing).toBe(false);
+  });
+});

--- a/docs/adr/0002-uj-term-weeks-are-snapped.md
+++ b/docs/adr/0002-uj-term-weeks-are-snapped.md
@@ -1,0 +1,82 @@
+# ADR 0002 — UJ term weeks are snapped, not official
+
+- **Status**: Accepted
+- **Date**: 2026-08-05
+- **Context**: roster calendar context ([#8](https://github.com/urbanjungleirc/staff-site/issues/8), [#10](https://github.com/urbanjungleirc/staff-site/issues/10))
+
+> ADR 0001 (hybrid calendar sourcing) lands with the public-holiday slice,
+> [#11](https://github.com/urbanjungleirc/staff-site/issues/11). The numbering
+> was assigned in #8.
+
+## Context
+
+The roster shows staff which school term and week a date falls in, so coaches
+know which session of a term block they are about to run.
+
+The official WA term dates do not divide into whole weeks. Terms routinely start
+on a Wednesday and end on a Thursday or Friday, and the Department defines the
+break as starting the very next day:
+
+```
+2028  Term 1  Wednesday 2 February to Friday 7 April
+      Break   Saturday 8 April to Sunday 23 April
+2029  Term 1  Wednesday 31 January to Thursday 29 March
+      Break   Friday 30 March to Sunday 15 April
+```
+
+UJ classes run Monday–Saturday. A term block is a run of whole weeks, and the
+Saturday session at the end of a term is part of that block regardless of when
+school finishes.
+
+Taking the official dates literally would mean:
+
+- a term starting Wednesday has a three-day "week 1", so every subsequent week
+  number is a week ahead of the class block it is meant to describe;
+- the Saturday session after school finishes is labelled a school break, which
+  is exactly wrong for the person running it.
+
+## Decision
+
+Snap each official term outward to whole Monday–Sunday weeks:
+
+- **Week 1 begins the Monday** of the week containing the official term start.
+- **The final week runs through the Sunday** of the week containing the official
+  term end.
+- Sunday closes the week.
+
+A school break is whatever lies between two snapped terms.
+
+A school break advertises the next term's **snapped** start — the Monday — not
+the official start. Otherwise the endpoint contradicts itself: in January 2028 it
+would say "Term 1 starts Wed 2 Feb" while already classifying Mon 31 Jan as term.
+
+## Consequences
+
+This **deliberately deviates from education.wa.edu.au.** Under our rule, the
+first Saturday after school finishes is still term. Under theirs it is a break.
+Both are correct for their own purpose; ours is the one that matches the class
+blocks we actually run.
+
+**Do not "correct" the dates to match the official page.** It looks like a bug
+fix and is not. It silently shifts every week number in the affected term, and
+nothing about the display would look broken afterwards — which is why this ADR
+exists.
+
+The rule buys a clean invariant, since every term now ends on a Sunday and every
+term starts on a Monday: **every school break is exactly 14 days, or 42 across
+summer.** That is asserted across the entire term table (2025–2031) in
+`cloudflare-worker/test/calendar.test.js`, and it is the check that would catch a
+mistyped date in the table.
+
+Snapping is applied to the table at module load; the official dates are kept
+verbatim in `WA_SCHOOL_TERMS` so they can be re-checked against the source page.
+
+## Alternatives considered
+
+- **Use the official dates as published.** Rejected: produces partial weeks and
+  mislabels end-of-term Saturdays, which is the whole problem.
+- **Snap only the end, not the start.** Rejected: fixes the Saturday case but
+  leaves a short week 1, so the week numbers still drift from the class block.
+- **Store pre-snapped dates in the table.** Rejected: the table would no longer
+  be comparable line-for-line against the government page, which is the only way
+  to verify it.

--- a/roster.html
+++ b/roster.html
@@ -96,6 +96,37 @@
         text-align: center;
       }
 
+      /* ── Day context (term week / school break) ── */
+      .day-context {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: center;
+        gap: 4px 12px;
+        margin-top: 18px;
+        margin-bottom: 0;
+        font-size: 0.92rem;
+        color: rgba(255, 255, 255, 0.9);
+        /* Wrap inside the nav width rather than pushing the header wider. */
+        max-width: 640px;
+        margin-left: auto;
+        margin-right: auto;
+        padding: 0 8px;
+      }
+
+      .day-context:empty { display: none; }
+
+      /* Broken — the term table cannot describe this date. Amber, visible.
+         Green is reserved for the on-now shift state. */
+      .day-context.is-broken { color: #fcd34d; }
+
+      /* Ageing — the maintainer can act, staff cannot. Muted on purpose so
+         nobody is trained to ignore the amber one. */
+      .day-context .ctx-ageing {
+        font-size: 0.82rem;
+        color: rgba(255, 255, 255, 0.55);
+      }
+
       /* ── Main layout ── */
       main {
         flex: 1;
@@ -890,6 +921,7 @@
         <button class="nav-btn" id="btn-next" aria-label="Next day">Next &#8594;</button>
         <button class="nav-btn today" id="btn-today">Today</button>
       </div>
+      <p class="day-context" id="day-context"></p>
     </header>
 
     <main>
@@ -917,10 +949,15 @@
 
     <script>
       // ── Configuration ──
+      const IS_LOCAL = ['localhost', '127.0.0.1', ''].includes(window.location.hostname)
+        || window.location.protocol === 'file:';
+
       const CONFIG = {
-        rosterUrl: ['localhost', '127.0.0.1', ''].includes(window.location.hostname) || window.location.protocol === 'file:'
-          ? 'http://localhost:8787/api/roster'
-          : '/api/roster',
+        rosterUrl: IS_LOCAL ? 'http://localhost:8787/api/roster' : '/api/roster',
+
+        // Term weeks and school breaks. A separate endpoint on purpose, so a
+        // Deputy outage cannot take the term context down with the shifts.
+        calendarUrl: IS_LOCAL ? 'http://localhost:8787/api/calendar' : '/api/calendar',
 
         // How many days either side of today can you navigate?
         dayWindowDays: 7,
@@ -969,6 +1006,15 @@
         ? `${refreshMins / 60}h`
         : `${refreshMins} min`;
       let viewMode = 'timeline'; // 'grouped' | 'timeline' | 'alpha'
+
+      // ── Calendar cache ──
+      // The Worker sends a per-date map spanning −30/+90 days, so navigating
+      // dates is a dictionary lookup and never a refetch. Null means the
+      // calendar could not be loaded at all.
+      let calendarCache = null;
+      // Distinguishes "not fetched yet" from "fetched and failed", so the first
+      // paint shows nothing rather than flashing a warning.
+      let calendarAttempted = false;
 
       // ── Roster cache (avoids re-fetching on every day change) ──
       let rosterCache = null;
@@ -1450,6 +1496,80 @@
           ${buildLegendHtml(timed)}`;
       }
 
+      // ── Day context (term week / school break) ──
+
+      /** Local calendar date as YYYY-MM-DD. Not toISOString, which shifts to UTC. */
+      function dateKey(d) {
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      }
+
+      const CTX_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+      const CTX_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+      /**
+       * "Mon 12 Oct" from a plain YYYY-MM-DD. Composed from the parts because
+       * en-AU's short format puts a comma after the weekday, and the agreed
+       * display has none.
+       */
+      function formatPlainDate(ymd) {
+        const [y, m, d] = ymd.split('-').map(Number);
+        return `${CTX_DAYS[new Date(y, m - 1, d).getDay()]} ${d} ${CTX_MONTHS[m - 1]}`;
+      }
+
+      /** "Dec 2031" — the year matters for a date years out. */
+      function formatPlainMonth(ymd) {
+        const [y, m] = ymd.split('-').map(Number);
+        return `${CTX_MONTHS[m - 1]} ${y}`;
+      }
+
+      /** Never throws: the roster must render whether or not the calendar loads. */
+      async function fetchCalendar() {
+        try {
+          const res = await fetch(CONFIG.calendarUrl, { cache: 'no-store' });
+          if (!res.ok) throw new Error(`API returned ${res.status}`);
+          calendarCache = await res.json();
+        } catch (err) {
+          console.error('Calendar error:', err);
+          calendarCache = null;
+        }
+        calendarAttempted = true;
+        renderDayContext();
+      }
+
+      /**
+       * Describe the selected date. Lives outside #roster-content, so it
+       * survives every view switch and every roster failure.
+       */
+      function renderDayContext() {
+        const el = document.getElementById('day-context');
+        if (!calendarAttempted) { el.className = 'day-context'; el.textContent = ''; return; }
+
+        const day = calendarCache?.calendar?.[dateKey(currentDate)];
+
+        // Broken: say so where the context would be, rather than showing a blank.
+        // Three distinct causes, so three distinct messages — "the table needs
+        // extending" is a wrong diagnosis for the other two.
+        if (!day || day.state === 'unknown') {
+          el.className = 'day-context is-broken';
+          if (!calendarCache) el.textContent = 'Term and school-break info unavailable.';
+          else if (!day) el.textContent = 'Term dates not loaded for this date.';
+          else el.textContent = 'Term dates don’t cover this date — the term table needs extending.';
+          return;
+        }
+
+        el.className = 'day-context';
+        el.textContent = day.state === 'term'
+          ? `Term ${day.term} · Week ${day.week} of ${day.weeksInTerm}`
+          : `School holidays · Term ${day.nextTerm} starts ${formatPlainDate(day.nextTermStart)}`;
+
+        if (calendarCache.meta?.termTableAgeing) {
+          const note = document.createElement('span');
+          note.className = 'ctx-ageing';
+          note.textContent = `Term dates run out ${formatPlainMonth(calendarCache.meta.termTableCoversTo)} — time to extend the table.`;
+          el.appendChild(note);
+        }
+      }
+
       async function fetchRoster() {
         const res = await fetch(CONFIG.rosterUrl, { cache: 'no-store' });
         if (!res.ok) {
@@ -1500,6 +1620,7 @@
         const minDate = rosterDateRange.min || (() => { const d = new Date(today); d.setDate(today.getDate() - CONFIG.dayWindowDays); return d; })();
         const maxDate = rosterDateRange.max || (() => { const d = new Date(today); d.setDate(today.getDate() + CONFIG.dayWindowDays); return d; })();
         document.getElementById('day-label').textContent = formatDayLabel(currentDate);
+        renderDayContext();
         document.getElementById('btn-prev').disabled = currentDate <= minDate;
         document.getElementById('btn-next').disabled = currentDate >= maxDate;
         document.getElementById('btn-today').disabled = currentDate.getTime() === today.getTime();
@@ -1518,7 +1639,12 @@
         if (refreshTimer) clearInterval(refreshTimer);
         // Background refresh: fetch fresh ICS silently, re-render current day
         refreshTimer = setInterval(
-          () => loadRoster({ forceRefresh: true, showLoading: false }),
+          () => {
+            loadRoster({ forceRefresh: true, showLoading: false });
+            // The calendar window is relative to today, so it has to be
+            // re-fetched for a page left open across midnight.
+            fetchCalendar();
+          },
           CONFIG.refreshIntervalMs
         );
       }
@@ -1703,6 +1829,8 @@
 
       updateNav();
       loadRoster();
+      // Not awaited by the roster — either can fail without taking out the other.
+      fetchCalendar();
       scheduleRefresh();
       // ── Keyboard day navigation ──
       document.addEventListener('keydown', e => {


### PR DESCRIPTION
Implements #10 — the term half of the roster calendar context.

A single line under the day nav describes **whichever date is on screen**, in all three view modes:

```
Term 3 · Week 3 of 10
School holidays · Term 4 starts Mon 12 Oct
```

## What is here

- **`/api/calendar`** — a new route on the roster Worker returning a per-date map spanning −30/+90 days, so navigating dates is a dictionary lookup and never a refetch. Deliberately separate from `/api/roster`: a Deputy outage must not take the term context down with the shifts, and the two fetches are independent in the page so either can fail alone.
- **WA term table, 2025–2031** — hardcoded, since no machine-readable source exists. Re-read from education.wa.edu.au on 2026-08-05 rather than trusted from a parse; every date matches the customer-tools copy exactly.
- **Term snapping** — a UJ term week is a whole Mon–Sun week snapped outward from the official dates. This deliberately deviates from the official definition, so `docs/adr/0002-uj-term-weeks-are-snapped.md` records why it must not be "fixed" later.
- **Tiered staleness** — amber where the context would be when the table cannot describe the date; a muted grey note when the table is within six months of running out. Green stays reserved for `on-now`.
- **`CONTEXT.md`** — the repo's domain glossary, new at the root.

## Tests

28 new tests through the `/api/calendar` HTTP boundary with a fixed system time, matching the payments-proxy prior art. Nothing internal is exported for testing.

The 14/42-day break invariant is asserted across the **whole** table by harvesting the endpoint a window at a time and stitching the results — 27 breaks, every one exactly 14 days or 42 across summer. That is the check that would catch a mistyped date in the table.

Full suite: 55 Worker tests + 9 payments-proxy tests pass. The route was also exercised in the real workerd runtime via `wrangler dev`, confirming `Intl` resolves `Australia/Perth` there.

## Deploy note

`cloudflare-worker/` changed, so **deploy the Worker before or with the Pages push** — otherwise `roster.html` lands first and the line reads "Term and school-break info unavailable" until the Worker catches up.

```bash
cd cloudflare-worker && npx wrangler deploy
```

## Not in scope

Public holidays are #11 — `publicHoliday` is `null` throughout, and caching is left to that ticket along with the feed it protects.

Refs #8, #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHTeLpMgyyBw8kXfwvzQnZ