### PR TITLE
Show the build version in the voucher hub footer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ liverumble*.html        - Rumble in the Jungle pages
 livescore_ssp*.html     - Super Social Pumpfest scoring/result pages
 iFrameTestBookingCalendar.html - booking calendar embed test
 vouchers/scripts/version.mjs - derives the hub's build version from git at deploy time (unit tested)
+vouchers/version-display.js - formats that version for the footer, in Perth time (unit tested)
 .github/workflows/pages.yml - publishes the site to Pages; the repo's only build step
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ vouchers/unsubscribes-logic.js - pure suppression rules behind that page (unit t
 vouchers/delete-logic.js - pure confirmation rules behind the hard-delete action (unit tested)
 vouchers/type-surfaces.js - which voucher-type fields feed which output surface (unit tested)
 vouchers/scripts/version.mjs - derives the hub's build version from git at deploy time (unit tested)
+vouchers/version-display.js - formats that version for the footer, in Perth time (unit tested)
 .github/workflows/pages.yml - publishes the site to Pages; the repo's only build step
 hvt/                    - High-volume Training tool copy
 slideshow/              - Google Drive TV slideshow tool

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -179,6 +179,13 @@ It is scoped to `vouchers/`, so it moves when the hub moves and stays put when
 the roster or the HVT copy changes. See
 [ADR 0004](docs/adr/0004-voucher-hub-build-version.md).
 
+It renders in the hub footer beside the signed-in email, as
+`v67 · 32ef795 · 7 Aug 18:41`, formatted by `vouchers/version-display.js` in
+Perth time. **That fetch is `no-store`, and this is the point rather than a
+precaution**: `version.json` sits on the same static origin as the HTML, so a
+cached copy would name the previous build as the current one — announcing the
+page is fresh at exactly the moment it is stale.
+
 *Avoid*: "release" and "semver". The count orders builds; it claims nothing
 about compatibility, and nobody chooses it.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -186,6 +186,12 @@ precaution**: `version.json` sits on the same static origin as the HTML, so a
 cached copy would name the previous build as the current one — announcing the
 page is fresh at exactly the moment it is stale.
 
+Because that fetch always reaches the origin, the footer states **what is
+deployed, not what is running**. A browser serving a cached hub page prints the
+current version beside stale code. Telling those apart needs a second version
+carried by the page itself, which is
+[vouchers#66](https://github.com/urbanjungleirc/vouchers/issues/66).
+
 *Avoid*: "release" and "semver". The count orders builds; it claims nothing
 about compatibility, and nobody chooses it.
 

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -44,6 +44,14 @@
     // A stale cached copy would leave the type editor with no tabs to render.
     import * as typeSurfaces from './type-surfaces.js?v=1';
     window.typeSurfaces = typeSurfaces;
+    // And here: bump it whenever version-display.js gains or renames an export.
+    // A stale cached copy of this one is the mildest of the four — the footer
+    // loses its version line and nothing else changes — which is the whole
+    // point: the version display must never be able to break the page it is
+    // describing. loadBuildVersion() treats a missing export like a missing
+    // file.
+    import * as versionDisplay from './version-display.js?v=1';
+    window.versionDisplay = versionDisplay;
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
@@ -1894,6 +1902,15 @@
       <span x-show="accessEmail" x-cloak>
         Signed in as <span class="font-medium text-neutral-600" x-text="accessEmail"></span>
       </span>
+      <!-- Same rule, same reason: no version.json in local development, and
+           none whenever git could not be trusted at build time. Hidden rather
+           than blank — a version display that shows a broken placeholder is
+           worse than one that shows nothing.
+
+           The SHA is deliberately not a link. staff-site is a private repo and
+           the people reading this footer are on the front desk, so a commit
+           link would 404 for almost everyone who clicked it. -->
+      <span x-show="buildVersion" x-cloak x-text="buildVersion" class="tabular-nums"></span>
     </div>
   </footer>
 
@@ -3359,6 +3376,10 @@
       cancelLoading: false,
       cancelError: '',
       accessEmail: '',
+      // Formatted footer build version, or '' for "do not show a version".
+      // Starts empty so the footer never flashes a placeholder before the
+      // fetch lands, and stays empty on every failure path.
+      buildVersion: '',
 
       // Restore (un-cancel). Same manager gate; secret likewise never stored.
       restoreOpen: false,
@@ -3474,6 +3495,7 @@
           .then((r) => (r.ok ? r.json() : null))
           .then((d) => { if (d && d.email) this.accessEmail = d.email; })
           .catch(() => {});
+        this.loadBuildVersion();
         // Position help-tip bubbles on hover/focus so they escape the editor
         // panel's overflow and stay inside the viewport near a form edge.
         const onTip = (e) => { const t = e.target.closest && e.target.closest('.help-tip'); if (t) this.positionTip(t); };
@@ -4109,6 +4131,27 @@
           this.canDelete = me.can_delete === true;
         } catch {
           this.canDelete = false;
+        }
+      },
+
+      // The footer build version. Generated into version.json at deploy time,
+      // so it is absent in local development and after any failed deploy —
+      // both of which land on '' and simply hide the line.
+      //
+      // no-store is the point of the whole exercise, not a precaution. This
+      // file sits beside the HTML on the same static origin, so a cached copy
+      // would report the *previous* build as the current one — telling you the
+      // page is fresh at exactly the moment it is stale. That is worse than
+      // showing nothing, so the one fetch that must never be cached is this one.
+      async loadBuildVersion() {
+        try {
+          const res = await fetch('./version.json', { cache: 'no-store' });
+          if (!res.ok) return;
+          this.buildVersion = window.versionDisplay.formatBuildVersion(await res.json());
+        } catch {
+          // Missing file, unparseable JSON, or a stale cached module without
+          // the export. Nothing to show, and nothing worth telling staff about.
+          this.buildVersion = '';
         }
       },
 

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -4143,11 +4143,19 @@
       // would report the *previous* build as the current one — telling you the
       // page is fresh at exactly the moment it is stale. That is worse than
       // showing nothing, so the one fetch that must never be cached is this one.
