### PR TITLE
Ignore node_modules at the repo root, and untrack vitest's cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ hvt-test-*/
 
 # Wrangler local cache — should never be committed
 .wrangler/
+
+# Dependencies and test-runner caches, at any depth. vouchers/.gitignore has
+# covered its own copy for a while, but nothing covered the root — and vitest
+# writes its cache to a node_modules/ beside the repo root, not beside the
+# package it ran from, so a run in vouchers/ dirtied the tree here.
+node_modules/

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.10","results":[[":vouchers/test/type-surfaces.test.js",{"duration":9.147389000000004,"failed":false}]]}


### PR DESCRIPTION
## Why

Every `npm test` in `vouchers/` left the tree dirty, which is how this surfaced during work on vouchers#55.

vitest writes its run cache to a `node_modules/` beside the **repo root**, not beside the package it ran from. The root `.gitignore` covered `.wrangler/` and the two CI backup patterns but never `node_modules/` — `vouchers/`, `cloudflare-worker/`, `cloudflare-payments-proxy/` and `slideshow/` each cover their own, so the gap only ever showed at the root.

So `dc72b39` committed `node_modules/.vite/vitest/<hash>/results.json`, and every run since has rewritten it. Contents are one test filename and a duration — a build artefact with nothing to preserve.

## What

- Add `node_modules/` to the root `.gitignore` (unanchored, so it also holds at any depth).
- `git rm --cached` the tracked cache file. Left on disk; it regenerates on the next run.

Two side effects worth naming: the root `node_modules/` existed *only* to hold that file — there is no root `package.json` — so the tree loses a directory that was never a dependency install. And since Pages serves this repo's root, the deploy stops shipping a stray cache file it had no reason to publish.

## Verify

```bash
cd vouchers && npm test   # 109 pass across 6 files
git status --short        # clean — previously showed the cache file modified
git check-ignore -v node_modules/x cloudflare-worker/node_modules/x vouchers/node_modules/x
```

All five package directories resolve to an ignore rule. No served page, script or config is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)