### PR TITLE
Prompt staff to write the code on physical voucher cards

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,6 +108,21 @@ See [ADR 0003](docs/adr/0003-voucher-type-editor-organised-by-surface.md).
 one visual box; a surface may contain several. A tab is how a surface is
 reached.
 
+### Physical voucher
+
+A voucher whose type is flagged `is_physical` — it is a card handed over at the
+counter, not an email. The flag lives on the **type**, never on the create form,
+so "is this one physical?" is always answered by the created voucher's
+`is_physical`, which the create response carries.
+
+It is the flag that decides both halves of the handover: no email is sent, and
+the create confirmation instructs staff to write the voucher code on the card.
+That instruction is the only thing on screen that says so, so it must stay
+conditional — on an emailed voucher it is noise.
+
+*Avoid*: "printed voucher", "card voucher". The staff badge, the type editor
+checkbox and the column all read *physical*.
+
 ### Hero backdrop / hero artwork
 
 Two different public-page images, with **different blank behaviour**, which is

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -1258,8 +1258,8 @@
 
         <!-- Physical types only. The card in the staff member's hand is blank
              until this is written on it, and nothing later in the flow asks for
-             it — so the instruction goes here, carrying the code itself, and the
-             small "Code:" cell below steps aside so there is only one to copy. -->
+             it — so the instruction goes here and carries the code itself,
+             rather than sending staff to the summary line below for it. -->
         <div x-show="createdVoucher?.is_physical"
           class="bg-white border border-violet-200 rounded-card p-4 mb-3 flex items-start gap-3">
           <svg class="w-5 h-5 text-violet-600 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1275,7 +1275,7 @@
         </div>
 
         <div class="text-sm text-emerald-700 grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1">
-          <div x-show="!createdVoucher?.is_physical"><span class="font-medium">Code:</span> <span class="font-mono ml-1" x-text="createdVoucher?.voucher_id"></span></div>
+          <div><span class="font-medium">Code:</span> <span class="font-mono ml-1" x-text="createdVoucher?.voucher_id"></span></div>
           <div><span class="font-medium">Customer:</span> <span class="ml-1" x-text="createdVoucher?.customer_name"></span></div>
           <div><span class="font-medium">Value:</span> <span class="ml-1" x-text="fmtMoney(createdVoucher?.value)"></span></div>
           <div><span class="font-medium">Expires:</span> <span class="ml-1" x-text="fmtDate(createdVoucher?.expiry_date)"></span></div>

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -1255,8 +1255,27 @@
           </svg>
           <span class="text-sm font-semibold text-emerald-800">Voucher created</span>
         </div>
+
+        <!-- Physical types only. The card in the staff member's hand is blank
+             until this is written on it, and nothing later in the flow asks for
+             it — so the instruction goes here, carrying the code itself, and the
+             small "Code:" cell below steps aside so there is only one to copy. -->
+        <div x-show="createdVoucher?.is_physical"
+          class="bg-white border border-violet-200 rounded-card p-4 mb-3 flex items-start gap-3">
+          <svg class="w-5 h-5 text-violet-600 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+          </svg>
+          <div>
+            <p class="text-sm font-semibold text-violet-900">Write this code on the voucher card</p>
+            <p class="font-mono text-2xl font-bold tracking-[0.15em] text-neutral-900 mt-1.5 select-all"
+              x-text="createdVoucher?.voucher_id"></p>
+            <p class="text-xs text-violet-700 mt-1.5">Hand the card over with the code on it — it is what the customer is redeeming.</p>
+          </div>
+        </div>
+
         <div class="text-sm text-emerald-700 grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1">
-          <div><span class="font-medium">Code:</span> <span class="font-mono ml-1" x-text="createdVoucher?.voucher_id"></span></div>
+          <div x-show="!createdVoucher?.is_physical"><span class="font-medium">Code:</span> <span class="font-mono ml-1" x-text="createdVoucher?.voucher_id"></span></div>
           <div><span class="font-medium">Customer:</span> <span class="ml-1" x-text="createdVoucher?.customer_name"></span></div>
           <div><span class="font-medium">Value:</span> <span class="ml-1" x-text="fmtMoney(createdVoucher?.value)"></span></div>
           <div><span class="font-medium">Expires:</span> <span class="ml-1" x-text="fmtDate(createdVoucher?.expiry_date)"></span></div>