+      //
+      // Know what this does NOT catch. Because the fetch always reaches the
+      // origin, it reports the newest *deployed* build, not the build of the
+      // index.html you are looking at. A browser serving a cached hub page will
+      // print the current version beside stale code. Detecting that needs a
+      // second version baked into the HTML to compare against, which is
+      // vouchers#66 — until then this answers "what is deployed?", not "am I
+      // running it?".
       async loadBuildVersion() {
         try {
           const res = await fetch('./version.json', { cache: 'no-store' });
-          if (!res.ok) return;
-          this.buildVersion = window.versionDisplay.formatBuildVersion(await res.json());
+          const payload = res.ok ? await res.json() : null;
+          this.buildVersion = window.versionDisplay.formatBuildVersion(payload);
         } catch {
           // Missing file, unparseable JSON, or a stale cached module without
           // the export. Nothing to show, and nothing worth telling staff about.

--- a/vouchers/test/signed-in-footer.test.js
+++ b/vouchers/test/signed-in-footer.test.js
@@ -72,3 +72,47 @@ describe('an absent identity degrades quietly', () => {
     expect(line).not.toMatch(/x-show/);
   });
 });
+
+// The build version shares this footer, and shares reason (1) above: the
+// formatting is unit tested in version-display.test.js, but formatting a string
+// nothing renders would pass just as well. See vouchers#58.
+describe('the build version is shown beside the identity', () => {
+  test('the footer binds the formatted version', () => {
+    expect(footer()).toMatch(/x-text="buildVersion"/);
+  });
+
+  test('the value bound is the one the version fetch writes', () => {
+    // Same drift guard as the email: a binding and a loader on two different
+    // fields leaves the footer permanently empty and nothing else complains.
+    expect(between('async loadBuildVersion', '\n      },')).toMatch(/this\.buildVersion = /);
+  });
+
+  test('the loader actually runs on init', () => {
+    // Defining loadBuildVersion() and never calling it is the exact shape of
+    // the dead identity call this file was written for.
+    expect(page).toMatch(/this\.loadBuildVersion\(\);/);
+  });
+
+  test('the version is fetched with no-store', () => {
+    // Load-bearing, not a precaution: version.json sits on the same static
+    // origin as this HTML, so a cached copy would name the previous build as
+    // the current one — announcing the page is fresh at the moment it is
+    // stale. Nothing else in the system would catch that, which is why it is
+    // pinned here. See vouchers#58 and ADR 0004.
+    const loader = between('async loadBuildVersion', '\n      },');
+    expect(loader).toMatch(/fetch\('\.\/version\.json',\s*\{\s*cache:\s*'no-store'\s*\}\)/);
+  });
+});
+
+describe('an absent build version degrades quietly', () => {
+  test('the line is hidden rather than rendered empty', () => {
+    // version.json is absent in local development and after any failed deploy,
+    // so an empty slot or a bare "v" is a reachable state, not a hypothetical.
+    const versionSpan = between('x-show="buildVersion"', '</span>');
+    expect(versionSpan).toMatch(/x-text="buildVersion"/);
+  });
+
+  test('the version starts empty so nothing flashes before the fetch lands', () => {
+    expect(page).toMatch(/buildVersion: '',/);
+  });
+});

