### PR TITLE
feat(vouchers): delete button and typed-confirmation modal on the detail panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ vouchers/               - voucher management portal (auth = Cloudflare Access)
 vouchers/stats.html     - voucher analytics: revenue, liability, redemption, product mix
 vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and why
 vouchers/unsubscribes-logic.js - pure suppression rules behind that page (unit tested)
+vouchers/delete-logic.js - pure confirmation rules behind the hard-delete action (unit tested)
 hvt/                    - High-volume Training tool copy
 slideshow/              - Google Drive TV slideshow tool
 sls_tv.html             - Summer Lead Series TV display
@@ -180,6 +181,47 @@ Deploy the proxy from the **happyk** Cloudflare account (it owns `happyk.au`):
 cd cloudflare-payments-proxy
 npx wrangler deploy      # route is declared in its wrangler.toml
 ```
+
+### Deleting a voucher
+
+The **Delete Permanently** button on the voucher detail panel is a *hard* delete
+— the row leaves the database, along with the `purchase_tracking` row that
+counts against the buyer's per-customer limit. Cancel (the outlined rose button
+beside it) is the reversible one. They are deliberately styled differently:
+solid versus outlined.
+
+Three things about this are easy to break by accident:
+
+- **The button is identity-gated, not password-gated.** On load the page calls
+  `GET /v1/staff/me` and renders the button only when `can_delete` is true, so
+  nobody is shown an action that can only 403. That is a *display* gate — the
+  Worker re-checks the verified Access JWT against its `DELETE_ALLOWED_EMAILS`
+  allowlist on every DELETE, and `canDelete` starts `false` so a failed identity
+  call hides the button rather than exposing it.
+- **The typed voucher code is the real second factor**, and is not decoration.
+  The allowlist authenticates the *session*, which cannot tell one person from
+  their unlocked laptop; typing the code is what the allowlist cannot supply.
+- **401 and 403 must not be collapsed.** 401 is the staff gate (the Access
+  session lapsed — reloading fixes it). 403 is the allowlist (the session is
+  fine and reloading will never help). Showing "sign in again" for a 403 sends
+  someone round a loop that cannot succeed.
+
+The rules behind all of that live in `vouchers/delete-logic.js` — pure, unit
+tested in `vouchers/test/delete-logic.test.js`, and published as
+`window.deleteLogic` like the other extracted modules. Bump the `?v=` on its
+import whenever its exports change.
+
+A stale cached copy of that module is the one failure that would break the
+typed-code check, the required-reason check and the disabled button
+*simultaneously and silently*, so two things hold it closed: `openDelete()`
+refuses to open the modal when an export is missing, and `submitDelete()`
+re-checks before sending. The re-check is the load-bearing one — an Alpine
+expression that throws leaves `:disabled` unapplied, so a broken
+`canSubmitDelete` would *enable* the confirm button, and only a guard on the
+submit path turns that back into "nothing happens".
+
+Design: `docs/superpowers/specs/2026-08-05-voucher-hard-delete-design.md` in the
+`voucher-app` hub repo.
 
 ## Local Development
 

--- a/vouchers/delete-logic.js
+++ b/vouchers/delete-logic.js
@@ -1,0 +1,75 @@
+// Pure rules behind the hard-delete action on vouchers/index.html.
+//
+// Extracted so the things standing between a mis-click and an unrecoverable
+// delete are testable without a browser. The page imports this and publishes it
+// as `window.deleteLogic`, the same seam image-pipeline.js and
+// unsubscribes-logic.js use. Nothing here touches the DOM, Alpine, or the network.
+//
+// Hard delete has no eligibility rule on the server — any voucher, any status,
+// including paid and redeemed ones (that is deliberate; test vouchers arrive from
+// too many sources for a "safe to delete" predicate to be reliable). Its
+// protection is the Access-email allowlist plus the typed-code confirmation
+// below. See docs/superpowers/specs/2026-08-05-voucher-hard-delete-design.md in
+// the vouchers hub repo.
+
+const norm = (value) => String(value ?? '').trim().toUpperCase();
+
+// The typed confirmation is what the allowlist cannot provide: the allowlist
+// authenticates the session, not the person currently at the keyboard, so an
+// unlocked laptop is still an allowed identity.
+export function codeConfirmed(typed, voucherCode) {
+  const target = norm(voucherCode);
+  if (!target) return false; // no voucher ⇒ nothing can confirm, empty box included
+  return norm(typed) === target;
+}
+
+export function canSubmitDelete({ voucher, typedCode, reason, busy } = {}) {
+  if (busy) return false;
+  if (!voucher) return false;
+  if (!String(reason ?? '').trim()) return false;
+  return codeConfirmed(typedCode, voucher.voucher_id);
+}
+
+// Signals that this is a real transaction rather than a test artefact. Shown
+// louder than the rest of the modal, because these are the deletes that cost
+// something — a redeemed voucher's history and a customer's payment both vanish
+// from the live table (the audit snapshot survives, but only for manual recovery).
+export function deleteWarnings(voucher) {
+  if (!voucher) return [];
+  const warnings = [];
+
+  // Balance drift is the more reliable signal: rows migrated from v2 carry the
+  // reduced balance without the per-redemption columns.
+  const spent = Number(voucher.balance) < Number(voucher.value);
+  if (voucher.last_redeemed_amount || spent) {
+    warnings.push('This voucher has been redeemed — that history is deleted with it.');
+  }
+
+  if (String(voucher.payment_reference ?? '').trim()) {
+    const platform = String(voucher.payment_platform ?? '').trim();
+    warnings.push(
+      `This voucher was paid for${platform ? ` via ${platform}` : ''} — deleting it does not refund anything.`,
+    );
+  }
+
+  return warnings;
+}
+
+// 401 and 403 mean different things here and must not be collapsed. 401 is the
+// staff gate — the Access session lapsed, and reloading fixes it. 403 is the
+// delete allowlist — the session is perfectly valid and reloading will never
+// help, because the answer is about who you are.
+export function deleteErrorMessage(err) {
+  if (err?.status === 403) {
+    return 'Only an authorised account can delete vouchers. Your sign-in is valid, but this address is not on the delete allowlist.';
+  }
+  return err?.message || 'Could not delete this voucher. Please try again.';
+}
+
+// The deleted row is gone server-side, so leaving it in the result set offers a
+// detail view that 404s. Returns a new array — Alpine re-renders on assignment.
+export function withoutVoucher(results, code) {
+  if (!Array.isArray(results)) return [];
+  const target = norm(code);
+  return results.filter((row) => norm(row?.voucher_id) !== target);
+}

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -35,6 +35,11 @@
   <script type="module">
     import * as pipeline from './image-pipeline.js?v=1';
     window.imagePipeline = pipeline;
+    // Same rule for the ?v= here: bump it whenever delete-logic.js gains or
+    // renames an export. A stale cached copy would disarm every guard on the
+    // delete modal at once; openDelete() and submitDelete() both check for it.
+    import * as deleteLogic from './delete-logic.js?v=1';
+    window.deleteLogic = deleteLogic;
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
@@ -1189,6 +1194,16 @@
                 class="bg-white hover:bg-emerald-50 text-emerald-700 px-4 py-2 rounded-xl text-sm font-medium border border-emerald-200 hover:border-emerald-300 transition-colors inline-flex items-center gap-1.5">
                 <span class="button-icon"><svg viewBox="0 0 24 24"><path d="M8 7.5H4.5V4"/><path d="M5 7.25a7.5 7.5 0 1 1 1.4 9.25"/></svg></span>
                 Restore Voucher
+              </button>
+              <!-- Hard delete. Rendered only for an address on the Worker's
+                   DELETE_ALLOWED_EMAILS allowlist, so nobody is shown a button
+                   that can only 403. Deliberately SOLID where Cancel is
+                   outlined: the two sit side by side and do very different
+                   things, and only one of them can be undone. -->
+              <button x-show="canDelete && voucher" @click="openDelete()"
+                class="bg-rose-600 hover:bg-rose-700 text-white px-4 py-2 rounded-xl text-sm font-semibold transition-colors inline-flex items-center gap-1.5">
+                <span class="button-icon"><svg viewBox="0 0 24 24"><path d="M5.5 7.5h13"/><path d="M9.5 7.5V5h5v2.5"/><path d="M7 7.5 7.75 19h8.5L17 7.5"/><path d="M10.5 10.5v5.5"/><path d="M13.5 10.5v5.5"/></svg></span>
+                Delete Permanently
               </button>
             </div>
             <p x-show="!voucher?.customer_email && !voucher?.is_physical"
@@ -2742,6 +2757,65 @@
     </div>
   </div>
 
+  <!-- ── Delete voucher modal (Access-email gated HARD delete) ─────────────
+       Deliberately heavier than the cancel modal above: cancel keeps the record
+       and can be restored, this removes the row. The typed code is what the
+       allowlist cannot supply — it authenticates the session, not the person at
+       an unlocked laptop. -->
+  <div x-show="deleteOpen" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4"
+    @keydown.escape.window="deleteOpen = false">
+    <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="deleteOpen = false"></div>
+    <div class="relative bg-white rounded-card shadow-2xl shadow-neutral-900/15 w-full max-w-md p-6 border border-rose-200">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-base font-semibold text-rose-700">Permanently delete this voucher?</h3>
+        <button @click="deleteOpen = false" class="text-neutral-400 hover:text-neutral-700 text-xl leading-none">&times;</button>
+      </div>
+
+      <div class="bg-neutral-50 border border-neutral-200 rounded-xl px-3.5 py-2.5 text-sm mb-4">
+        <div class="font-mono font-semibold text-neutral-900" x-text="voucher?.voucher_id"></div>
+        <div class="text-neutral-600 text-xs mt-1">
+          <span x-show="voucher?.customer_name" x-text="voucher?.customer_name"></span>
+          <span x-show="voucher?.customer_name"> · </span>
+          <span x-text="fmtMoney(voucher?.balance)"></span> of <span x-text="fmtMoney(voucher?.value)"></span>
+          · <span class="uppercase tracking-wide" x-text="voucher?.status"></span>
+        </div>
+      </div>
+
+      <p class="text-sm text-neutral-700 mb-4">
+        This <b>erases the voucher from the database</b>, along with the purchase
+        record that counts against the buyer's limit. Unlike <b>Cancel</b>, it
+        <b class="text-rose-700">cannot be undone</b> from this page.
+      </p>
+
+      <!-- Loud only when there is something real to lose. A test artefact gets
+           the plain warning above; a paid or redeemed voucher gets this too. -->
+      <template x-for="warning in deleteWarnings()" :key="warning">
+        <div class="bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-3.5 py-2.5 text-xs mb-2.5" x-text="warning"></div>
+      </template>
+
+      <label class="block text-xs font-semibold text-neutral-500 uppercase tracking-wider mb-1.5 mt-4">Reason <span class="text-rose-500">*</span></label>
+      <textarea x-model="deleteReason" rows="2" maxlength="500" placeholder="e.g. test voucher created while checking the email template"
+        class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 focus:border-rose-400 mb-4"></textarea>
+
+      <label class="block text-xs font-semibold text-neutral-500 uppercase tracking-wider mb-1.5">
+        Type <b class="font-mono normal-case text-neutral-900 tracking-normal" x-text="voucher?.voucher_id"></b> to confirm <span class="text-rose-500">*</span>
+      </label>
+      <input type="text" x-model="deleteTypedCode" autocomplete="off" spellcheck="false"
+        class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm font-mono uppercase focus:outline-none focus:ring-2 focus:ring-rose-500/30 focus:border-rose-400 mb-2">
+
+      <p x-show="deleteError" class="text-sm text-rose-600 mb-2" x-text="deleteError"></p>
+
+      <div class="flex gap-2.5 mt-3">
+        <button @click="deleteOpen = false"
+          class="flex-1 border border-neutral-200 hover:bg-neutral-50 text-neutral-700 font-medium rounded-xl py-2.5 text-sm transition-colors">Keep voucher</button>
+        <button @click="submitDelete()" :disabled="!canSubmitDelete()"
+          class="flex-1 bg-rose-600 hover:bg-rose-700 disabled:opacity-40 disabled:cursor-not-allowed text-white font-semibold rounded-xl py-2.5 text-sm transition-colors">
+          <span x-text="deleteLoading ? 'Deleting…' : 'Delete permanently'"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+
   <!-- ── Restore voucher modal (manager-gated un-cancel) ──────────────────── -->
   <div x-show="restoreOpen" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4"
     @keydown.escape.window="restoreOpen = false">
@@ -2916,6 +2990,15 @@
     const IMAGE_PIPELINE_REQUIRED = [
       'isAcceptedType', 'tooLargeToProcess', 'formatBytes',
       'resizeImage', 'isTooSmall', 'overSoftBudget', 'overHardCap',
+    ];
+
+    // Everything this page calls on window.deleteLogic. Same stale-cache hazard
+    // as IMAGE_PIPELINE_REQUIRED, but the failure is worse: an Alpine expression
+    // that throws leaves :disabled unapplied, so a missing canSubmitDelete()
+    // would ENABLE the confirm button rather than disable it. Checked before the
+    // modal can be opened at all.
+    const DELETE_LOGIC_REQUIRED = [
+      'canSubmitDelete', 'deleteWarnings', 'deleteErrorMessage', 'withoutVoucher',
     ];
 
     const IS_LOCAL = ['localhost', '127.0.0.1'].includes(window.location.hostname);
@@ -3100,6 +3183,17 @@
       restoreError: '',
       undoLoading: false,
 
+      // Hard delete (Access-email allowlist, not a second password). canDelete
+      // comes from GET /v1/staff/me and starts false so a failed identity call
+      // hides the button rather than offering one that 403s. It is a display
+      // gate only — the Worker re-checks the verified JWT on every DELETE.
+      canDelete: false,
+      deleteOpen: false,
+      deleteReason: '',
+      deleteTypedCode: '',
+      deleteLoading: false,
+      deleteError: '',
+
       // Formatting / placeholders help
       formatHelpOpen: false,
       formatHelpTab: 'markdown',
@@ -3200,6 +3294,7 @@
         if (this.isAuthed()) {
           await this.search();
           this.loadDashStats(); // fire and forget — don't block the search
+          this.loadStaffMe();   // likewise: only decides whether one button renders
         }
         // Background refresh: on tab focus (throttled inside refreshData) plus
         // a 5-minute tick that only fires while the tab is visible.
@@ -3809,6 +3904,98 @@
           this.cancelError = e.status === 403 ? 'Manager password incorrect' : e.message;
         } finally {
           this.cancelLoading = false;
+        }
+      },
+
+      // Whether the Worker will accept a delete from this identity. Only
+      // can_delete is kept — the email it also returns is already shown from
+      // /cdn-cgi/access/get-identity, and a second writer would race it.
+      // Failure is silent and leaves canDelete false: someone who cannot delete
+      // never sees the button, which is also the safe outcome when we could not ask.
+      async loadStaffMe() {
+        try {
+          const me = await this.api('/v1/staff/me');
+          this.canDelete = me.can_delete === true;
+        } catch {
+          this.canDelete = false;
+        }
+      },
+
+      // Refuses to open rather than opening a modal whose guards cannot run.
+      // A stale cached delete-logic.js is the one case where every protection in
+      // the modal — typed code, required reason, the disabled button — silently
+      // stops working at once, so the check belongs in front of the door.
+      openDelete() {
+        const missing = DELETE_LOGIC_REQUIRED.filter((fn) => typeof window.deleteLogic?.[fn] !== 'function');
+        if (missing.length) {
+          this.showToast(
+            'This page loaded an out-of-date script, so deleting is disabled. '
+            + 'Reload with Ctrl+Shift+R (Cmd+Shift+R on a Mac). '
+            + `If it keeps happening, tell Jiri — missing: ${missing.join(', ')}.`,
+            'error',
+          );
+          return;
+        }
+        this.deleteReason = '';
+        this.deleteTypedCode = '';
+        this.deleteError = '';
+        this.deleteOpen = true;
+      },
+
+      // Mirrors of the pure rules in delete-logic.js, so the template stays
+      // readable and the rules stay testable. Called bare, as the sibling
+      // modules are: openDelete() has already refused to open the modal if
+      // either is missing, and submitDelete() re-checks before sending.
+      deleteWarnings() {
+        return window.deleteLogic.deleteWarnings(this.voucher);
+      },
+
+      canSubmitDelete() {
+        return window.deleteLogic.canSubmitDelete({
+          voucher: this.voucher,
+          typedCode: this.deleteTypedCode,
+          reason: this.deleteReason,
+          busy: this.deleteLoading,
+        });
+      },
+
+      async submitDelete() {
+        // The disabled button is the visible guard; this is the one that decides.
+        // It is also what keeps a stale module fail-CLOSED: if canSubmitDelete
+        // were missing, this throws before the DELETE is sent rather than after.
+        if (!this.canSubmitDelete()) return;
+        this.deleteLoading = true;
+        this.deleteError = '';
+        const code = this.voucher.voucher_id;
+        try {
+          await this.api('/v1/vouchers/' + encodeURIComponent(code), {
+            method: 'DELETE',
+            body: JSON.stringify({
+              deleted_by: this.createIssuer || 'staff',
+              reason: this.deleteReason.trim(),
+            }),
+          });
+          this.deleteOpen = false;
+          // The row is gone server-side, so drop it from every list holding a
+          // copy — leaving one behind offers a detail view that 404s. The report
+          // lists matter as much as search: the detail panel can be opened from
+          // either, and we are about to send the user back to whichever it was.
+          this.results = window.deleteLogic.withoutVoucher(this.results, code);
+          if (this.report) {
+            this.report.issued = window.deleteLogic.withoutVoucher(this.report.issued, code);
+            this.report.redeemed = window.deleteLogic.withoutVoucher(this.report.redeemed, code);
+          }
+          this.voucher = null;
+          this.view = this.detailOrigin === 'report' ? 'report' : 'search';
+          // The dashboard counters we are about to land back on counted this
+          // voucher. Re-read them rather than leave visibly wrong totals sitting
+          // there until the next five-minute tick.
+          this.loadDashStats();
+          this.showToast('Voucher ' + code + ' deleted');
+        } catch (e) {
+          this.deleteError = window.deleteLogic.deleteErrorMessage(e);
+        } finally {
+          this.deleteLoading = false;
         }
       },
 

--- a/vouchers/test/delete-logic.test.js
+++ b/vouchers/test/delete-logic.test.js
@@ -1,0 +1,180 @@
+import { describe, expect, test } from 'vitest';
+import {
+  codeConfirmed,
+  canSubmitDelete,
+  deleteWarnings,
+  deleteErrorMessage,
+  withoutVoucher,
+} from '../delete-logic.js';
+
+// Hard delete is irreversible and unguarded by any eligibility rule — the Worker
+// deletes whatever the allowlisted account names. Everything standing between a
+// mis-click and a lost voucher lives in these functions, so they are pinned here
+// rather than left to an Alpine expression that nothing can execute.
+// See 2026-08-05-voucher-hard-delete-design.md (section 3) in the vouchers hub.
+
+describe('codeConfirmed', () => {
+  test('accepts the code typed exactly', () => {
+    expect(codeConfirmed('UJ-WF36-4FWE', 'UJ-WF36-4FWE')).toBe(true);
+  });
+
+  test('accepts case and surrounding whitespace differences', () => {
+    // Codes are displayed uppercase but typed by hand, and a trailing space from
+    // a double-click copy is not a different voucher.
+    expect(codeConfirmed('  uj-wf36-4fwe  ', 'UJ-WF36-4FWE')).toBe(true);
+  });
+
+  test('rejects a partial or near-miss code', () => {
+    expect(codeConfirmed('UJ-WF36', 'UJ-WF36-4FWE')).toBe(false);
+    expect(codeConfirmed('UJ-WF36-4FW', 'UJ-WF36-4FWE')).toBe(false);
+    expect(codeConfirmed('UJ-WF36-4FWF', 'UJ-WF36-4FWE')).toBe(false);
+  });
+
+  test('rejects blank input, whatever the voucher', () => {
+    expect(codeConfirmed('', 'UJ-WF36-4FWE')).toBe(false);
+    expect(codeConfirmed('   ', 'UJ-WF36-4FWE')).toBe(false);
+  });
+
+  test('never confirms when there is no voucher code to match', () => {
+    // Otherwise an empty box would match an empty code and enable the button.
+    expect(codeConfirmed('', '')).toBe(false);
+    expect(codeConfirmed('', null)).toBe(false);
+    expect(codeConfirmed('anything', undefined)).toBe(false);
+  });
+});
+
+describe('canSubmitDelete', () => {
+  const ok = {
+    voucher: { voucher_id: 'UJ-WF36-4FWE' },
+    typedCode: 'UJ-WF36-4FWE',
+    reason: 'test voucher',
+    busy: false,
+  };
+
+  test('allows submission once code and reason are both given', () => {
+    expect(canSubmitDelete(ok)).toBe(true);
+  });
+
+  test('blocks until the code matches', () => {
+    expect(canSubmitDelete({ ...ok, typedCode: 'UJ-WF36' })).toBe(false);
+  });
+
+  test('blocks on a missing or whitespace-only reason', () => {
+    expect(canSubmitDelete({ ...ok, reason: '' })).toBe(false);
+    expect(canSubmitDelete({ ...ok, reason: '   ' })).toBe(false);
+  });
+
+  test('blocks while a delete is already in flight', () => {
+    // Double-submitting sends a second DELETE that 404s and reads as an error
+    // on a delete that in fact succeeded.
+    expect(canSubmitDelete({ ...ok, busy: true })).toBe(false);
+  });
+
+  test('blocks when there is no voucher loaded', () => {
+    expect(canSubmitDelete({ ...ok, voucher: null })).toBe(false);
+  });
+});
+
+describe('deleteWarnings', () => {
+  test('says nothing for a voucher with no transaction history', () => {
+    expect(deleteWarnings({ voucher_id: 'UJ-AAAA-BBBB', value: 50, balance: 50 })).toEqual([]);
+  });
+
+  test('warns when the voucher has been redeemed', () => {
+    const warnings = deleteWarnings({ value: 50, balance: 50, last_redeemed_amount: 20 });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/redeemed/i);
+  });
+
+  test('warns on a spent-down balance even without a last-redeemed amount', () => {
+    // Migrated v2 rows carry the reduced balance but not the per-redemption
+    // fields, so balance drift is the more reliable of the two signals.
+    expect(deleteWarnings({ value: 50, balance: 30 })).toHaveLength(1);
+  });
+
+  test('warns when a payment reference means real money was taken', () => {
+    const warnings = deleteWarnings({
+      value: 50,
+      balance: 50,
+      payment_platform: 'stripe',
+      payment_reference: 'pi_3QabcXYZ',
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/paid/i);
+  });
+
+  test('warns about both when a paid voucher has also been redeemed', () => {
+    expect(deleteWarnings({
+      value: 50,
+      balance: 0,
+      last_redeemed_amount: 50,
+      payment_reference: 'pi_3QabcXYZ',
+    })).toHaveLength(2);
+  });
+
+  test('ignores a blank payment reference', () => {
+    expect(deleteWarnings({ value: 50, balance: 50, payment_reference: '  ' })).toEqual([]);
+  });
+
+  test('tolerates a missing voucher rather than throwing into the modal', () => {
+    expect(deleteWarnings(null)).toEqual([]);
+  });
+});
+
+describe('deleteErrorMessage', () => {
+  test('names the allowlist on a 403, not the staff gate', () => {
+    // 401 means "signed out"; 403 means "signed in as the wrong person". Telling
+    // someone to sign in again when the answer is that their address is not
+    // allowed sends them round a loop that can never succeed.
+    const message = deleteErrorMessage({ status: 403, message: 'forbidden' });
+
+    expect(message).toMatch(/authorised account/i);
+    expect(message).not.toMatch(/expired|sign in again/i);
+  });
+
+  test('passes the session-expiry message through untouched on a 401', () => {
+    expect(deleteErrorMessage({ status: 401, message: 'Your session expired — reload the page to sign in again.' }))
+      .toBe('Your session expired — reload the page to sign in again.');
+  });
+
+  test('surfaces the server text for a 400 or 404', () => {
+    expect(deleteErrorMessage({ status: 400, message: 'reason is required' })).toBe('reason is required');
+    expect(deleteErrorMessage({ status: 404, message: 'Voucher not found' })).toBe('Voucher not found');
+  });
+
+  test('falls back to a readable line when the error carries no message', () => {
+    expect(deleteErrorMessage({ status: 500 })).toMatch(/delete/i);
+    expect(deleteErrorMessage(null)).toMatch(/delete/i);
+  });
+});
+
+describe('withoutVoucher', () => {
+  const results = [
+    { voucher_id: 'UJ-AAAA-1111' },
+    { voucher_id: 'UJ-BBBB-2222' },
+    { voucher_id: 'UJ-CCCC-3333' },
+  ];
+
+  test('drops the deleted row so the stale list does not outlive the voucher', () => {
+    expect(withoutVoucher(results, 'UJ-BBBB-2222').map((r) => r.voucher_id))
+      .toEqual(['UJ-AAAA-1111', 'UJ-CCCC-3333']);
+  });
+
+  test('leaves the list alone when the code is not in it', () => {
+    expect(withoutVoucher(results, 'UJ-ZZZZ-9999')).toHaveLength(3);
+  });
+
+  test('returns a new array rather than mutating the one passed in', () => {
+    const out = withoutVoucher(results, 'UJ-AAAA-1111');
+
+    expect(out).not.toBe(results);
+    expect(results).toHaveLength(3);
+  });
+
+  test('tolerates a list that has not loaded yet', () => {
+    expect(withoutVoucher(null, 'UJ-AAAA-1111')).toEqual([]);
+    expect(withoutVoucher(undefined, 'UJ-AAAA-1111')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements **urbanjungleirc/vouchers#39** — the staff-facing half of the Access-email-gated hard delete.

> Cross-repo: the issue lives in `urbanjungleirc/vouchers`, so merging this will **not** auto-close it. Close #39 there by hand.

The Worker side (`DELETE /v1/vouchers/:code`, `GET /v1/staff/me`, `DELETE_ALLOWED_EMAILS`) landed with vouchers#38. This is the UI that reaches it. Its other blocker, vouchers#27 (image library modal), is closed — so the modal-collision risk the design warned about is gone.

Design: `docs/superpowers/specs/2026-08-05-voucher-hard-delete-design.md` §3, in the vouchers hub.

## What it does

On load the page calls `GET /v1/staff/me` and renders **Delete Permanently** only when `can_delete` is true, so nobody is shown a button that can only 403. That is a *display* gate — the Worker re-checks the verified JWT on every request, and `canDelete` starts `false` so a failed identity call hides the button rather than exposing it.

The modal requires a reason and the voucher code **typed out** before confirm enables. The typed code is the part the allowlist cannot supply: the allowlist authenticates the *session*, which cannot tell one person from their unlocked laptop. Vouchers with redemption history or a payment reference get an extra warning, since those indicate a real transaction rather than a test artefact. Delete is solid where Cancel is outlined — they sit side by side and only one can be undone.

401 and 403 are deliberately not collapsed: 401 means the Access session lapsed and reloading fixes it; 403 means the address is not on the allowlist and reloading never will.

## Acceptance criteria

All ten from the issue are met. AC1 (identity endpoint) was delivered by vouchers#38 and is verified against here rather than re-implemented.

## Notable

**A fail-open bug, caught and closed.** Alpine swallows exceptions inside bindings, so a throwing `canSubmitDelete()` would leave `:disabled` unapplied and the confirm button on an irreversible action *enabled*. The repo's existing `image-pipeline.js` guard is what surfaced it. Now guarded at the door (`openDelete()`) and on the submit path — the latter is load-bearing, since it turns a throw into "nothing happens".

**Two small extensions beyond the ticket's wording**, both to avoid showing state the delete just invalidated:
- the report lists are pruned alongside the search results — the detail panel opens from either, and we navigate back to whichever it was, so pruning only search would leave a row that 404s on click;
- the dashboard totals are re-read.

Happy to drop either if you'd rather keep strictly to the wording.

## Verification

- **75 unit tests pass** (25 new in `vouchers/test/delete-logic.test.js`, 50 pre-existing untouched)
- **Driven in a real browser** across three identities — allowed, non-allowlisted, and allowed-but-refused-by-server. 34 checks covering button gating, disabled-until-typed (including partial and case-insensitive codes), the DELETE request body, the 403 message, and list pruning. The browser pass is what actually verifies the template bindings; unit tests can't reach them.

The confirmation rules live in `vouchers/delete-logic.js` — pure and unit tested, following the `unsubscribes-logic.js` seam.

## Not in this PR

**Nothing is deployed.** Deploy and live verification is vouchers#40, which needs an explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USwTQtGiP7TYFiCNSnV9qT
