### PR TITLE
docs: sync AGENTS with voucher portal guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ index.html              - hub homepage; renders cards/groups from tools.json
 tools.json              - source of truth for hub entries
 roster.html             - daily staff roster, pulled from Deputy via Cloudflare Worker
 cloudflare-worker/      - Worker for roster API and tools.json editor API
+cloudflare-payments-proxy/ - Worker bridging vouchers/ to uj-payments with the Access JWT
+vouchers/               - voucher management portal (auth = Cloudflare Access)
+vouchers/stats.html     - voucher analytics: revenue, liability, redemption, product mix
+vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and why
+vouchers/unsubscribes-logic.js - pure suppression rules behind that page (unit tested)
+vouchers/delete-logic.js - pure confirmation rules behind the hard-delete action (unit tested)
 hvt/                    - High-volume Training tool copy
 slideshow/              - Google Drive TV slideshow tool
 sls_tv.html             - Summer Lead Series TV display
@@ -23,7 +29,7 @@ livescore_ssp*.html     - Super Social Pumpfest scoring/result pages
 iFrameTestBookingCalendar.html - booking calendar embed test
 ```
 
-There is also a separate `slideshow/AGENTS.md` for the slideshow tool. This root file describes the overall staff-site repo.
+There is also a separate `slideshow/CLAUDE.md` for the slideshow tool. This root file describes the overall staff-site repo.
 
 ## Hub Entries
 
@@ -95,7 +101,9 @@ Keep these synced with Deputy area colors where practical. Green is reserved for
 
 Under the day nav, `roster.html` shows one line describing the **selected**
 date — `Term 3 · Week 3 of 10`, or `School holidays · Term 4 starts Mon 12 Oct`.
-It is present in all three view modes.
+On a public holiday a badge goes in front of it, never instead of it:
+`[PUBLIC HOLIDAY] Anzac Day · Term 2 · Wk 2 of 11`. It is present in all three
+view modes.
 
 The data comes from `/api/calendar`, a route deliberately separate from
 `/api/roster` so a Deputy outage cannot remove term context. The Worker returns
@@ -109,8 +117,18 @@ term dates. This deliberately deviates from education.wa.edu.au — read
 the snapping logic. Definitions are in `CONTEXT.md`.
 
 The term table in `cloudflare-worker/src/calendar.js` is hardcoded through 2031
-and must be extended before then; the UI warns as it approaches expiry. Public
-holidays are not implemented yet — `publicHoliday` is always `null`.
+and must be extended before then; the UI warns as it approaches expiry.
+
+Public holidays come from a live WA feed the Worker fetches and caches (the feed
+sends no CORS headers, so the Worker is required, not a convenience). Read
+`docs/adr/0001-hybrid-calendar-sourcing.md` before touching that path — it
+records the three traps that fail *silently*: exclusive all-day end dates, the
+required trailing slash on the feed URL, and the rule that holidays must never
+be deduplicated by name.
+
+The two halves fail independently. If the feed is unreachable the Worker serves
+the last cached copy flagged stale, and if there is nothing cached it marks
+holidays unavailable and still returns term context.
 
 ### Deputy Worker Configuration
 
@@ -133,6 +151,77 @@ Important Worker vars:
 - `ALLOWED_ORIGIN` - CORS origin for the staff site
 
 The Worker still contains a legacy `/api/ics` route, but `roster.html` should use `/api/roster`.
+
+## Voucher Portal Auth
+
+`vouchers/` authenticates via Cloudflare Access — there is no shared secret in
+normal use. The page calls `/api/payments/*` same-origin; Access injects a
+signed `Cf-Access-Jwt-Assertion` header; `cloudflare-payments-proxy/` forwards
+it to the `uj-payments` Worker, which verifies the signature against the
+`happyk.cloudflareaccess.com` JWKS. The verified email is written to the audit
+trail.
+
+Two things to know before changing any of this:
+
+- **Access runs in front of Workers routes on this zone.** That is what makes
+  the proxy work despite `uj-payments` living in a *different* Cloudflare
+  account. Weakening the Zero Trust app breaks voucher auth, not just page
+  privacy.
+- **The proxy allowlists paths** (`/v1/vouchers`, `/v1/voucher-types`,
+  `/v1/staff/`). It must never relay `/v1/checkout/sessions`, or it becomes an
+  open relay for creating Stripe sessions. It also forwards `X-Manager-Secret`,
+  the second factor on cancel/restore.
+
+`X-Staff-Secret` survives only for localhost dev and as a break-glass path. A
+present-but-invalid JWT fails closed rather than falling back to it.
+
+Deploy the proxy from the **happyk** Cloudflare account (it owns `happyk.au`):
+
+```bash
+cd cloudflare-payments-proxy
+npx wrangler deploy      # route is declared in its wrangler.toml
+```
+
+### Deleting a voucher
+
+The **Delete Permanently** button on the voucher detail panel is a *hard* delete
+— the row leaves the database, along with the `purchase_tracking` row that
+counts against the buyer's per-customer limit. Cancel (the outlined rose button
+beside it) is the reversible one. They are deliberately styled differently:
+solid versus outlined.
+
+Three things about this are easy to break by accident:
+
+- **The button is identity-gated, not password-gated.** On load the page calls
+  `GET /v1/staff/me` and renders the button only when `can_delete` is true, so
+  nobody is shown an action that can only 403. That is a *display* gate — the
+  Worker re-checks the verified Access JWT against its `DELETE_ALLOWED_EMAILS`
+  allowlist on every DELETE, and `canDelete` starts `false` so a failed identity
+  call hides the button rather than exposing it.
+- **The typed voucher code is the real second factor**, and is not decoration.
+  The allowlist authenticates the *session*, which cannot tell one person from
+  their unlocked laptop; typing the code is what the allowlist cannot supply.
+- **401 and 403 must not be collapsed.** 401 is the staff gate (the Access
+  session lapsed — reloading fixes it). 403 is the allowlist (the session is
+  fine and reloading will never help). Showing "sign in again" for a 403 sends
+  someone round a loop that cannot succeed.
+
+The rules behind all of that live in `vouchers/delete-logic.js` — pure, unit
+tested in `vouchers/test/delete-logic.test.js`, and published as
+`window.deleteLogic` like the other extracted modules. Bump the `?v=` on its
+import whenever its exports change.
+
+A stale cached copy of that module is the one failure that would break the
+typed-code check, the required-reason check and the disabled button
+*simultaneously and silently*, so two things hold it closed: `openDelete()`
+refuses to open the modal when an export is missing, and `submitDelete()`
+re-checks before sending. The re-check is the load-bearing one — an Alpine
+expression that throws leaves `:disabled` unapplied, so a broken
+`canSubmitDelete` would *enable* the confirm button, and only a guard on the
+submit path turns that back into "nothing happens".
+
+Design: `docs/superpowers/specs/2026-08-05-voucher-hard-delete-design.md` in the
+`voucher-app` hub repo.
 
 ## Local Development
 
@@ -204,8 +293,14 @@ npx wrangler deploy
 
 ## Agent skills
 
-Shared configuration for the engineering skills — mirrored from `CLAUDE.md`, which is authoritative.
+### Issue tracker
 
-- **Issue tracker** — GitHub Issues via the `gh` CLI. See `docs/agents/issue-tracker.md`.
-- **Triage labels** — default canonical vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
-- **Domain docs** — single-context layout (`CONTEXT.md` + `docs/adr/` at repo root). See `docs/agents/domain.md`.
+Issues are tracked in GitHub Issues (via the `gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout (`CONTEXT.md` + `docs/adr/` at repo root). See `docs/agents/domain.md`.


### PR DESCRIPTION
## Summary

Sync `AGENTS.md` back to `CLAUDE.md` so Codex-style agents see the current voucher portal guidance and repository structure.

This adds the missing voucher portal/proxy entries, voucher auth and hard-delete guidance, the current public-holiday roster notes, and the expanded agent-skills sections. It also updates the slideshow handoff reference to the existing `slideshow/CLAUDE.md` path.

Closes #28.

## Validation

- `diff -u AGENTS.md CLAUDE.md`
- `git diff --check`
- verified referenced voucher/proxy/docs paths exist
- `node --check vouchers/delete-logic.js`
- `node --check vouchers/unsubscribes-logic.js`
- `node --check vouchers/image-pipeline.js`
- `node --check cloudflare-payments-proxy/src/index.js`
- `node --check cloudflare-worker/src/calendar.js`
- `node --check cloudflare-worker/src/index.js`

I also tried the exposed package tests in `vouchers`, `cloudflare-payments-proxy`, and `cloudflare-worker`; they could not run in this checkout because `vitest` is not installed and the subpackages do not include lockfiles. This PR is Markdown-only.