### PR TITLE
fix(vouchers): stop a cached logic module rendering an empty unsubscribes list

### DIFF
--- a/vouchers/unsubscribes.html
+++ b/vouchers/unsubscribes.html
@@ -28,8 +28,13 @@
        in document order — so this sits ABOVE the Alpine tag deliberately, to guarantee
        window.unsubscribeLogic exists before any expression evaluates. Same seam as
        image-pipeline.js on the hub page. -->
+  <!-- ?v= MUST be bumped whenever unsubscribes-logic.js gains or renames an export.
+       GitHub Pages sets a long cache lifetime and this page is a static file with no
+       build step, so without it a browser keeps a previously cached module while
+       loading new HTML — and the page renders no rows at all. That exact regression
+       shipped once; the boot check in init() is what makes it say so out loud. -->
   <script type="module">
-    import * as logic from './unsubscribes-logic.js';
+    import * as logic from './unsubscribes-logic.js?v=2';
     window.unsubscribeLogic = logic;
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
@@ -279,7 +284,7 @@
 
       <div x-show="loading" class="py-10 text-center text-sm text-neutral-500">Loading…</div>
 
-      <template x-if="!loading">
+      <template x-if="!loading && !scriptStale">
         <div>
 
           <!-- ── Add ─────────────────────────────────────────────────────── -->
@@ -551,6 +556,12 @@
     // Alpine-bound rows are not built for a lookup that wants one of them.
     const ROW_CAP = 50;
 
+    // Every function the template depends on. Checked at boot — see init().
+    const REQUIRED_LOGIC = [
+      'partitionSuppressions', 'isRemovable', 'sourceLabel',
+      'matchMembers', 'isFreeTextOffer', 'filterSuppressions',
+    ];
+
     const PERTH_DATE = new Intl.DateTimeFormat('en-AU', {
       timeZone: 'Australia/Perth', day: 'numeric', month: 'short', year: 'numeric',
     });
@@ -563,6 +574,10 @@
         loading: true,
         error: '',
         busy: false,
+
+        // Set when the boot check finds the logic module too old for this page.
+        // Suppresses the body entirely, so no getter evaluates against it.
+        scriptStale: false,
 
         suppressions: [],
         members: [],
@@ -592,6 +607,22 @@
         justResubscribed: [],
 
         async init() {
+          // A stale cached module fails one expression at a time, which Alpine
+          // swallows per-expression: the page renders, the list is simply empty,
+          // and an empty list here reads as "nobody is suppressed". Checking up
+          // front turns that into a message staff can act on.
+          const missing = REQUIRED_LOGIC.filter(
+            (fn) => typeof window.unsubscribeLogic?.[fn] !== 'function',
+          );
+          if (missing.length) {
+            this.scriptStale = true;
+            this.loading = false;
+            this.error = 'This page loaded an out-of-date script, so the list cannot be shown. '
+              + 'Reload with Ctrl+Shift+R (Cmd+Shift+R on a Mac). '
+              + `If it keeps happening, tell Jiri — missing: ${missing.join(', ')}.`;
+            return;
+          }
+
           if (this.IS_LOCAL) {
             const hash = window.location.hash.slice(1);
             if (hash) {


### PR DESCRIPTION
Reported live after #23: the unsubscribes page showed **no records at all**.

## Cause

#23 added `filterSuppressions` to `unsubscribes-logic.js` and made the template
depend on it. The module is imported by a bare relative URL from a static Pages
site with no build step, so a browser that had cached it from #6 kept the old
copy and every call threw `filterSuppressions is not a function`.

Alpine catches expression errors one at a time, so nothing crashed — the list
just rendered zero rows.

**That's the worst possible shape for this page.** An empty list here doesn't
read as "something is broken", it reads as "nobody is suppressed" — the
confidently-wrong answer this whole surface exists to prevent, reached through a
stale file instead of bad data.

## Fix

- **`?v=2` on the import**, so this deploy refetches. Must be bumped whenever the
  module gains or renames an export; there's a comment above it saying so.
- **A boot check in `init()`** for every function the template needs. If any is
  missing it suppresses the body and shows staff a message naming the missing
  export and telling them to hard-refresh. Version bumps get forgotten — this is
  what makes the next one loud instead of silent.

## Verification

Reproduced first, by serving the current HTML against the module exactly as it
shipped in #6: **0 rows, 3 uncaught TypeErrors**. With the fix, that same setup
renders no rows but shows the message, and no uncaught errors.

Healthy path unchanged: **50 unit tests**, **39 browser checks**, both passing.

## Note for later

`vouchers/index.html` imports `image-pipeline.js` through the same seam with no
version marker. Not broken today — that module hasn't changed since it shipped —
but it carries the same latent trap the moment it gains an export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)