### PR TITLE
docs: say plainly that main is production and merging is deploying

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,18 @@ Local Worker secrets can go in `cloudflare-worker/.dev.vars`. Do not commit real
 
 ## Deployment
 
-Normal static site changes deploy by pushing to `main`.
+> ⚠️ **`main` IS production.** GitHub Pages serves this repo's root directly to
+> `ujstaff.happyk.au` — legacy Pages, `source: main /`. No build step, no
+> workflow, no approval gate; the repo has no `.github/` directory at all.
+> Anything reaching `main` is live in well under a minute.
+>
+> **That includes merging a pull request.** There is no separate "deploy" step
+> to hold back, so *merging is deploying*. If a change is not ready to be seen by
+> staff — or a ticket says not to deploy yet — it must not reach `main`, on a
+> branch or otherwise. Where deploy **order** matters (the voucher portal needs
+> its Worker and migration live first), merge this repo **last**.
+
+Static changes therefore publish either way — a direct push, or a merged PR:
 
 ```bash
 git add <files>
@@ -163,10 +174,24 @@ git commit -m "description"
 git push origin main
 ```
 
-GitHub Pages publishes the static files. The Cloudflare Worker must also be deployed when `cloudflare-worker/` code or Worker config changes:
+Confirm a deploy from the Pages build, and check the commit it built:
 
 ```bash
-cd cloudflare-worker
+gh api repos/urbanjungleirc/staff-site/pages/builds/latest -q '.status + " " + .commit'
+```
+
+**Do not confirm it by fetching the page.** The zone sits behind Cloudflare
+Access, so an unauthenticated request returns **HTTP 200 carrying the Access
+login page**, not the file you asked for — a success status and a body that
+never contains your change. Verifying content needs a real browser session.
+
+The two Workers deploy separately; a Pages publish does not touch them.
+
+```bash
+cd cloudflare-worker          # roster + tools.json API
+npx wrangler deploy
+
+cd cloudflare-payments-proxy  # voucher portal → uj-payments; happyk account
 npx wrangler deploy
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,18 @@ Local Worker secrets can go in `cloudflare-worker/.dev.vars`. Do not commit real
 
 ## Deployment
 
-Normal static site changes deploy by pushing to `main`.
+> ⚠️ **`main` IS production.** GitHub Pages serves this repo's root directly to
+> `ujstaff.happyk.au` — legacy Pages, `source: main /`. No build step, no
+> workflow, no approval gate; the repo has no `.github/` directory at all.
+> Anything reaching `main` is live in well under a minute.
+>
+> **That includes merging a pull request.** There is no separate "deploy" step
+> to hold back, so *merging is deploying*. If a change is not ready to be seen by
+> staff — or a ticket says not to deploy yet — it must not reach `main`, on a
+> branch or otherwise. Where deploy **order** matters (the voucher portal needs
+> its Worker and migration live first), merge this repo **last**.
+
+Static changes therefore publish either way — a direct push, or a merged PR:
 
 ```bash
 git add <files>
@@ -252,10 +263,24 @@ git commit -m "description"
 git push origin main
 ```
 
-GitHub Pages publishes the static files. The Cloudflare Worker must also be deployed when `cloudflare-worker/` code or Worker config changes:
+Confirm a deploy from the Pages build, and check the commit it built:
 
 ```bash
-cd cloudflare-worker
+gh api repos/urbanjungleirc/staff-site/pages/builds/latest -q '.status + " " + .commit'
+```
+
+**Do not confirm it by fetching the page.** The zone sits behind Cloudflare
+Access, so an unauthenticated request returns **HTTP 200 carrying the Access
+login page**, not the file you asked for — a success status and a body that
+never contains your change. Verifying content needs a real browser session.
+
+The two Workers deploy separately; a Pages publish does not touch them.
+
+```bash
+cd cloudflare-worker          # roster + tools.json API
+npx wrangler deploy
+
+cd cloudflare-payments-proxy  # voucher portal → uj-payments; happyk account
 npx wrangler deploy
 ```
 


### PR DESCRIPTION
Documentation only — no behaviour change.

## The gap

The `## Deployment` section described pushing directly to `main`, which is accurate but incomplete: it never said that **merging a pull request** publishes too. Since the workspace convention pushes non-trivial work onto branches and PRs, the route most changes actually take was the one route the docs did not cover.

That bit during vouchers#39 (staff-site#26). The ticket said "nothing is deployed under this ticket" and vouchers#40 was held back as the deploy step — but merging the PR published the UI to `ujstaff.happyk.au` straight away. It was safe only because the migration and Worker were already live from vouchers#38, so the required migration → Worker → UI order still held. Confirmed with Jiri before merging.

## Also recorded

Two things that cost time to work out:

- **Verify a deploy from the Pages build, not by fetching the page.** The zone is behind Cloudflare Access, so an unauthenticated request returns **HTTP 200 carrying the Access login page** — a success status whose body never contains your change. That reads as a failed deploy when nothing is wrong. The documented `gh api …/pages/builds/latest` command was run before committing it and returns the merge commit.
- **The payments proxy Worker deploys separately too.** Only the roster Worker was listed.

Applied identically to `CLAUDE.md` and `AGENTS.md`, which already mirror each other (verified byte-identical with `diff`).

## Known drift, not fixed here

`AGENTS.md` has drifted from `CLAUDE.md` — its Repository Structure block lists neither `vouchers/` nor `cloudflare-payments-proxy/`, so the new `cd cloudflare-payments-proxy` line references a directory that file never introduces. Reconciling the two is a separate job; filed separately rather than half-fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USwTQtGiP7TYFiCNSnV9qT