--- a/vouchers/test/version-display.test.js
+++ b/vouchers/test/version-display.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { formatBuildVersion } from '../version-display.js';
+import { formatBuildVersion, TIME_FMT } from '../version-display.js';
 
 // The footer version exists so a stale cached copy of the hub can be spotted.
 // That makes a *wrong* version worse than none: it reports a stale build as
@@ -25,10 +25,20 @@ describe('formatBuildVersion', () => {
   });
 
   test('renders midnight as 00:00, not 24:00', () => {
-    // hour12:false is specified to permit a broken h24 cycle that renders
-    // midnight as "24:00"; hourCycle:"h23" is the knob that does not.
     expect(formatBuildVersion({ ...BUILT, builtAt: '2026-08-06T16:00:00.000Z' }))
       .toBe('v66 · da9185f · 7 Aug 00:00');
+  });
+
+  test('resolves to the h23 hour cycle, never h24', () => {
+    // Under h24 the same instant renders "7 Aug 24:00" — verified, not assumed.
+    //
+    // Be clear about what this does and does not defend. The source asks for
+    // hourCycle:'h23' because hour12:false is *specified* to permit h24. On the
+    // ICU this suite runs against, hour12:false also resolves to h23, so
+    // neither this assertion nor the midnight test above can tell the two
+    // apart; swapping one for the other would leave both green. What this
+    // catches is an explicit h24, and it records which cycle is intended.
+    expect(TIME_FMT.resolvedOptions().hourCycle).toBe('h23');
   });
 
   test('abbreviates the month', () => {

--- a/vouchers/test/version-display.test.js
+++ b/vouchers/test/version-display.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+import { formatBuildVersion } from '../version-display.js';
+
+// The footer version exists so a stale cached copy of the hub can be spotted.
+// That makes a *wrong* version worse than none: it reports a stale build as
+// current, with the authority of being printed on the page. So every input this
+// function does not fully trust has to render as nothing at all, leaving the
+// footer showing the signed-in email alone.
+// See docs/adr/0004-voucher-hub-build-version.md.
+
+const BUILT = { version: '66', sha: 'da9185f', builtAt: '2026-08-07T10:14:50.591Z' };
+
+describe('formatBuildVersion', () => {
+  test('renders version, short SHA and the build time in Perth', () => {
+    // 10:14 UTC is 18:14 in Perth (UTC+8, no DST) — the same day, here.
+    expect(formatBuildVersion(BUILT)).toBe('v66 · da9185f · 7 Aug 18:14');
+  });
+
+  test('puts the build time in Perth even when that changes the date', () => {
+    // 20:30 UTC on the 6th is 04:30 on the 7th in Perth. Rendering the UTC date
+    // would have the footer disagree with every other date in the voucher
+    // system, which are all Perth.
+    expect(formatBuildVersion({ ...BUILT, builtAt: '2026-08-06T20:30:00.000Z' }))
+      .toBe('v66 · da9185f · 7 Aug 04:30');
+  });
+
+  test('renders midnight as 00:00, not 24:00', () => {
+    // hour12:false is specified to permit a broken h24 cycle that renders
+    // midnight as "24:00"; hourCycle:"h23" is the knob that does not.
+    expect(formatBuildVersion({ ...BUILT, builtAt: '2026-08-06T16:00:00.000Z' }))
+      .toBe('v66 · da9185f · 7 Aug 00:00');
+  });
+
+  test('abbreviates the month', () => {
+    // en-AU renders month:"short" as "July" rather than "Jul", so the locale
+    // here is en-GB deliberately. This catches a well-meaning "fix" to en-AU.
+    expect(formatBuildVersion({ ...BUILT, builtAt: '2026-07-19T10:36:00.000Z' }))
+      .toBe('v66 · da9185f · 19 Jul 18:36');
+  });
+
+  test('shows nothing for the dev version', () => {
+    // What the generator emits whenever git could not be trusted. It is not an
+    // error, and it is not something staff should be shown.
+    expect(formatBuildVersion({ version: 'dev', sha: '', builtAt: BUILT.builtAt })).toBe('');
+  });
+
+  test('shows nothing when there is no version file at all', () => {
+    // The normal state in local development, where version.json is never
+    // generated, and after any failed fetch.
+    expect(formatBuildVersion(undefined)).toBe('');
+    expect(formatBuildVersion(null)).toBe('');
+    expect(formatBuildVersion({})).toBe('');
+  });
+
+  test('shows nothing for a version that is not a build number', () => {
+    // The generator only ever emits digits or "dev". Anything else means we are
+    // reading something other than what we think, so print none of it.
+    expect(formatBuildVersion({ ...BUILT, version: '0.1.48' })).toBe('');
+    expect(formatBuildVersion({ ...BUILT, version: 'v66' })).toBe('');
+    expect(formatBuildVersion({ ...BUILT, version: 66 })).toBe('');
+    expect(formatBuildVersion({ ...BUILT, version: '' })).toBe('');
+  });
+
+  test('drops a SHA that is not a short SHA, keeping the rest', () => {
+    // A partial payload still answers "which build?" usefully. Dropping only
+    // the bad field beats dropping the line.
+    expect(formatBuildVersion({ ...BUILT, sha: '' })).toBe('v66 · 7 Aug 18:14');
+    expect(formatBuildVersion({ ...BUILT, sha: 'HEAD' })).toBe('v66 · 7 Aug 18:14');
+    expect(formatBuildVersion({ ...BUILT, sha: 'DA9185F' })).toBe('v66 · 7 Aug 18:14');
+  });
+
+  test('drops a build time that is not a date, keeping the rest', () => {
+    expect(formatBuildVersion({ ...BUILT, builtAt: 'yesterday' })).toBe('v66 · da9185f');
+    expect(formatBuildVersion({ ...BUILT, builtAt: '' })).toBe('v66 · da9185f');
+    expect(formatBuildVersion({ version: '66' })).toBe('v66');
+  });
+});

--- a/vouchers/version-display.js
+++ b/vouchers/version-display.js
@@ -1,0 +1,52 @@
+// vouchers/version-display.js
+// Formats the build version for the hub footer. Pure on purpose — no DOM, no
+// fetch — so the two things that are genuinely easy to get wrong, the Perth
+// timestamp and the decision to show nothing, are unit-testable.
+//
+// The version is on the page so a stale cached copy can be spotted, which makes
+// a wrong version worse than none: it reports a stale build as current with the
+// authority of being printed. Anything not fully trusted renders as '', and the
+// footer falls back to showing the signed-in email alone.
+//
+// See docs/adr/0004-voucher-hub-build-version.md for where the payload comes
+// from, and why it is absent on a plain checkout.
+
+// Two traps here, both deliberate rather than incidental:
+//  - en-AU renders month:"short" as "July", not "Jul". en-GB gives "Jul".
+//  - hour12:false is specified to permit a broken h24 cycle that renders
+//    midnight as "24:00"; hourCycle:"h23" is the knob that does not.
+// Assembled from formatToParts rather than by string-munging the formatted
+// output, because separator and field order are ICU details that differ between
+// browsers — and this formats client-side, on whatever ICU is there.
+const TIME_FMT = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'Australia/Perth',
+  day: 'numeric',
+  month: 'short',
+  hour: '2-digit',
+  minute: '2-digit',
+  hourCycle: 'h23',
+});
+
+function perthTime(builtAt) {
+  if (typeof builtAt !== 'string' || !builtAt) return '';
+  const d = new Date(builtAt);
+  if (Number.isNaN(d.getTime())) return '';
+  const p = {};
+  for (const part of TIME_FMT.formatToParts(d)) p[part.type] = part.value;
+  return `${p.day} ${p.month} ${p.hour}:${p.minute}`;
+}
+
+export function formatBuildVersion(payload) {
+  const { version, sha, builtAt } = payload || {};
+
+  // The generator emits a bare commit count, or "dev" when git could not be
+  // trusted. Anything else means we are reading something other than what we
+  // think we are, so none of it gets shown.
+  if (typeof version !== 'string' || !/^\d+$/.test(version)) return '';
+
+  return [
+    `v${version}`,
+    /^[0-9a-f]{7}$/.test(sha) ? sha : '',
+    perthTime(builtAt),
+  ].filter(Boolean).join(' · ');
+}

