### PR TITLE
fix(vouchers): stop remembering "Created by" on the shared front desk machine

### DIFF
--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -1350,7 +1350,7 @@
             <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">
               Created by <span class="text-rose-400 normal-case tracking-normal font-normal">*</span>
             </label>
-            <input type="text" x-model="createIssuer" placeholder="Your name"
+            <input type="text" x-model="createIssuer" placeholder="Your name" autocomplete="off"
               class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
           </div>
         </div>

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -3427,7 +3427,10 @@
           localStorage.removeItem('uj_staff_secret');
           this.secret = '';
         }
-        this.createIssuer = localStorage.getItem('uj_voucher_created_by') || '';
+        // "Created by" is never restored: the front desk machine is shared, so a
+        // remembered name is somebody else's more often than not. Purge any copy
+        // left by the old behaviour rather than leaving it to go stale on disk.
+        localStorage.removeItem('uj_voucher_created_by');
         // Cloudflare Access identity, for the "signed in as" hint only. The API
         // verifies the JWT itself and never trusts this value.
         fetch('/cdn-cgi/access/get-identity')
@@ -4007,7 +4010,10 @@
             method: 'POST',
             headers: { 'X-Manager-Secret': this.restoreManagerSecret },
             body: JSON.stringify({
-              restored_by: this.createIssuer || 'staff',
+              // No name is asked for here, so there is none to attribute. Naming
+              // whoever last used the create form would be a guess nobody can see
+              // to correct; the verified actor is on the audit row regardless.
+              restored_by: 'staff',
               reason: this.restoreReason.trim(),
             }),
           });
@@ -4039,7 +4045,7 @@
             method: 'POST',
             headers: { 'X-Manager-Secret': this.cancelManagerSecret },
             body: JSON.stringify({
-              cancelled_by: this.createIssuer || 'staff',
+              cancelled_by: 'staff', // unattributed by design — see restored_by above
               reason: this.cancelReason.trim(),
             }),
           });
@@ -4119,7 +4125,7 @@
           await this.api('/v1/vouchers/' + encodeURIComponent(code), {
             method: 'DELETE',
             body: JSON.stringify({
-              deleted_by: this.createIssuer || 'staff',
+              deleted_by: 'staff', // unattributed by design — see restored_by above
               reason: this.deleteReason.trim(),
             }),
           });
@@ -4203,6 +4209,7 @@
         this.view = 'create';
         this.createdVoucher = null;
         this.createError = '';
+        this.createIssuer = '';
         this.createName = '';
         this.createPhone = '';
         this.createEmail = '';
@@ -4388,9 +4395,11 @@
               issued_by: this.createIssuer.trim(),
             }),
           });
-          // Remember who's creating vouchers on this device so staff type it once.
-          localStorage.setItem('uj_voucher_created_by', this.createIssuer.trim());
           this.showToast(this.createdVoucher.voucher_id + ' created');
+          // Cleared with the customer fields, not kept for the next voucher: the
+          // form stays open and usable after a create, so whoever steps up next
+          // would otherwise inherit this name without it ever leaving the box.
+          this.createIssuer = '';
           this.createName = '';
           this.createPhone = '';
           this.createEmail = '';

--- a/vouchers/test/created-by-attribution.test.js
+++ b/vouchers/test/created-by-attribution.test.js
@@ -16,19 +16,38 @@ import { readFileSync } from 'node:fs';
 
 const page = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
 