--- a/vouchers/test/create-confirmation.test.js
+++ b/vouchers/test/create-confirmation.test.js
@@ -1,9 +1,14 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 
-// The create confirmation lives in index.html's Alpine markup, so these read
-// the source the same way type-surfaces.test.js reads blankTypeForm() — the
-// rules being asserted have no module to import.
+// The create confirmation is Alpine markup inside index.html, so these read the
+// source — there is no module to import, the way type-surfaces.test.js has one.
+//
+// Be clear about what that can prove: these assert the markup SAYS the right
+// thing, not that a browser renders it. A gate that is correct here can still
+// never appear (hidden ancestor, is_physical absent from the response). What
+// they do catch is the rule going missing or being re-pointed at the form —
+// which is what issue #55 is about.
 function successBanner() {
   const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
   const block = html.match(/<!-- Success banner -->([\s\S]*?)<!-- Error banner -->/);
@@ -11,31 +16,42 @@ function successBanner() {
   return block[1];
 }
 
+const GATE = 'x-show="createdVoucher?.is_physical"';
+
+// The reminder element, taken by walking <div> depth out from its gate, so an
+// added wrapper or a reflow cannot quietly shrink what the assertions below see.
+function writeOnCardReminder() {
+  const banner = successBanner();
+  const gate = banner.indexOf(GATE);
+  if (gate === -1) throw new Error(`no element gated on ${GATE} in the success banner`);
+  const start = banner.lastIndexOf('<div', gate);
+  const tags = /<(\/?)div\b/g;
+  tags.lastIndex = start;
+  let depth = 0;
+  for (let m = tags.exec(banner); m; m = tags.exec(banner)) {
+    depth += m[1] ? -1 : 1;
+    if (depth === 0) return banner.slice(start, banner.indexOf('>', m.index) + 1);
+  }
+  throw new Error('unbalanced <div> around the write-on-card reminder');
+}
+
 describe('physical voucher: write-the-code reminder', () => {
   it('is shown only when the created voucher is physical', () => {
-    const banner = successBanner();
-    expect(banner).toMatch(/x-show="createdVoucher\?\.is_physical"/);
+    expect(successBanner()).toContain(GATE);
   });
 
   it('gates on the created voucher, not the create form', () => {
     // createType survives a submit so staff can issue several of a kind. Gating
-    // on it would keep the reminder on screen against a stale form selection.
-    const banner = successBanner();
-    expect(banner).not.toMatch(/createType/);
+    // on it would keep the reminder up against a stale form selection.
+    expect(writeOnCardReminder()).not.toMatch(/createType/);
   });
 
   it('tells staff what to write, and where', () => {
-    const banner = successBanner();
-    const reminder = banner.match(/x-show="createdVoucher\?\.is_physical"[\s\S]*?<\/div>\s*<\/div>/);
-    expect(reminder).toBeTruthy();
-    expect(reminder[0]).toMatch(/write/i);
-    expect(reminder[0]).toMatch(/voucher/i);
+    expect(writeOnCardReminder()).toMatch(/write this code on the voucher card/i);
   });
 
   it('renders the code inside the reminder, so it is copied from the instruction itself', () => {
-    const banner = successBanner();
-    const reminder = banner.match(/x-show="createdVoucher\?\.is_physical"[\s\S]*?<\/div>\s*<\/div>/);
-    expect(reminder[0]).toMatch(/x-text="createdVoucher\?\.voucher_id"/);
+    expect(writeOnCardReminder()).toContain('x-text="createdVoucher?.voucher_id"');
   });
 
   it('never names the old habit it is displacing', () => {

--- a/vouchers/test/create-confirmation.test.js
+++ b/vouchers/test/create-confirmation.test.js
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+
+// The create confirmation lives in index.html's Alpine markup, so these read
+// the source the same way type-surfaces.test.js reads blankTypeForm() — the
+// rules being asserted have no module to import.
+function successBanner() {
+  const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const block = html.match(/<!-- Success banner -->([\s\S]*?)<!-- Error banner -->/);
+  if (!block) throw new Error('could not find the create success banner in index.html');
+  return block[1];
+}
+
+describe('physical voucher: write-the-code reminder', () => {
+  it('is shown only when the created voucher is physical', () => {
+    const banner = successBanner();
+    expect(banner).toMatch(/x-show="createdVoucher\?\.is_physical"/);
+  });
+
+  it('gates on the created voucher, not the create form', () => {
+    // createType survives a submit so staff can issue several of a kind. Gating
+    // on it would keep the reminder on screen against a stale form selection.
+    const banner = successBanner();
+    expect(banner).not.toMatch(/createType/);
+  });
+
+  it('tells staff what to write, and where', () => {
+    const banner = successBanner();
+    const reminder = banner.match(/x-show="createdVoucher\?\.is_physical"[\s\S]*?<\/div>\s*<\/div>/);
+    expect(reminder).toBeTruthy();
+    expect(reminder[0]).toMatch(/write/i);
+    expect(reminder[0]).toMatch(/voucher/i);
+  });
+
+  it('renders the code inside the reminder, so it is copied from the instruction itself', () => {
+    const banner = successBanner();
+    const reminder = banner.match(/x-show="createdVoucher\?\.is_physical"[\s\S]*?<\/div>\s*<\/div>/);
+    expect(reminder[0]).toMatch(/x-text="createdVoucher\?\.voucher_id"/);
+  });
+
+  it('never names the old habit it is displacing', () => {
+    // Deliberate: staff who never wrote the Clubworx receipt on a card must not
+    // learn from this banner that anyone did. See issue #55.
+    expect(successBanner()).not.toMatch(/clubworx/i);
+  });
+});


### PR DESCRIPTION
Closes urbanjungleirc/vouchers#55

## What

After creating a physical voucher, the confirmation now carries an explicit instruction to write the voucher code onto the card, with the code rendered large and monospaced so it is hard to transcribe wrongly. Emailed vouchers are unchanged.

The gate is the **created voucher's** `is_physical`, which `POST /v1/vouchers` returns (it re-reads the row with `select=*`). Deliberately not the create form's type selection — that survives a submit so staff can issue several of a kind, and would keep the reminder up against a stale selection.

Per the issue, the UI says nothing about the Clubworx receipt: naming the habit this displaces would teach it to staff who never had it. A test pins that.

Purely additive to the banner — the existing Code / Customer / Value / Expires summary is untouched.

## Verify

```bash
cd vouchers && npm test     # 102 pass, 5 of them new
```

In the browser: Create → pick a type flagged physical → create. The reminder appears above the summary. Repeat with a non-physical type: no reminder.

## Note on merging

`main` is production for this repo — GitHub Pages serves it to ujstaff.happyk.au within a minute, so merging is deploying. There is no backend or migration dependency here (the field it reads has been on the create response all along), so this can go whenever suits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)