### PR TITLE
Organise the voucher type editor by output surface (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ vouchers/stats.html     - voucher analytics: revenue, liability, redemption, pro
 vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and why
 vouchers/unsubscribes-logic.js - pure suppression rules behind that page (unit tested)
 vouchers/delete-logic.js - pure confirmation rules behind the hard-delete action (unit tested)
+vouchers/type-surfaces.js - which voucher-type fields feed which output surface (unit tested)
 hvt/                    - High-volume Training tool copy
 slideshow/              - Google Drive TV slideshow tool
 sls_tv.html             - Summer Lead Series TV display

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,3 +84,53 @@ a term context that still renders. Term context does not depend on the feed.
 
 Green is reserved for the "on now" shift state and is never used for calendar
 states.
+
+## Voucher type editor
+
+Terms describing how a voucher type's settings are organised. Implemented in
+`vouchers/type-surfaces.js` and consumed by the type editor in
+`vouchers/index.html`.
+
+### Surface
+
+The output a group of a voucher type's fields actually produces. A type has
+exactly three: **Setup** (behaviour — identity, rules, limits, and the staff
+redemption warning; no customer-facing output), **Email** (everything that
+renders into the customer's voucher email, branding included), and **Public
+page** (everything that renders onto the public purchase page).
+
+Surfaces are the editor's organising principle — one tab each — and the
+partition is exported as data from `type-surfaces.js` rather than implied by
+markup, so "which surface owns this field?" is answered by reading a constant.
+See [ADR 0003](docs/adr/0003-voucher-type-editor-organised-by-surface.md).
+
+*Avoid*: "section", "card", "tab" when you mean the grouping itself. A card is
+one visual box; a surface may contain several. A tab is how a surface is
+reached.
+
+### Hero backdrop / hero artwork
+
+Two different public-page images, with **different blank behaviour**, which is
+why they never share a word.
+
+The **hero backdrop** (`hero_background_url`) is the full-width band behind the
+hero. Left blank, the page draws a gradient derived from the type's brand
+colour, so a blank backdrop still renders something.
+
+The **hero artwork** (`hero_image_url`) sits beside the hero copy. Left blank,
+nothing renders — there is no fallback, and it is never inherited from another
+type.
+
+*Avoid*: "hero image" unqualified. It reads as either one and the difference is
+the whole point.
+
+### Theme inheritance
+
+The rule that a **blank** public page field on a voucher type falls back to the
+Gift Voucher type's value, and then to the page's built-in default.
+
+It is **per field, not per type**: a partially filled public page inherits only
+the fields left blank. The two hero image fields are exempt — they do not
+inherit at all (see above). The editor makes this visible with a chip on an
+untouched tab and, when creating a type, a confirmation before saving a surface
+that was never opened; neither changes the cascade itself.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,11 +118,16 @@ hero. Left blank, the page draws a gradient derived from the type's brand
 colour, so a blank backdrop still renders something.
 
 The **hero artwork** (`hero_image_url`) sits beside the hero copy. Left blank,
-nothing renders — there is no fallback, and it is never inherited from another
-type.
+nothing renders — there is no colour fallback for it.
 
 *Avoid*: "hero image" unqualified. It reads as either one and the difference is
 the whole point.
+
+Note that neither image is *theme-inherited* at render time (below), but both
+are **seeded** into a new type from the Gift Voucher type by the editor — so a
+new type does start out carrying that product's artwork. Seeding and
+inheritance are different mechanisms and the difference matters when reasoning
+about what a customer will see.
 
 ### Theme inheritance
 
@@ -134,3 +139,9 @@ the fields left blank. The two hero image fields are exempt — they do not
 inherit at all (see above). The editor makes this visible with a chip on an
 untouched tab and, when creating a type, a confirmation before saving a surface
 that was never opened; neither changes the cascade itself.
+
+Inheritance applies to types whose columns are **null**. Because the editor
+seeds a new draft from the Gift Voucher record, a type created through the UI
+usually has no null columns to inherit through — it holds copies instead. The
+chip therefore appears mainly on types created before seeding, or through the
+API. See [ADR 0003](docs/adr/0003-voucher-type-editor-organised-by-surface.md).

--- a/docs/adr/0003-voucher-type-editor-organised-by-surface.md
+++ b/docs/adr/0003-voucher-type-editor-organised-by-surface.md
@@ -1,0 +1,132 @@
+# ADR 0003 — The voucher type editor is organised by output surface
+
+- **Status**: Accepted
+- **Date**: 2026-08-07
+- **Context**: voucher type editor tabs ([vouchers#42](https://github.com/urbanjungleirc/vouchers/issues/42))
+
+## Context
+
+A voucher type carries roughly 31 fields. They were laid out as five stacked
+cards — Identity & rules, Email content, Branding, Public page, Staff — with a
+live email preview pinned beside them for the whole scroll. Reaching Save meant
+travelling about three screens.
+
+The people who edit voucher types are not the people who built the form. Types
+are configuration: created rarely, edited a few times a year, usually by a duty
+manager who has not seen the form since the last time. Three things follow from
+that.
+
+The grouping existed visually but its *reason* did not. Nothing said that the
+fields on screen governed the customer email while the ones two screens down
+governed the public purchase page.
+
+Half the modal was spent on a preview of one of those outputs. It reflects nine
+fields. While the largest section — the public page — was being edited, it
+showed an email unrelated to every keystroke, and the public page had no preview
+at all.
+
+And the brand colour, which themes the *entire* customer page, appeared once, in
+a card the user had to scroll away from to edit the page it themes.
+
+Underneath sat a discoverability problem with a real consequence: blank public
+page fields inherit the Gift Voucher type's wording, and a cleared hero backdrop
+becomes a gradient. Neither was stated anywhere, so a duty manager could save a
+new type whose customer page silently borrowed another product's copy.
+
+## Decision
+
+**Group the fields by surface — the output they produce — and give each surface
+a tab.**
+
+| Surface | Cards | Preview |
+|---|---|---|
+| Setup | Identity & rules, Staff | none |
+| Email | Email content, Branding | live email preview |
+| Public page | Public page | none |
+
+The partition is derived from what the code consumes, not from how the cards
+happened to be grouped. The email renderer consumes exactly nine type columns,
+and that is the Email tab's membership — which is why **Branding belongs to
+Email**: all four of its fields feed the email renderer.
+
+Three consequences of that boundary are worth stating, because each looks like
+an inconsistency until the rule is known:
+
+- **Brand colour is mirrored onto the Public page tab, not moved.** It themes
+  the whole public page, so it must be visible while that page's copy is
+  written — but it is shown read-only, with a button that jumps to the Email
+  tab. A second editable control was rejected: binding two inputs to one value
+  is nearly free, but presenting the same setting twice to someone who visits
+  twice a year costs more than the saved click.
+- **The staff redemption warning gets no surface of its own.** It is one field
+  describing a redemption rule, so it sits with the other rules on Setup, as a
+  visually distinct card.
+- **The display name stays on Setup** despite feeding the email heading. The
+  modal title renders it reactively, so it is on screen and live whichever tab
+  is active.
+
+The partition is **exported as data** from `vouchers/type-surfaces.js`, so the
+branding-belongs-to-email decision is answerable by reading one constant rather
+than by scanning markup. The same module holds the derivations over a draft
+type: chip state, unreviewed surfaces, and the backdrop fallback CSS.
+
+Panels are shown and hidden, never created and destroyed. Form state therefore
+survives tab switching, one `@input` handler still covers every field, and chip
+state is computable from the form model at any moment.
+
+## Consequences
+
+**A long scroll had one accidental virtue.** Reaching Save meant passing every
+field, so nobody creating a type could avoid noticing that a public page section
+existed. Tabs remove that, and without compensation this change would make it
+*easier* to publish an unconfigured customer page.
+
+Two things buy that property back, and they are load-bearing rather than
+decorative:
+
+- A **chip** on a tab, present only while that surface is untouched, naming what
+  the customer gets instead ("Inherits Gift Voucher", "Default wording"). Setup
+  never carries one — its identity fields are required, so a permanent
+  indicator would be noise. The pre-filled email defaults
+  (`redemption_instructions`, `voucher_label`) do not count as customisation; if
+  they did, every type would read as customised forever.
+- A **save guard on creation only**. If a surface was never opened, saving a new
+  type asks first, and states the actual consequence — the customer page will
+  use the Gift Voucher type's wording and show no hero artwork. Editing an
+  existing type never asks.
+
+If either is dropped later, reopen this trade rather than accepting it quietly.
+
+**The chip is deliberately imprecise.** Theme inheritance is per field, so a
+partially filled public page still inherits for the fields left blank, and the
+chip will not say so; the two hero image fields do not inherit at all. A tab
+label cannot carry that nuance. The guard text is where the real behaviour is
+spelled out. This is a division of labour, not an oversight.
+
+**A completion count was rejected.** It reads as a score and implies filling
+every field is the goal. Blank is a legitimate configuration.
+
+**The preview is now conditional, so it needs a dirty flag.** It refreshes only
+while the Email tab is active. Because the display name lives on Setup and feeds
+the email heading, entering the Email tab re-renders once if anything changed
+while it was hidden. Without that, the preview would show a stale heading.
+
+**The editor gains no colour maths.** The empty backdrop slot renders the real
+fallback gradient using `color-mix(in srgb, <accent> 70%, black)` for the dark
+stop. That is arithmetically identical to the `shade(accent, -0.3)` used by both
+the public page and the email renderer, so a *fourth* hand-written darkening was
+avoided and this one cannot drift from the others. The existing pair was left
+alone — merging them is a separate job.
+
+**No public page preview.** The email preview is server-rendered from the draft,
+which is why it can show unsaved edits. The public page is a client-side
+application that reads saved data only, so previewing a draft would need either
+a second server-side renderer or a draft-injection channel spanning two
+repositories. This decision compensates for its absence — the full modal width,
+the page-mirroring field arrangement, and the brand colour swatch — rather than
+providing it.
+
+**Modal anatomy changed with it**: pinned header carrying title, error banner
+and tab strip; scrolling body; pinned footer carrying Cancel and Save. That
+fixes a pre-existing fault where Save sat below the fold on tall types, and it
+keeps the error banner visible on any tab at any scroll position.

--- a/docs/adr/0003-voucher-type-editor-organised-by-surface.md
+++ b/docs/adr/0003-voucher-type-editor-organised-by-surface.md
@@ -91,11 +91,33 @@ decorative:
   (`redemption_instructions`, `voucher_label`) do not count as customisation; if
   they did, every type would read as customised forever.
 - A **save guard on creation only**. If a surface was never opened, saving a new
-  type asks first, and states the actual consequence — the customer page will
-  use the Gift Voucher type's wording and show no hero artwork. Editing an
-  existing type never asks.
+  type asks first, and states the actual consequence. Editing an existing type
+  never asks.
 
 If either is dropped later, reopen this trade rather than accepting it quietly.
+
+**The chip and the create path do not meet, and that is worth knowing.**
+`openTypeEditor()` seeds a new draft from the live Gift Voucher record — it has
+done so since long before this change. Those fields therefore arrive *populated*,
+not blank, so on the create path neither chip appears: there is nothing to
+inherit, because the type holds copies. The chip does its job on the edit path,
+where types created before seeding (or through the API) genuinely carry nulls.
+
+The spec's chip rule was written as "chip when the fields are blank", and that
+is what shipped. Two consequences follow, both deliberate:
+
+- The **save guard carries the whole weight on the create path**, which is the
+  path the guard was written for. That is why its text says the unopened surface
+  still holds *the Gift Voucher type's own wording and artwork* rather than the
+  spec's "will use the Gift Voucher type's wording and show no hero artwork" —
+  the latter describes the inheritance cascade, which a seeded type does not
+  reach. Stating the cascade there would have been false.
+- Making the chip mean "still identical to the Gift Voucher template" would give
+  it a job on the create path too. It is a real option, it changes the rule the
+  spec pinned down precisely, and it was **not** taken here. Reopen it as its own
+  decision rather than folding it into a reorganisation.
+
+Changing the seeding behaviour was not considered in scope.
 
 **The chip is deliberately imprecise.** Theme inheritance is per field, so a
 partially filled public page still inherits for the fields left blank, and the

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.10","results":[[":vouchers/test/type-surfaces.test.js",{"duration":9.147389000000004,"failed":false}]]}

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -2035,13 +2035,18 @@
   </div>
 
   <!-- ── Voucher Type editor modal ──────────────────────────────────────── -->
-  <div x-show="typeEditorOpen" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4"
+  <!-- Top-aligned, not centred: the three tabs are different heights, and a
+       centred panel re-centres on every switch, so the whole form jumps under
+       the pointer. Anchoring it means only the content below changes. -->
+  <div x-show="typeEditorOpen" x-cloak class="fixed inset-0 z-50 flex items-start justify-center p-4 pt-8"
     @keydown.escape.window="!discardOpen && !revenueClassConfirmOpen && !unreviewedConfirmOpen && !imgModal && closeTypeEditor()">
     <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="closeTypeEditor()"></div>
     <!-- Conventional modal anatomy: pinned header, scrolling body, pinned footer.
          Save used to sit below the fold on tall types, and the error banner
          could scroll out of sight; both are now reachable from any position. -->
-    <div class="relative bg-white rounded-card shadow-2xl shadow-neutral-900/15 w-full max-w-7xl max-h-[90vh] flex flex-col overflow-hidden border border-neutral-100">
+    <!-- 3rem = the wrapper's 2rem top + 1rem bottom padding, so a full-height
+         panel still clears the viewport. -->
+    <div class="relative bg-white rounded-card shadow-2xl shadow-neutral-900/15 w-full max-w-7xl max-h-[calc(100vh-3rem)] flex flex-col overflow-hidden border border-neutral-100">
       <div class="shrink-0 px-6 pt-6 border-b border-neutral-100">
         <div class="flex items-center justify-between mb-4">
           <h3 class="text-base font-semibold text-neutral-900"
@@ -2358,10 +2363,17 @@
           <!-- Hero backdrop (full-width band behind everything) -->
           <div>
             <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero background<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Photo behind the hero. Leave blank to use the accent colour gradient. Text sits over this — pick something that keeps white type readable. Aim for 1920 × 1080; the edges get cropped on phones.</span></span></label>
-            <div class="rounded-xl border border-neutral-200 p-4">
+            <!-- Preview first at the full width available, details under it. This
+                 is the field where the judgement call is "does white type stay
+                 readable over this photo", and a thumbnail cannot answer it. -->
+            <div class="rounded-xl border border-neutral-200 bg-white p-4">
               <div class="flex flex-wrap gap-4 items-start">
-                <div class="flex-shrink-0">
-                  <div class="w-56 aspect-[16/9] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
+                <!-- Capped by WIDTH, not height: a max-height would fight the aspect
+                     ratio and crop the preview. 500px at 16:9 is 281px tall, which
+                     is enough to judge the photo without owning the tab — and it
+                     leaves room for the details beside it rather than beneath. -->
+                <div class="flex-1 min-w-[18rem] max-w-[500px]">
+                  <div class="w-full aspect-[16/9] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
                     <img :src="typeForm.hero_background_url" x-show="typeForm.hero_background_url" alt=""
                       class="w-full h-full object-cover"
                       x-on:load="imgBroken['hero_background_url'] = false"
@@ -2431,32 +2443,31 @@
             <!-- Hero artwork (sits beside the copy) -->
             <div>
               <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero artwork<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Artwork shown beside the hero copy. Leave blank to show no artwork. Aim for 1200 × 900 — it's cropped to a wide strip on phones, so keep the subject in the middle.</span></span></label>
-              <div class="rounded-xl border border-neutral-200 p-4">
+              <div class="rounded-xl border border-neutral-200 bg-white p-4 grid gap-3">
                 <!-- The crops stay side by side at every width — seeing them together
-                     is the whole point — so they share a fluid two-column grid rather
-                     than fixed widths. This control sits in the narrower right-hand
-                     column, so the details wrap below instead of spilling out. -->
-                <div class="flex flex-wrap gap-4 items-start">
-                  <div class="grid grid-cols-2 gap-3 flex-1 min-w-[12rem] max-w-sm">
-                    <!-- desktop crop -->
-                    <div>
-                      <div class="w-full aspect-[4/3] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
-                        <img :src="typeForm.hero_image_url" x-show="typeForm.hero_image_url" alt=""
-                          class="w-full h-full object-cover"
-                          x-on:load="imgBroken['hero_image_url'] = false"
-                          x-on:error="imgBroken['hero_image_url'] = true" />
-                      </div>
-                      <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Desktop · 4:3</p>
+                     is the whole point — and they take the full width of the control,
+                     with the details on their own row underneath. -->
+                <div class="grid grid-cols-2 gap-3">
+                  <!-- desktop crop -->
+                  <div>
+                    <div class="w-full aspect-[4/3] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
+                      <img :src="typeForm.hero_image_url" x-show="typeForm.hero_image_url" alt=""
+                        class="w-full h-full object-cover"
+                        x-on:load="imgBroken['hero_image_url'] = false"
+                        x-on:error="imgBroken['hero_image_url'] = true" />
                     </div>
-                    <!-- mobile crop -->
-                    <div>
-                      <div class="w-full aspect-[21/9] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
-                        <img :src="typeForm.hero_image_url" x-show="typeForm.hero_image_url" alt=""
-                          class="w-full h-full object-cover" />
-                      </div>
-                      <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Phone · 21:9</p>
-                    </div>
+                    <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Desktop · 4:3</p>
                   </div>
+                  <!-- mobile crop -->
+                  <div>
+                    <div class="w-full aspect-[21/9] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
+                      <img :src="typeForm.hero_image_url" x-show="typeForm.hero_image_url" alt=""
+                        class="w-full h-full object-cover" />
+                    </div>
+                    <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Phone · 21:9</p>
+                  </div>
+                </div>
+                <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
                   <div class="flex-1 min-w-[11rem]">
                     <p class="text-sm font-semibold text-neutral-700 truncate"
                       x-text="imgMeta('hero_image_url').name || 'No artwork'"></p>
@@ -2466,13 +2477,13 @@
                     </p>
                     <p class="text-xs text-neutral-400" x-text="imgMeta('hero_image_url').size"></p>
                     <p class="text-xs text-neutral-400 mt-0.5" x-text="imgMeta('hero_image_url').used"></p>
-                    <div class="flex gap-2 mt-3">
-                      <button type="button" @click="openImgModal('hero')"
-                        class="text-xs font-semibold px-3 py-1.5 rounded-lg bg-uj text-white hover:bg-uj-dark">Change image</button>
-                      <button type="button" @click="typeForm.hero_image_url = ''; refreshPreview()"
-                        x-show="typeForm.hero_image_url"
-                        class="text-xs font-semibold px-3 py-1.5 rounded-lg border border-neutral-200 text-neutral-600 hover:bg-neutral-50">Remove</button>
-                    </div>
+                  </div>
+                  <div class="flex gap-2 shrink-0">
+                    <button type="button" @click="openImgModal('hero')"
+                      class="text-xs font-semibold px-3 py-1.5 rounded-lg bg-uj text-white hover:bg-uj-dark">Change image</button>
+                    <button type="button" @click="typeForm.hero_image_url = ''; refreshPreview()"
+                      x-show="typeForm.hero_image_url"
+                      class="text-xs font-semibold px-3 py-1.5 rounded-lg border border-neutral-200 text-neutral-600 hover:bg-neutral-50">Remove</button>
                   </div>
                 </div>
               </div>

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -2332,10 +2332,10 @@
              two editable controls for one setting would be worse than a jump. -->
         <div class="flex flex-wrap items-center gap-3 rounded-2xl border border-neutral-200 bg-neutral-50/70 px-4 py-3">
           <span class="h-7 w-7 rounded-lg ring-1 ring-inset ring-black/10 shrink-0"
-            :style="`background:${typeForm.accent_color || '#ae222a'}`"></span>
+            :style="`background:${accentColour()}`"></span>
           <div class="leading-tight">
             <p class="text-xs font-semibold text-neutral-700">Brand colour
-              <span class="font-mono font-normal text-neutral-500" x-text="typeForm.accent_color || '#ae222a'"></span>
+              <span class="font-mono font-normal text-neutral-500" x-text="accentColour()"></span>
             </p>
             <p class="text-[0.7rem] text-neutral-400">Themes this page. Set on the Email tab.</p>
           </div>
@@ -2460,10 +2460,9 @@
                   <div class="flex-1 min-w-[11rem]">
                     <p class="text-sm font-semibold text-neutral-700 truncate"
                       x-text="imgMeta('hero_image_url').name || 'No artwork'"></p>
-                    <!-- Unlike the backdrop, artwork has no colour fallback and
-                         is never inherited from another type. -->
+                    <!-- Unlike the backdrop, artwork has no colour fallback. -->
                     <p x-show="!typeForm.hero_image_url" class="text-xs text-neutral-400">
-                      Blank shows nothing — artwork never falls back.
+                      Blank shows nothing — no colour fallback.
                     </p>
                     <p class="text-xs text-neutral-400" x-text="imgMeta('hero_image_url').size"></p>
                     <p class="text-xs text-neutral-400 mt-0.5" x-text="imgMeta('hero_image_url').used"></p>
@@ -2791,13 +2790,15 @@
         <span class="font-semibold" x-text="unreviewedLabels()"></span>
         on this new type.
       </p>
-      <p x-show="_pendingUnreviewedIds.includes('public')" class="text-sm text-neutral-700 mb-3">
-        Any public page field left blank falls back to the Gift Voucher type's wording, and the hero
-        artwork does not fall back at all — so the customer page may show another product's copy with
-        no artwork on it.
-      </p>
-      <p x-show="_pendingUnreviewedIds.includes('email')" class="text-sm text-neutral-700 mb-3">
-        Any email field left blank falls back to the built-in default wording.
+      <!-- States what the customer actually gets, which on a NEW type is the
+           Gift Voucher type's own wording and artwork: openTypeEditor() seeds a
+           new draft from that record, so unopened fields are not blank — they
+           are already that product's copy. Anything genuinely left blank then
+           falls back to the same place when the page renders. -->
+      <p class="text-sm text-neutral-700 mb-3">
+        A new type starts from the Gift Voucher type's settings, so anything you have not looked at
+        is still <span class="font-semibold">that product's wording and artwork</span> — and any field
+        you do clear falls back to it again when the customer page is rendered.
       </p>
       <p class="text-sm text-neutral-500 mb-6">That may be exactly what you want.</p>
       <div class="flex gap-2.5">
@@ -3118,6 +3119,14 @@
       'canSubmitDelete', 'deleteWarnings', 'deleteErrorMessage', 'withoutVoucher',
     ];
 
+    // Everything the type editor calls on window.typeSurfaces. Same hazard
+    // again, and here a throw inside the tab strip's x-for renders no tabs at
+    // all — Setup would be the only reachable surface, with nothing saying why.
+    // Checked before the editor can be opened.
+    const TYPE_SURFACES_REQUIRED = [
+      'chipFor', 'unreviewedSurfaces', 'backdropFallbackCss',
+    ];
+
     const IS_LOCAL = ['localhost', '127.0.0.1'].includes(window.location.hostname);
     const WORKER = IS_LOCAL ? 'https://uj-payments.urbanjungle.workers.dev' : '/api/payments';
 
@@ -3233,7 +3242,7 @@
       typeTabsVisited: ['setup'],
       unreviewedConfirmOpen: false,
       _pendingUnreviewedPayload: null,
-      _pendingUnreviewedIds: [],
+      _pendingUnreviewed: [],
       previewHtml: '',
       previewLoading: false,
       // The preview only refreshes while the Email tab is showing, so this
@@ -4788,6 +4797,17 @@
       },
 
       openTypeEditor(t = null) {
+        const missing = TYPE_SURFACES_REQUIRED.filter((fn) => typeof window.typeSurfaces?.[fn] !== 'function');
+        if (!Array.isArray(window.typeSurfaces?.SURFACES)) missing.push('SURFACES');
+        if (missing.length) {
+          this.showToast(
+            'This page loaded an out-of-date script, so the type editor is disabled. '
+            + 'Reload with Ctrl+Shift+R (Cmd+Shift+R on a Mac). '
+            + `If it keeps happening, tell Jiri — missing: ${missing.join(', ')}.`,
+            'error',
+          );
+          return;
+        }
         this.typeEditorError = '';
         this.editingExisting = !!t;
         // Remember the class as loaded, so saveVoucherType() can tell a genuine
@@ -4872,10 +4892,12 @@
       },
 
       unreviewedLabels() {
-        const labels = this._pendingUnreviewedIds
-          .map(id => (window.typeSurfaces.SURFACES.find(s => s.id === id) || {}).label)
-          .filter(Boolean);
+        const labels = this._pendingUnreviewed.map(s => s.label);
         return labels.length === 2 ? labels.join(' or ') : labels.join(', ');
+      },
+
+      accentColour() {
+        return this.typeForm.accent_color || window.typeSurfaces.DEFAULT_ACCENT;
       },
 
       refreshPreview() {
@@ -5253,21 +5275,13 @@
         // Creating a type without having looked at a customer-facing surface is
         // how an unconfigured customer page gets published. Editing an existing
         // type is routine and never asks.
-        //
-        // A browser holding a stale cached type-surfaces.js would throw here and
-        // save nothing, with no explanation — the same trap the delete modal and
-        // the image pipeline already guard. Say so instead.
-        if (typeof window.typeSurfaces?.unreviewedSurfaces !== 'function') {
-          this.typeEditorError = 'The editor did not finish loading. Hard-refresh the page (Ctrl+Shift+R) and try again.';
-          return;
-        }
         const unreviewed = window.typeSurfaces.unreviewedSurfaces({
           editingExisting: this.editingExisting,
           visited: this.typeTabsVisited,
         });
         if (unreviewed.length) {
           this._pendingUnreviewedPayload = payload;
-          this._pendingUnreviewedIds = unreviewed.map(s => s.id);
+          this._pendingUnreviewed = unreviewed;
           this.unreviewedConfirmOpen = true;
           return;
         }
@@ -5287,7 +5301,7 @@
         this._pendingUnreviewedPayload = null;
         // Land on the first surface they skipped, so "go and look" needs no
         // second decision about where.
-        if (this._pendingUnreviewedIds.length) this.setTypeTab(this._pendingUnreviewedIds[0]);
+        if (this._pendingUnreviewed.length) this.setTypeTab(this._pendingUnreviewed[0].id);
       },
 
       async _doSaveVoucherType(payload) {

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -40,6 +40,10 @@
     // delete modal at once; openDelete() and submitDelete() both check for it.
     import * as deleteLogic from './delete-logic.js?v=1';
     window.deleteLogic = deleteLogic;
+    // And here: bump it whenever type-surfaces.js gains or renames an export.
+    // A stale cached copy would leave the type editor with no tabs to render.
+    import * as typeSurfaces from './type-surfaces.js?v=1';
+    window.typeSurfaces = typeSurfaces;
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
@@ -2032,22 +2036,51 @@
 
   <!-- ── Voucher Type editor modal ──────────────────────────────────────── -->
   <div x-show="typeEditorOpen" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4"
-    @keydown.escape.window="!discardOpen && !revenueClassConfirmOpen && !imgModal && closeTypeEditor()">
+    @keydown.escape.window="!discardOpen && !revenueClassConfirmOpen && !unreviewedConfirmOpen && !imgModal && closeTypeEditor()">
     <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="closeTypeEditor()"></div>
-    <div class="relative bg-white rounded-card shadow-2xl shadow-neutral-900/15 w-full max-w-7xl max-h-[90vh] overflow-y-auto p-6 border border-neutral-100">
-      <div class="flex items-center justify-between mb-4">
-        <h3 class="text-base font-semibold text-neutral-900"
-          x-text="editingExisting ? ('Edit ' + typeForm.display_name) : 'New voucher type'"></h3>
-        <button @click="closeTypeEditor()" class="text-neutral-400 hover:text-neutral-700 text-xl leading-none">&times;</button>
+    <!-- Conventional modal anatomy: pinned header, scrolling body, pinned footer.
+         Save used to sit below the fold on tall types, and the error banner
+         could scroll out of sight; both are now reachable from any position. -->
+    <div class="relative bg-white rounded-card shadow-2xl shadow-neutral-900/15 w-full max-w-7xl max-h-[90vh] flex flex-col overflow-hidden border border-neutral-100">
+      <div class="shrink-0 px-6 pt-6 border-b border-neutral-100">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-base font-semibold text-neutral-900"
+            x-text="editingExisting ? ('Edit ' + typeForm.display_name) : 'New voucher type'"></h3>
+          <button @click="closeTypeEditor()" class="text-neutral-400 hover:text-neutral-700 text-xl leading-none">&times;</button>
+        </div>
+
+        <div x-show="typeEditorError"
+          class="bg-rose-50 border border-rose-200 text-rose-700 rounded-xl p-3 text-sm mb-4"
+          x-text="typeEditorError"></div>
+
+        <!-- Tab strip — one tab per output surface. A chip appears only while a
+             surface is untouched, and names what the customer gets instead. -->
+        <div class="flex gap-1 -mb-px" role="tablist">
+          <template x-for="s in typeSurfaceList()" :key="s.id">
+            <button type="button" role="tab" :aria-selected="(typeTab === s.id).toString()"
+              @click="setTypeTab(s.id)"
+              :class="typeTab === s.id
+                ? 'border-uj text-uj'
+                : 'border-transparent text-neutral-500 hover:text-neutral-800'"
+              class="flex items-center gap-2 px-4 py-2.5 text-sm font-semibold border-b-2 transition-colors">
+              <span x-text="s.label"></span>
+              <span x-show="typeTabChip(s.id)" x-cloak x-text="typeTabChip(s.id)"
+                class="text-[0.6rem] font-medium uppercase tracking-wider bg-amber-50 text-amber-700 border border-amber-200 rounded-full px-2 py-0.5"></span>
+            </button>
+          </template>
+        </div>
       </div>
 
-      <div x-show="typeEditorError"
-        class="bg-rose-50 border border-rose-200 text-rose-700 rounded-xl p-3 text-sm mb-4"
-        x-text="typeEditorError"></div>
-
-      <div class="grid lg:grid-cols-2 gap-6">
-        <div class="order-2 lg:order-1" @input="refreshPreview()">
+      <div class="flex-1 overflow-y-auto px-6 py-5" @input="refreshPreview()">
+      <div class="grid gap-6" :class="typeTab === 'email' ? 'lg:grid-cols-2' : ''">
+        <div>
           <div class="grid gap-5">
+
+        <!-- ── Setup panel ──────────────────────────────────────────────────
+             Panels are shown and hidden, never created and destroyed, so form
+             state survives tab switching and the @input handler above keeps
+             covering every field on every surface. -->
+        <div x-show="typeTab === 'setup'" class="grid gap-5">
 
         <!-- Identity & rules -->
         <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-x-4 gap-y-3.5">
@@ -2181,6 +2214,24 @@
           </div>
         </fieldset>
 
+        <!-- Staff — a single field, but a redemption rule, so it sits with the
+             other rules rather than earning a surface of its own. -->
+        <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid gap-3">
+          <div class="col-span-full flex items-center gap-2.5 pb-2.5 mb-0.5 border-b border-neutral-200/80">
+            <div class="section-icon"><svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></div>
+            <span class="text-xs font-semibold text-neutral-600 uppercase tracking-wider">Staff</span>
+          </div>
+          <div>
+            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Redemption warning — shown to staff (Markdown)<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Caution shown to staff on the voucher detail panel and redeem modal before redeeming (e.g. account-credit rules). Never shown to customers.</span></span></label>
+            <textarea x-model="typeForm.redemption_warning" rows="2"
+              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj"></textarea>
+          </div>
+        </fieldset>
+        </div>
+
+        <!-- ── Email panel ─────────────────────────────────────────────────── -->
+        <div x-show="typeTab === 'email'" class="grid gap-5">
+
         <!-- Email content -->
         <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid gap-3">
           <div class="col-span-full flex items-center gap-2.5 pb-2.5 mb-0.5 border-b border-neutral-200/80">
@@ -2271,6 +2322,28 @@
             Show value<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Show the dollar value + expiry box on the voucher email. Turn off to hide the amount.</span></span>
           </label>
         </fieldset>
+        </div>
+
+        <!-- ── Public page panel ───────────────────────────────────────────── -->
+        <div x-show="typeTab === 'public'" class="grid gap-5">
+
+        <!-- Brand colour, mirrored read-only. It themes this whole page but is
+             edited on the Email tab, so it is shown here rather than moved:
+             two editable controls for one setting would be worse than a jump. -->
+        <div class="flex flex-wrap items-center gap-3 rounded-2xl border border-neutral-200 bg-neutral-50/70 px-4 py-3">
+          <span class="h-7 w-7 rounded-lg ring-1 ring-inset ring-black/10 shrink-0"
+            :style="`background:${typeForm.accent_color || '#ae222a'}`"></span>
+          <div class="leading-tight">
+            <p class="text-xs font-semibold text-neutral-700">Brand colour
+              <span class="font-mono font-normal text-neutral-500" x-text="typeForm.accent_color || '#ae222a'"></span>
+            </p>
+            <p class="text-[0.7rem] text-neutral-400">Themes this page. Set on the Email tab.</p>
+          </div>
+          <button type="button" @click="setTypeTab('email')"
+            class="ml-auto text-xs font-semibold px-3 py-1.5 rounded-lg border border-neutral-200 text-neutral-600 hover:bg-white transition-colors">
+            Edit on Email tab
+          </button>
+        </div>
 
         <!-- Public page -->
         <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid gap-4">
@@ -2293,12 +2366,19 @@
                       class="w-full h-full object-cover"
                       x-on:load="imgBroken['hero_background_url'] = false"
                       x-on:error="imgBroken['hero_background_url'] = true" />
+                    <!-- With no backdrop the page draws a gradient from the brand
+                         colour. Showing the real thing beats saying it happens. -->
+                    <div x-show="!typeForm.hero_background_url" class="w-full h-full"
+                      :style="`background-image:${backdropFallbackCss()}`"></div>
                   </div>
                   <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Backdrop · 16:9</p>
                 </div>
                 <div class="flex-1 min-w-[11rem]">
                   <p class="text-sm font-semibold text-neutral-700 truncate"
-                    x-text="imgMeta('hero_background_url').name || 'No background'"></p>
+                    x-text="imgMeta('hero_background_url').name || 'Brand colour gradient'"></p>
+                  <p x-show="!typeForm.hero_background_url" class="text-xs text-neutral-400">
+                    No photo set — the page falls back to the brand colour.
+                  </p>
                   <p class="text-xs text-neutral-400" x-text="imgMeta('hero_background_url').size"></p>
                   <p class="text-xs text-neutral-400 mt-0.5" x-text="imgMeta('hero_background_url').used"></p>
                   <div class="flex gap-2 mt-3">
@@ -2380,6 +2460,11 @@
                   <div class="flex-1 min-w-[11rem]">
                     <p class="text-sm font-semibold text-neutral-700 truncate"
                       x-text="imgMeta('hero_image_url').name || 'No artwork'"></p>
+                    <!-- Unlike the backdrop, artwork has no colour fallback and
+                         is never inherited from another type. -->
+                    <p x-show="!typeForm.hero_image_url" class="text-xs text-neutral-400">
+                      Blank shows nothing — artwork never falls back.
+                    </p>
                     <p class="text-xs text-neutral-400" x-text="imgMeta('hero_image_url').size"></p>
                     <p class="text-xs text-neutral-400 mt-0.5" x-text="imgMeta('hero_image_url').used"></p>
                     <div class="flex gap-2 mt-3">
@@ -2424,22 +2509,14 @@
             </div>
           </div>
         </fieldset>
+        </div>
 
-        <!-- Staff -->
-        <fieldset class="section-card border rounded-2xl p-4 sm:p-5 grid gap-3">
-          <div class="col-span-full flex items-center gap-2.5 pb-2.5 mb-0.5 border-b border-neutral-200/80">
-            <div class="section-icon"><svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></div>
-            <span class="text-xs font-semibold text-neutral-600 uppercase tracking-wider">Staff</span>
-          </div>
-          <div>
-            <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Redemption warning — shown to staff (Markdown)<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Caution shown to staff on the voucher detail panel and redeem modal before redeeming (e.g. account-credit rules). Never shown to customers.</span></span></label>
-            <textarea x-model="typeForm.redemption_warning" rows="2"
-              class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj"></textarea>
-          </div>
-        </fieldset>
           </div>
         </div>
-        <div class="order-1 lg:order-2">
+        <!-- The preview belongs to the Email tab, where it is live. Elsewhere it
+             would show an email unrelated to what is being edited, so it goes
+             and the form takes the full modal width. -->
+        <div x-show="typeTab === 'email'">
           <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Live email preview</label>
           <div class="relative border border-neutral-200 rounded-xl overflow-hidden bg-neutral-50 lg:sticky lg:top-0" style="height:75vh;">
             <div x-show="previewLoading" class="absolute top-2 right-2 text-xs text-neutral-400 bg-white/80 rounded px-2 py-0.5">Rendering…</div>
@@ -2447,8 +2524,9 @@
           </div>
         </div>
       </div>
+      </div>
 
-      <div class="flex gap-2.5 mt-6">
+      <div class="shrink-0 flex gap-2.5 px-6 py-4 border-t border-neutral-100">
         <button @click="closeTypeEditor()"
           class="flex-1 border border-neutral-200 hover:bg-neutral-50 text-neutral-700 font-medium rounded-xl py-2.5 text-sm transition-colors">
           Cancel
@@ -2691,6 +2769,45 @@
         <button @click="confirmRevenueClassChange()"
           class="flex-1 bg-uj hover:bg-uj-dark text-white font-semibold rounded-xl py-2.5 text-sm transition-colors">
           Change class
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Unreviewed surface confirmation modal ───────────────────────────
+       Tabs remove the one accidental virtue of a long scroll: that reaching
+       Save meant travelling past every field. This buys it back on creation,
+       and states the actual consequence rather than a generic warning. -->
+  <div x-show="unreviewedConfirmOpen" x-cloak class="fixed inset-0 z-[60] flex items-center justify-center p-4"
+    @keydown.escape.window="cancelUnreviewedSave()">
+    <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="cancelUnreviewedSave()"></div>
+    <div class="relative bg-white rounded-card shadow-2xl shadow-neutral-900/15 w-full max-w-md p-6 border border-neutral-100">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-base font-semibold text-neutral-900">Save without checking every tab?</h3>
+        <button @click="cancelUnreviewedSave()" class="text-neutral-400 hover:text-neutral-700 text-xl leading-none">&times;</button>
+      </div>
+      <p class="text-sm text-neutral-700 mb-3">
+        You have not opened
+        <span class="font-semibold" x-text="unreviewedLabels()"></span>
+        on this new type.
+      </p>
+      <p x-show="_pendingUnreviewedIds.includes('public')" class="text-sm text-neutral-700 mb-3">
+        Any public page field left blank falls back to the Gift Voucher type's wording, and the hero
+        artwork does not fall back at all — so the customer page may show another product's copy with
+        no artwork on it.
+      </p>
+      <p x-show="_pendingUnreviewedIds.includes('email')" class="text-sm text-neutral-700 mb-3">
+        Any email field left blank falls back to the built-in default wording.
+      </p>
+      <p class="text-sm text-neutral-500 mb-6">That may be exactly what you want.</p>
+      <div class="flex gap-2.5">
+        <button @click="cancelUnreviewedSave()"
+          class="flex-1 border border-neutral-200 hover:bg-neutral-50 text-neutral-700 font-medium rounded-xl py-2.5 text-sm transition-colors">
+          Go and look
+        </button>
+        <button @click="confirmUnreviewedSave()"
+          class="flex-1 bg-uj hover:bg-uj-dark text-white font-semibold rounded-xl py-2.5 text-sm transition-colors">
+          Save anyway
         </button>
       </div>
     </div>
@@ -3109,8 +3226,19 @@
       typeEditorSaving: false,
       typeEditorError: '',
       typeForm: {},
+      // Which output surface the editor is showing, and which have been opened.
+      // Setup counts as visited from the moment the editor opens, because it is
+      // what the editor opens on.
+      typeTab: 'setup',
+      typeTabsVisited: ['setup'],
+      unreviewedConfirmOpen: false,
+      _pendingUnreviewedPayload: null,
+      _pendingUnreviewedIds: [],
       previewHtml: '',
       previewLoading: false,
+      // The preview only refreshes while the Email tab is showing, so this
+      // records whether anything changed while it was hidden.
+      _previewDirty: false,
       itemsEditorOpen: false,
       itemsEditorType: null,
       items: [],
@@ -4692,6 +4820,10 @@
             }
           }
         }