--- a/vouchers/version-display.js
+++ b/vouchers/version-display.js
@@ -18,7 +18,9 @@
 // Assembled from formatToParts rather than by string-munging the formatted
 // output, because separator and field order are ICU details that differ between
 // browsers — and this formats client-side, on whatever ICU is there.
-const TIME_FMT = new Intl.DateTimeFormat('en-GB', {
+// Exported only so the resolved hour cycle can be asserted; nothing outside the
+// tests should reach for it.
+export const TIME_FMT = new Intl.DateTimeFormat('en-GB', {
   timeZone: 'Australia/Perth',
   day: 'numeric',
   month: 'short',
@@ -42,6 +44,11 @@ export function formatBuildVersion(payload) {
   // The generator emits a bare commit count, or "dev" when git could not be
   // trusted. Anything else means we are reading something other than what we
   // think we are, so none of it gets shown.
+  //
+  // These two shapes are the wire contract with scripts/version.mjs, which
+  // validates the same way before writing. Changing the payload format is
+  // therefore a two-file edit — deliberately, so a producer change cannot
+  // quietly start rendering here unreviewed.
   if (typeof version !== 'string' || !/^\d+$/.test(version)) return '';
 
   return [


### PR DESCRIPTION
Closes [urbanjungleirc/vouchers#58](https://github.com/urbanjungleirc/vouchers/issues/58). Both its blockers are already merged — #56 (the footer) and #57 (generating the version).

Merging this deploys.

## What it does

The footer now reads `v67 · 32ef795 · 7 Aug 18:41` beside the signed-in email, formatted by `vouchers/version-display.js` in Perth time.

Verified end to end, not just in unit tests — the real generator's output fed through the real display module:

```
generator emitted: {"version":"67","sha":"32ef795","builtAt":"2026-08-07T10:41:42.990Z"}
footer would read: "v67 · 32ef795 · 7 Aug 18:41"
dev shape        : ""
no version.json  : ""
```

## Two formatting traps, both pinned

- **en-AU renders `month:"short"` as "July", not "Jul"** — so the locale is `en-GB`. This one is real and the test genuinely catches a swap back.
- **`hour12:false` is specified to permit an h24 cycle** that shows midnight as `24:00`, so the source asks for `hourCycle:'h23'`. Being straight about this: on the ICU the suite runs against, `hour12:false` also resolves to `h23`, so no test can tell the two apart. The assertion catches an explicit `h24` and records the intent — the comment says exactly that rather than implying more.

## Degrading quietly

No `version.json` (the normal state in local development), the `dev` shape, a malformed payload, or a stale cached module without the export all render as nothing and hide the line. A version display showing a broken placeholder is worse than one showing nothing.

The SHA is deliberately **not** linked. #58 makes the link optional — "worth doing if the repository is reachable by the people who would click it". staff-site is private and this footer is read at the front desk, so it would 404 for almost everyone.

## Known limitation, now written down

Because the fetch is `no-store` it always reaches the origin, so the footer reports the newest **deployed** build, not the build actually running. A cached hub page prints the current version beside stale code. That is the follow-up #58 anticipated; filed as [vouchers#66](https://github.com/urbanjungleirc/vouchers/issues/66) and recorded in the code and `CONTEXT.md` rather than left as an implied guarantee.

## Verification

- `npx vitest run` in `vouchers/` — **140 tests, 9 files, all passing** (10 new formatting tests, 5 new page-source pins).
- The page wiring is pinned in `signed-in-footer.test.js`, following the convention #56 established after the identity field shipped assigned-but-never-rendered. Each new pin was **verified to fail when the wiring is broken** — the binding and the `no-store` fetch were each removed, the tests went red, and were restored.
- Not verified: rendering in a real browser. The zone is behind Access, so that needs a signed-in session — same constraint as vouchers#62.

Reviewed with `/code-review` on both axes; findings fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)