+// Slicing on an anchor that has moved yields a one-character string and a
+// failure that reads as a fault in the page rather than in this file.
+function between(startAnchor, endAnchor) {
+  const start = page.indexOf(startAnchor);
+  if (start < 0) throw new Error('could not find ' + startAnchor + ' in index.html');
+  const end = page.indexOf(endAnchor, start);
+  if (end < 0) throw new Error('could not find ' + endAnchor + ' after ' + startAnchor);
+  return page.slice(start, end);
+}
+
 describe('created-by is not remembered across staff', () => {
   test('the page never reads or writes the remembered-name key, except to purge it', () => {
-    const uses = page.match(/localStorage\.\w+\('uj_voucher_created_by'\)/g) || [];
-    expect(uses).toEqual(["localStorage.removeItem('uj_voucher_created_by')"]);
+    // Match on the method alone, not the whole call: setItem takes a second
+    // argument, so a pattern ending in `)` would silently miss every write —
+    // which is the regression this test exists to catch. Either quote style,
+    // for the same reason: the net has to hold whatever a future edit writes.
+    const methods = [...page.matchAll(/localStorage\.(\w+)\(\s*['"]uj_voucher_created_by['"]/g)].map((m) => m[1]);
+    expect(methods).toEqual(['removeItem']);
   });
 
   test('opening the create form clears the name along with the customer fields', () => {
-    const goCreate = page.slice(page.indexOf('async goCreate()'), page.indexOf('async submitCreate()'));
-    expect(goCreate).toMatch(/this\.createIssuer = '';/);
+    expect(between('async goCreate()', 'async submitCreate()')).toMatch(/this\.createIssuer = '';/);
+  });
+
+  test('the browser is not asked to remember the name either', () => {
+    // Same reason the manager password and typed delete code carry this.
+    const field = between('x-model="createIssuer"', '/>');
+    expect(field).toMatch(/autocomplete="off"/);
   });
 
   test('a successful create clears the name so the next voucher is attributed afresh', () => {
-    const submitCreate = page.slice(page.indexOf('async submitCreate()'), page.indexOf('async goReport()'));
+    const submitCreate = between('async submitCreate()', 'async goReport()');
     // After the POST, not before it — the value still has to reach the request.
     const posted = submitCreate.indexOf('issued_by: this.createIssuer.trim()');
     const cleared = submitCreate.indexOf("this.createIssuer = '';");

--- a/vouchers/test/created-by-attribution.test.js
+++ b/vouchers/test/created-by-attribution.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// The front desk machine is shared. Two rules protect attribution on it, and
+// both live inline in index.html's Alpine component where no unit test can
+// call them — so they are pinned against the page source instead.
+//
+//   1. The typed "Created by" name is never persisted or restored. Anything
+//      that survives a reload belongs to whoever was last at the counter.
+//   2. Cancel, restore and delete never borrow that name. Those actions show
+//      no name field at all, so a wrong value there is invisible — worse than
+//      the create form, where at least it is on screen to be corrected.
+//
+// The verified audit actor is unaffected either way: the Worker derives it from
+// the Access JWT, not from anything the browser sends. See vouchers#59.
+
+const page = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+describe('created-by is not remembered across staff', () => {
+  test('the page never reads or writes the remembered-name key, except to purge it', () => {
+    const uses = page.match(/localStorage\.\w+\('uj_voucher_created_by'\)/g) || [];
+    expect(uses).toEqual(["localStorage.removeItem('uj_voucher_created_by')"]);
+  });
+
+  test('opening the create form clears the name along with the customer fields', () => {
+    const goCreate = page.slice(page.indexOf('async goCreate()'), page.indexOf('async submitCreate()'));
+    expect(goCreate).toMatch(/this\.createIssuer = '';/);
+  });
+
+  test('a successful create clears the name so the next voucher is attributed afresh', () => {
+    const submitCreate = page.slice(page.indexOf('async submitCreate()'), page.indexOf('async goReport()'));
+    // After the POST, not before it — the value still has to reach the request.
+    const posted = submitCreate.indexOf('issued_by: this.createIssuer.trim()');
+    const cleared = submitCreate.indexOf("this.createIssuer = '';");
+    expect(posted).toBeGreaterThan(-1);
+    expect(cleared).toBeGreaterThan(posted);
+  });
+});
+
+describe('lifecycle actions do not borrow the create-form name', () => {
+  test.each(['restored_by', 'cancelled_by', 'deleted_by'])('%s is sent unattributed', (field) => {
+    const line = page.split('\n').find((l) => l.includes(field + ':'));
+    expect(line).toBeDefined();
+    expect(line).not.toMatch(/createIssuer/);
+    expect(line).toMatch(/'staff'/);
+  });
+});


### PR DESCRIPTION
Fixes the mis-attribution reported in urbanjungleirc/vouchers#59.

## What was wrong

The hub stored the typed **Created by** name in `localStorage` and restored it on load. The front desk computer is shared, so the remembered name was usually the *previous* staff member’s — and because the field arrived pre-filled, the required-field check passed without anyone reading it.

The same value was reused as the actor for **cancel**, **restore** and **hard delete**. Those actions show no name field at all, so a wrong value there was invisible: whoever last created a voucher on that machine was recorded as having performed them. That was the more serious half.

## What changed

- Never read or write `uj_voucher_created_by`; any copy already on a machine is purged on load.
- Clear `createIssuer` when the create form opens **and** after a successful create. The form stays open and reusable after a create, so a name left in the box would carry to the next person without ever having been persisted.
- Send `cancelled_by` / `restored_by` / `deleted_by` unattributed as `staff` rather than borrowing a name nobody was shown. This matches the seven sites in this file that already do so (`redeemed_by`, `updated_by`, `undone_by`, `resent_by`).
- `autocomplete="off"` on the input, so the browser’s own form history cannot re-offer the previous name. The manager password and typed delete code already set it.

**The audit trail is unaffected.** The Worker derives the verified actor from the Access JWT, never from the browser. This changes only the typed name stored on the voucher, which is what staff read when reviewing one.

## Notes on scope

- **`deleted_by` is not named in the issue** (it scopes case 2 to cancel and restore). Included anyway: same expression, same defect class, same file — and once the name is never restored, the old `this.createIssuer || 'staff'` would evaluate to `'staff'` in nearly every real case, so leaving it would have been misleading dead code.
- **Both exclusions respected.** No pre-fill from the signed-in identity (tracked separately), and the field remains client-supplied free text.

## Trade-off

Staff creating several vouchers in a row now retype their name each time. On a shared counter that is the point — the issue asks for the field to "start empty and the staff member should enter their own name each time".

## Verification

- Full suite green: **189 tests, 9 files** (`npx vitest run` from the repo root).
- 6 new tests in `vouchers/test/created-by-attribution.test.js`, asserting against the page source — the same approach `type-surfaces.test.js` already uses for inline Alpine logic that no unit test can call.
- **Mutation-verified**: reverting any one of the five behaviours turns exactly one test red. Two blind spots in the first draft of these tests were found this way and fixed in `00a2465`.

⚠️ `main` is production here (GitHub Pages, no build step) — **merging is deploying**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)