+        // Always open on Setup, so the form behaves the same across the months
+        // between visits. Everything else is unreviewed until it is opened.
+        this.typeTab = 'setup';
+        this.typeTabsVisited = ['setup'];
         this.typeEditorOpen = true;
         // Snapshot AFTER Alpine binds x-model (next tick) so value coercion during
         // binding (e.g. number inputs) can't make an untouched form look dirty.
@@ -4718,12 +4850,45 @@
           && this._formFingerprint(this.typeForm) !== this._typeFormSnapshot;
       },
 
+      // ── Surface tabs ─────────────────────────────────────────────────────
+      typeSurfaceList() { return window.typeSurfaces.SURFACES; },
+
+      typeTabChip(id) { return window.typeSurfaces.chipFor(id, this.typeForm); },
+
+      setTypeTab(id) {
+        this.typeTab = id;
+        if (!this.typeTabsVisited.includes(id)) this.typeTabsVisited.push(id);
+        // The display name lives on Setup but feeds the email heading, so a
+        // preview rendered before that edit would come back stale. Catch up on
+        // arrival rather than on every keystroke of a hidden preview.
+        if (id === 'email' && this._previewDirty) {
+          if (this._previewTimer) clearTimeout(this._previewTimer);
+          this._doPreview();
+        }
+      },
+
+      backdropFallbackCss() {
+        return window.typeSurfaces.backdropFallbackCss(this.typeForm.accent_color);
+      },
+
+      unreviewedLabels() {
+        const labels = this._pendingUnreviewedIds
+          .map(id => (window.typeSurfaces.SURFACES.find(s => s.id === id) || {}).label)
+          .filter(Boolean);
+        return labels.length === 2 ? labels.join(' or ') : labels.join(', ');
+      },
+
       refreshPreview() {
+        this._previewDirty = true;
+        // Nothing to refresh while the preview is off screen; setTypeTab()
+        // renders once on the way back in.
+        if (this.typeTab !== 'email') return;
         if (this._previewTimer) clearTimeout(this._previewTimer);
         this._previewTimer = setTimeout(() => this._doPreview(), 500);
       },
 
       async _doPreview() {
+        this._previewDirty = false;
         this.previewLoading = true;
         try {
           const res = await fetch(this.WORKER + '/v1/staff/voucher-types/preview', {
@@ -5030,8 +5195,10 @@
 
       async saveVoucherType() {
         const f = this.typeForm;
-        if (!f.type_id || !f.type_id.trim()) { this.typeEditorError = 'Type ID is required'; return; }
-        if (!f.display_name || !f.display_name.trim()) { this.typeEditorError = 'Display name is required'; return; }
+        // Both required fields live on Setup, so send the user there — an error
+        // naming a field on another tab would point off screen.
+        if (!f.type_id || !f.type_id.trim()) { this.typeEditorError = 'Type ID is required'; this.setTypeTab('setup'); return; }
+        if (!f.display_name || !f.display_name.trim()) { this.typeEditorError = 'Display name is required'; this.setTypeTab('setup'); return; }
 
         const numOrNull = (v) => (v === '' || v === null || v === undefined ? null : Number(v));
         const textOrNull = (v) => (v === '' || v === null || v === undefined ? null : v);
@@ -5083,7 +5250,44 @@
           return;
         }
 
+        // Creating a type without having looked at a customer-facing surface is
+        // how an unconfigured customer page gets published. Editing an existing
+        // type is routine and never asks.
+        //
+        // A browser holding a stale cached type-surfaces.js would throw here and
+        // save nothing, with no explanation — the same trap the delete modal and
+        // the image pipeline already guard. Say so instead.
+        if (typeof window.typeSurfaces?.unreviewedSurfaces !== 'function') {
+          this.typeEditorError = 'The editor did not finish loading. Hard-refresh the page (Ctrl+Shift+R) and try again.';
+          return;
+        }
+        const unreviewed = window.typeSurfaces.unreviewedSurfaces({
+          editingExisting: this.editingExisting,
+          visited: this.typeTabsVisited,
+        });
+        if (unreviewed.length) {
+          this._pendingUnreviewedPayload = payload;
+          this._pendingUnreviewedIds = unreviewed.map(s => s.id);
+          this.unreviewedConfirmOpen = true;
+          return;
+        }
+
         await this._doSaveVoucherType(payload);
+      },
+
+      async confirmUnreviewedSave() {
+        const payload = this._pendingUnreviewedPayload;
+        this.unreviewedConfirmOpen = false;
+        this._pendingUnreviewedPayload = null;
+        if (payload) await this._doSaveVoucherType(payload);
+      },
+
+      cancelUnreviewedSave() {
+        this.unreviewedConfirmOpen = false;
+        this._pendingUnreviewedPayload = null;
+        // Land on the first surface they skipped, so "go and look" needs no
+        // second decision about where.
+        if (this._pendingUnreviewedIds.length) this.setTypeTab(this._pendingUnreviewedIds[0]);
       },
 
       async _doSaveVoucherType(payload) {

--- a/vouchers/test/type-surfaces.test.js
+++ b/vouchers/test/type-surfaces.test.js
@@ -1,12 +1,23 @@
+import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import {
-  SURFACES, SURFACE_IDS, EMAIL_CUSTOMISABLE_FIELDS, PUBLIC_PAGE_FIELDS,
+  SURFACES, EMAIL_CUSTOMISABLE_FIELDS, PUBLIC_PAGE_FIELDS, DEFAULT_ACCENT,
   surfaceOf, isUntouched, chipFor, unreviewedSurfaces, backdropFallbackCss,
 } from '../type-surfaces.js';
 
-// A blank draft as blankTypeForm() in index.html produces it. Two fields carry
-// pre-filled defaults (redemption_instructions, voucher_label) — that is the
-// point of the "defaults don't count as customisation" rule below.
+// The columns blankTypeForm() actually seeds, read out of index.html rather
+// than copied. A field added to the editor and to no surface has to fail the
+// partition test below, and it only can if this list comes from the source.
+function editorDraftFields() {
+  const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const body = html.match(/blankTypeForm\(\)\s*\{\s*return\s*\{([\s\S]*?)\n\s*\};/);
+  if (!body) throw new Error('could not find blankTypeForm() in index.html');
+  return [...body[1].matchAll(/(?:^|[{,])\s*([a-z_][a-z0-9_]*)\s*:/gi)].map(m => m[1]);
+}
+
+// A blank draft as blankTypeForm() produces it. Two fields carry pre-filled
+// defaults (redemption_instructions, voucher_label) — that is the point of the
+// "defaults don't count as customisation" rule below.
 const blankDraft = () => ({
   type_id: '', display_name: '', description: '',
   availability: 'both', revenue_class: 'sale', expiry_months: '', max_per_customer: '',
@@ -25,19 +36,24 @@ const blankDraft = () => ({
 
 describe('the surface partition', () => {
   it('has exactly three surfaces, in editor order', () => {
-    expect(SURFACE_IDS).toEqual(['setup', 'email', 'public']);
+    expect(SURFACES.map(s => s.id)).toEqual(['setup', 'email', 'public']);
   });
 
-  it('assigns every field of a draft type to exactly one surface', () => {
-    const fields = Object.keys(blankDraft());
-    for (const field of fields) {
+  // Guards the fixture above: if it drifts from the editor, every other test in
+  // this file is asserting against a type that no longer exists.
+  it('has a fixture matching the editor blank form field for field', () => {
+    expect(Object.keys(blankDraft()).sort()).toEqual(editorDraftFields().sort());
+  });
+
+  it('assigns every field the editor puts on a draft to exactly one surface', () => {
+    for (const field of editorDraftFields()) {
       const owners = SURFACES.filter(s => s.fields.includes(field));
       expect(owners, `${field} should belong to exactly one surface`).toHaveLength(1);
     }
   });
 
-  it('claims no field the draft does not have', () => {
-    const fields = new Set(Object.keys(blankDraft()));
+  it('claims no field the editor does not put on a draft', () => {
+    const fields = new Set(editorDraftFields());
     for (const surface of SURFACES) {
       for (const field of surface.fields) {
         expect(fields.has(field), `${field} is on ${surface.id} but not on the draft`).toBe(true);
@@ -146,9 +162,9 @@ describe('unreviewed surfaces', () => {
     expect(unreviewedSurfaces({ editingExisting: true, visited: ['setup'] })).toEqual([]);
   });
 
-  it('accepts a Set as well as an array', () => {
-    expect(unreviewedSurfaces({ editingExisting: false, visited: new Set(['setup', 'email']) })
-      .map(s => s.id)).toEqual(['public']);
+  it('carries the label the guard needs, so the caller need not look it up', () => {
+    expect(unreviewedSurfaces({ editingExisting: false, visited: ['setup', 'email'] }))
+      .toEqual([{ id: 'public', label: 'Public page' }]);
   });
 });
 
@@ -171,7 +187,8 @@ describe('backdrop fallback', () => {
 
   // The colour input can be empty on a draft that has never been saved.
   it('falls back to the house accent when none is set', () => {
-    expect(backdropFallbackCss('')).toContain('#ae222a');
-    expect(backdropFallbackCss(null)).toContain('#ae222a');
+    expect(DEFAULT_ACCENT).toBe('#ae222a');
+    expect(backdropFallbackCss('')).toContain(DEFAULT_ACCENT);
+    expect(backdropFallbackCss(null)).toContain(DEFAULT_ACCENT);
   });
 });

--- a/vouchers/test/type-surfaces.test.js
+++ b/vouchers/test/type-surfaces.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SURFACES, SURFACE_IDS, EMAIL_CUSTOMISABLE_FIELDS, PUBLIC_PAGE_FIELDS,
+  surfaceOf, isUntouched, chipFor, unreviewedSurfaces, backdropFallbackCss,
+} from '../type-surfaces.js';
+
+// A blank draft as blankTypeForm() in index.html produces it. Two fields carry
+// pre-filled defaults (redemption_instructions, voucher_label) — that is the
+// point of the "defaults don't count as customisation" rule below.
+const blankDraft = () => ({
+  type_id: '', display_name: '', description: '',
+  availability: 'both', revenue_class: 'sale', expiry_months: '', max_per_customer: '',
+  limit_period: '', promo_id: '', sort_order: 0,
+  is_physical: false, is_active: true,
+  email_subject: '', email_body: '',
+  terms_conditions: '', usage_info: '',
+  redemption_instructions: 'Scan at the front desk to redeem',
+  accent_color: '#ae222a', voucher_label: 'Your Voucher',
+  show_qr: true, show_value: true,
+  redemption_warning: '',
+  hero_headline: '', hero_subheadline: '', hero_description: '',
+  cta_label: '', hero_image_url: '', hero_background_url: '',
+  features_heading: '', features_subheading: '', features_md: '',
+});
+
+describe('the surface partition', () => {
+  it('has exactly three surfaces, in editor order', () => {
+    expect(SURFACE_IDS).toEqual(['setup', 'email', 'public']);
+  });
+
+  it('assigns every field of a draft type to exactly one surface', () => {
+    const fields = Object.keys(blankDraft());
+    for (const field of fields) {
+      const owners = SURFACES.filter(s => s.fields.includes(field));
+      expect(owners, `${field} should belong to exactly one surface`).toHaveLength(1);
+    }
+  });
+
+  it('claims no field the draft does not have', () => {
+    const fields = new Set(Object.keys(blankDraft()));
+    for (const surface of SURFACES) {
+      for (const field of surface.fields) {
+        expect(fields.has(field), `${field} is on ${surface.id} but not on the draft`).toBe(true);
+      }
+    }
+  });
+
+  // The email renderer in payments-worker consumes exactly these nine columns.
+  // That count is what fixes the Email tab's membership, and is why branding
+  // sits with the email rather than with the public page.
+  it('gives the email surface the nine fields the email renderer consumes', () => {
+    expect(surfaceOf('email_subject')).toBe('email');
+    expect(surfaceOf('email_body')).toBe('email');
+    expect(surfaceOf('terms_conditions')).toBe('email');
+    expect(surfaceOf('usage_info')).toBe('email');
+    expect(surfaceOf('redemption_instructions')).toBe('email');
+    expect(surfaceOf('accent_color')).toBe('email');
+    expect(surfaceOf('voucher_label')).toBe('email');
+    expect(surfaceOf('show_qr')).toBe('email');
+    expect(surfaceOf('show_value')).toBe('email');
+    expect(SURFACES.find(s => s.id === 'email').fields).toHaveLength(9);
+  });
+
+  it('keeps the staff redemption warning on setup, not on a surface of its own', () => {
+    expect(surfaceOf('redemption_warning')).toBe('setup');
+  });
+
+  // The display name feeds the email heading but stays on Setup: the modal
+  // title renders it reactively, so it is on screen whichever tab is active.
+  it('keeps identity fields on setup even when they feed another surface', () => {
+    expect(surfaceOf('display_name')).toBe('setup');
+    expect(surfaceOf('type_id')).toBe('setup');
+  });
+
+  it('returns null for a field it does not know', () => {
+    expect(surfaceOf('not_a_column')).toBe(null);
+  });
+});
+
+describe('untouched surfaces', () => {
+  it('reports email and public page as untouched for a blank draft', () => {
+    const d = blankDraft();
+    expect(isUntouched('email', d)).toBe(true);
+    expect(isUntouched('public', d)).toBe(true);
+  });
+
+  // Identity fields are required, so setup is always populated. A chip that is
+  // permanently lit is noise, not information.
+  it('never reports setup as untouched', () => {
+    expect(isUntouched('setup', blankDraft())).toBe(false);
+    expect(isUntouched('setup', { ...blankDraft(), display_name: 'Gift Voucher' })).toBe(false);
+  });
+
+  it('clears the email chip when any one free-text email field is filled', () => {
+    for (const field of EMAIL_CUSTOMISABLE_FIELDS) {
+      expect(isUntouched('email', { ...blankDraft(), [field]: 'x' }),
+        `${field} should count as email customisation`).toBe(false);
+    }
+  });
+
+  // The pre-filled defaults arrive on every new draft. If they counted, no type
+  // would ever read as untouched and the chip would never appear.
+  it('does not count the pre-filled email defaults as customisation', () => {
+    expect(EMAIL_CUSTOMISABLE_FIELDS).toEqual(
+      ['email_subject', 'email_body', 'terms_conditions', 'usage_info']);
+    expect(isUntouched('email', blankDraft())).toBe(true);
+  });
+
+  it('clears the public page chip when any one of its nine fields is filled', () => {
+    expect(PUBLIC_PAGE_FIELDS).toHaveLength(9);
+    for (const field of PUBLIC_PAGE_FIELDS) {
+      expect(isUntouched('public', { ...blankDraft(), [field]: 'x' }),
+        `${field} should count as public page customisation`).toBe(false);
+    }
+  });
+
+  it('treats whitespace-only and null as still untouched', () => {
+    expect(isUntouched('public', { ...blankDraft(), hero_headline: '   ' })).toBe(true);
+    expect(isUntouched('email', { ...blankDraft(), email_body: null })).toBe(true);
+  });
+
+  it('names the consequence rather than just the state', () => {
+    const d = blankDraft();
+    expect(chipFor('email', d)).toMatch(/default/i);
+    expect(chipFor('public', d)).toMatch(/gift voucher/i);
+    expect(chipFor('setup', d)).toBe(null);
+    expect(chipFor('public', { ...d, hero_headline: 'Climb more' })).toBe(null);
+  });
+});
+
+describe('unreviewed surfaces', () => {
+  it('returns the surfaces never opened while creating a type', () => {
+    const unreviewed = unreviewedSurfaces({ editingExisting: false, visited: ['setup'] });
+    expect(unreviewed.map(s => s.id)).toEqual(['email', 'public']);
+    expect(unreviewed[0].label).toBe('Email');
+  });
+
+  it('returns nothing once every surface has been opened', () => {
+    expect(unreviewedSurfaces({ editingExisting: false, visited: ['setup', 'email', 'public'] }))
+      .toEqual([]);
+  });
+
+  // Routine edits must not be nagged, however little of the form was visited.
+  it('returns nothing when editing an existing type, whatever was visited', () => {
+    expect(unreviewedSurfaces({ editingExisting: true, visited: [] })).toEqual([]);
+    expect(unreviewedSurfaces({ editingExisting: true, visited: ['setup'] })).toEqual([]);
+  });
+
+  it('accepts a Set as well as an array', () => {
+    expect(unreviewedSurfaces({ editingExisting: false, visited: new Set(['setup', 'email']) })
+      .map(s => s.id)).toEqual(['public']);
+  });
+});
+
+describe('backdrop fallback', () => {
+  // Must reproduce the public page's own gradient (voucher-site index.html):
+  //   linear-gradient(135deg, #1C121B, var(--accent) 55%, var(--accent-dark))
+  // where --accent-dark is shade(accent, -0.3) — every channel x 0.7.
+  it('emits the public page gradient for the given accent', () => {
+    expect(backdropFallbackCss('#ae222a')).toBe(
+      'linear-gradient(135deg, #1C121B, #ae222a 55%, color-mix(in srgb, #ae222a 70%, black))');
+  });
+
+  // Expressed as a colour-mix, NOT a hex the editor computed itself: a fourth
+  // hand-written darkening is exactly what would drift from the other three.
+  it('expresses the dark stop as a colour-mix of the accent, not a computed hex', () => {
+    const css = backdropFallbackCss('#123456');
+    expect(css).toContain('color-mix(in srgb, #123456 70%, black)');
+    expect(css).not.toMatch(/#0c243|#0d243c/i);
+  });
+
+  // The colour input can be empty on a draft that has never been saved.
+  it('falls back to the house accent when none is set', () => {
+    expect(backdropFallbackCss('')).toContain('#ae222a');
+    expect(backdropFallbackCss(null)).toContain('#ae222a');
+  });
+});

--- a/vouchers/type-surfaces.js
+++ b/vouchers/type-surfaces.js
@@ -51,8 +51,6 @@ export const SURFACES = [
   },
 ];
 
-export const SURFACE_IDS = SURFACES.map(s => s.id);
-
 // The free-text email fields that arrive BLANK on a new draft. The other two
 // text fields on that surface (redemption_instructions, voucher_label) ship
 // pre-filled, so counting them would make every type read as customised
@@ -71,8 +69,9 @@ const UNTOUCHED_TEST_FIELDS = {
 };
 
 // The house accent, matching blankTypeForm() and the payload default in
-// saveVoucherType(). Used only to render a preview of an empty colour input.
-const DEFAULT_ACCENT = '#ae222a';
+// saveVoucherType(). Exported so the editor's swatch reads it from here rather
+// than inlining a fourth copy of the literal.
+export const DEFAULT_ACCENT = '#ae222a';
 
 export function surfaceOf(field) {
   const surface = SURFACES.find(s => s.fields.includes(field));
@@ -102,9 +101,9 @@ export function chipFor(surfaceId, draft) {
 // an existing type is a routine act and must not be nagged.
 export function unreviewedSurfaces({ editingExisting, visited }) {
   if (editingExisting) return [];
-  const seen = new Set(visited || []);
+  const seen = visited || [];
   return SURFACES
-    .filter(s => !seen.has(s.id))
+    .filter(s => !seen.includes(s.id))
     .map(s => ({ id: s.id, label: s.label }));
 }
 

--- a/vouchers/type-surfaces.js
+++ b/vouchers/type-surfaces.js
@@ -1,0 +1,121 @@
+// How the voucher type editor is organised: by SURFACE — the output a group
+// of fields actually produces — rather than by how the cards happen to be
+// grouped.
+//
+// Three surfaces. Setup produces nothing customer-facing; Email is everything
+// that renders into the customer's voucher email; Public page is everything
+// that renders onto the public purchase page. Branding sits with Email because
+// all four of its fields feed the email renderer — the accent colour also
+// themes the public page, which is handled by mirroring it read-only on that
+// tab rather than by moving the card.
+//
+// Kept out of index.html so the rules are testable without a browser. See
+// docs/adr/0003-voucher-type-editor-organised-by-surface.md
+
+export const SURFACES = [
+  {
+    id: 'setup',
+    label: 'Setup',
+    // Identity, rules, limits, and the staff redemption warning. The display
+    // name feeds the email heading but stays here: the modal title renders it
+    // reactively, so it is on screen whichever tab is active.
+    fields: [
+      'type_id', 'display_name', 'description',
+      'availability', 'revenue_class', 'expiry_months', 'max_per_customer',
+      'limit_period', 'promo_id', 'sort_order',
+      'is_physical', 'is_active',
+      'redemption_warning',
+    ],
+    chip: null,          // never — identity fields are required, so it is always populated
+  },
+  {
+    id: 'email',
+    label: 'Email',
+    // Exactly the nine columns the email renderer consumes.
+    fields: [
+      'email_subject', 'email_body', 'terms_conditions', 'usage_info',
+      'redemption_instructions',
+      'accent_color', 'voucher_label', 'show_qr', 'show_value',
+    ],
+    chip: 'Default wording',
+  },
+  {
+    id: 'public',
+    label: 'Public page',
+    fields: [
+      'hero_headline', 'hero_subheadline', 'hero_description', 'cta_label',
+      'hero_image_url', 'hero_background_url',
+      'features_heading', 'features_subheading', 'features_md',
+    ],
+    chip: 'Inherits Gift Voucher',
+  },
+];
+
+export const SURFACE_IDS = SURFACES.map(s => s.id);
+
+// The free-text email fields that arrive BLANK on a new draft. The other two
+// text fields on that surface (redemption_instructions, voucher_label) ship
+// pre-filled, so counting them would make every type read as customised
+// forever and the chip would never appear.
+export const EMAIL_CUSTOMISABLE_FIELDS = [
+  'email_subject', 'email_body', 'terms_conditions', 'usage_info',
+];
+
+export const PUBLIC_PAGE_FIELDS = SURFACES.find(s => s.id === 'public').fields;
+
+// Which fields decide whether a surface counts as untouched. Setup is absent
+// deliberately — see its `chip: null` above.
+const UNTOUCHED_TEST_FIELDS = {
+  email: EMAIL_CUSTOMISABLE_FIELDS,
+  public: PUBLIC_PAGE_FIELDS,
+};
+
+// The house accent, matching blankTypeForm() and the payload default in
+// saveVoucherType(). Used only to render a preview of an empty colour input.
+const DEFAULT_ACCENT = '#ae222a';
+
+export function surfaceOf(field) {
+  const surface = SURFACES.find(s => s.fields.includes(field));
+  return surface ? surface.id : null;
+}
+
+const isBlank = (v) => v === null || v === undefined || String(v).trim() === '';
+
+// True when nothing on the surface has been customised, so the customer sees
+// whatever the fallback produces.
+export function isUntouched(surfaceId, draft) {
+  const fields = UNTOUCHED_TEST_FIELDS[surfaceId];
+  if (!fields) return false;
+  return fields.every(f => isBlank(draft?.[f]));
+}
+
+// The chip text for a tab, or null when the surface has been customised (or
+// never carries a chip). It names the consequence, not the state — a duty
+// manager who visits twice a year learns what blank means from reading it.
+export function chipFor(surfaceId, draft) {
+  const surface = SURFACES.find(s => s.id === surfaceId);
+  if (!surface || !surface.chip) return null;
+  return isUntouched(surfaceId, draft) ? surface.chip : null;
+}
+
+// Surfaces the user never opened, for the save guard. Creation only: editing
+// an existing type is a routine act and must not be nagged.
+export function unreviewedSurfaces({ editingExisting, visited }) {
+  if (editingExisting) return [];
+  const seen = new Set(visited || []);
+  return SURFACES
+    .filter(s => !seen.has(s.id))
+    .map(s => ({ id: s.id, label: s.label }));
+}
+
+// The gradient the public page draws when no hero backdrop is set, so an empty
+// backdrop slot can show the real thing rather than describing it.
+//
+// The dark stop is a colour-mix rather than a hex this module computed: 70% of
+// the accent mixed with black is arithmetically identical to the shade(accent,
+// -0.3) used by both the public page and the email renderer, so the editor
+// gains no colour maths of its own and cannot drift from them.
+export function backdropFallbackCss(accent) {
+  const c = isBlank(accent) ? DEFAULT_ACCENT : String(accent).trim();
+  return `linear-gradient(135deg, #1C121B, ${c} 55%, color-mix(in srgb, ${c} 70%, black))`;
+}


### PR DESCRIPTION
Implements [urbanjungleirc/vouchers#42](https://github.com/urbanjungleirc/vouchers/issues/42).

The type editor's ~31 fields are now grouped by **surface** — the output each group produces — one tab each:

| Surface | Cards | Preview |
|---|---|---|
| Setup | Identity & rules, Staff | none |
| Email | Email content, Branding | live email preview |
| Public page | Public page | none |

- New pure module `vouchers/type-surfaces.js` (partition as data, chip state, unreviewed surfaces, backdrop fallback CSS) with 22 tests.
- Modal becomes pinned header / scrolling body / pinned footer, fixing Save sitting below the fold on tall types.
- Preview is Email-only and live, with a dirty flag so a display-name edit on Setup is not stale on return. Public page tab gets the full modal width.
- Brand colour mirrored read-only onto the Public page tab with a jump button; empty backdrop slot renders the real gradient via `color-mix`, arithmetically the same darkening the page and email already use.
- Chips on untouched surfaces plus a create-only save guard, buying back the property tabs remove — that reaching Save meant passing every field.
- ADR 0003 and a voucher section in `CONTEXT.md`.

**Known gap, recorded in ADR 0003:** `openTypeEditor()` seeds a new draft from the Gift Voucher record, so those fields arrive populated and neither chip fires on the create path. The save guard carries that path alone. Redefining the chip as "still identical to the Gift Voucher template" is a real option and was deliberately left as its own decision.

Verification: 97 tests pass (`cd vouchers && npx vitest run`). Tab behaviour, chips, swatch, gradient and pinned chrome were verified manually against a local server — this page has no DOM harness, as the spec anticipated.

⚠️ `main` is production for `ujstaff.happyk.au`; merging this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)