### PR TITLE
Collapse the voucher hub's secondary nav into a hamburger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and 
 vouchers/unsubscribes-logic.js - pure suppression rules behind that page (unit tested)
 vouchers/delete-logic.js - pure confirmation rules behind the hard-delete action (unit tested)
 vouchers/type-surfaces.js - which voucher-type fields feed which output surface (unit tested)
+vouchers/nav-menu.js    - what the header hamburger holds, and which section it is hiding (unit tested)
 vouchers/scripts/version.mjs - derives the hub's build version from git at deploy time (unit tested)
 vouchers/version-display.js - formats that version for the footer, in Perth time (unit tested)
 .github/workflows/pages.yml - publishes the site to Pages; the repo's only build step

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -44,6 +44,11 @@
     // A stale cached copy would leave the type editor with no tabs to render.
     import * as typeSurfaces from './type-surfaces.js?v=1';
     window.typeSurfaces = typeSurfaces;
+    // Same rule again for the ?v= here. A stale cached copy of this one costs
+    // only the label on the hamburger, so activeMenuLabel() degrades to '' and
+    // the menu keeps working rather than throwing on every render.
+    import * as navMenu from './nav-menu.js?v=1';
+    window.navMenu = navMenu;
     // And here: bump it whenever version-display.js gains or renames an export.
     // A stale cached copy of this one is the mildest of the four — the footer
     // loses its version line and nothing else changes — which is the whole
@@ -475,6 +480,77 @@
        that. .day-menu already opts out; the status menu needs a floor. */
     .combo-sm .combo-menu { min-width: 100%; width: max-content; }
     .combo-sm .day-menu { width: 268px; }
+    /* Header hamburger. The trigger itself is a nav button like the ones beside
+       it and keeps their Tailwind classes; only the panel is styled here, and it
+       borrows the combo panel's card so a menu in the dark header still reads as
+       part of the same app. */
+    .nav-menu {
+      position: relative;
+    }
+    .nav-menu-panel {
+      position: absolute;
+      z-index: 60;
+      right: 0;
+      top: calc(100% + 6px);
+      min-width: 208px;
+      padding: 6px;
+      border-radius: 14px;
+      border: 1px solid rgba(139, 28, 35, 0.14);
+      background: #fff;
+      box-shadow: 0 18px 36px -26px rgba(15, 23, 42, 0.75);
+      text-align: left;
+    }
+    /* The header is right-aligned from sm up but starts at the left edge on a
+       phone, where a right-pinned panel would hang off the screen. */
+    @media (max-width: 639px) {
+      .nav-menu-panel { right: auto; left: 0; }
+    }
+    .nav-menu-item {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      border: 0;
+      border-radius: 10px;
+      padding: 8px 10px;
+      background: transparent;
+      color: #1f2937;
+      font-size: 0.875rem;
+      font-weight: 500;
+      text-align: left;
+      cursor: pointer;
+    }
+    .nav-menu-item:hover,
+    .nav-menu-item.active {
+      background: rgba(139, 28, 35, 0.08);
+      color: var(--uj);
+    }
+    .nav-menu-item.active {
+      font-weight: 700;
+    }
+    .nav-menu-heading {
+      padding: 8px 10px 4px;
+      margin-top: 4px;
+      border-top: 1px solid rgba(31, 41, 55, 0.08);
+      font-size: 0.62rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #9ca3af;
+    }
+    /* The "you are leaving the hub" arrow, pushed to the far edge of the row. */
+    .nav-menu-away {
+      margin-left: auto;
+      width: 14px;
+      height: 14px;
+      color: #9ca3af;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    .nav-menu-away svg { width: 100%; height: 100%; }
 
     /* Day picker.
        Native <input type="date"> renders OS-supplied chrome that no stylesheet
@@ -719,7 +795,8 @@
         </div>
       </div>
 
-      <!-- Nav — primary actions on row 1, Reports/Voucher Types pinned to row 2 -->
+      <!-- Nav — primary actions on row 1; Reports pinned to row 2 beside the menu
+           holding everything else. See vouchers#54. -->
       <nav class="flex flex-col gap-1.5 sm:items-end">
         <div class="flex items-center gap-1.5 flex-wrap sm:justify-end">
         <button @click="view='search'; stopScannerIfActive()"
@@ -744,34 +821,57 @@
         </button>
         </div>
         <div class="flex items-center gap-1.5 flex-wrap sm:justify-end">
-        <button @click="goReport()"
-          :class="view==='report' ? 'bg-white/[0.16] text-white font-semibold' : 'text-white/70 hover:text-white hover:bg-white/10'"
+        <button @click="goReports()"
+          :class="view==='reports' ? 'bg-white/[0.16] text-white font-semibold' : 'text-white/70 hover:text-white hover:bg-white/10'"
           class="px-3 py-2 rounded-xl text-[0.84rem] font-medium transition-all inline-flex items-center gap-1.5">
           <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M4.5 19.5h15"/><path d="M7 16v-5"/><path d="M12 16V6.5"/><path d="M17 16v-8"/></svg></span>
           Reports
         </button>
-        <button @click="goVoucherTypes()"
-          :class="view==='voucherTypes' ? 'bg-white/[0.16] text-white font-semibold' : 'text-white/70 hover:text-white hover:bg-white/10'"
-          class="px-3 py-2 rounded-xl text-[0.84rem] font-medium transition-all inline-flex items-center gap-1.5">
-          <span class="nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18M8 4v16"/></svg></span>
-          Voucher Types
-        </button>
-        <button @click="goExport()"
-          :class="view==='export' ? 'bg-white/[0.16] text-white font-semibold' : 'text-white/70 hover:text-white hover:bg-white/10'"
-          class="px-3 py-2 rounded-xl text-[0.84rem] font-medium transition-all inline-flex items-center gap-1.5">
-          <span class="nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="m8 11 4 4 4-4"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg></span>
-          Export
-        </button>
-        <a href="/vouchers/stats.html"
-          class="px-3 py-2 rounded-xl text-[0.84rem] font-medium transition-all inline-flex items-center gap-1.5 text-white/70 hover:text-white hover:bg-white/10">
-          <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M4.5 19.5h15"/><path d="M8 16v-6"/><path d="M13 16V8"/><path d="M18 16v-4"/></svg></span>
-          Stats
-        </a>
-        <a href="/vouchers/unsubscribes.html"
-          class="px-3 py-2 rounded-xl text-[0.84rem] font-medium transition-all inline-flex items-center gap-1.5 text-white/70 hover:text-white hover:bg-white/10">
-          <span class="nav-icon"><svg viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3.5 7l8.5 5.5L20.5 7"/></svg></span>
-          Unsubscribes
-        </a>
+
+        <!-- Everything else the row used to carry, in one menu. It collapses at
+             every width deliberately: the row grew an item at a time until it
+             wrapped, and a desktop-only escape hatch would let that happen
+             again. The trigger names the section when the open view is one of
+             the hidden ones, so collapsing does not cost staff their bearings. -->
+        <div class="nav-menu" @click.outside="navMenuOpen = false" @keydown.escape.window="navMenuOpen = false">
+          <button type="button" @click="navMenuOpen = !navMenuOpen"
+            :class="activeMenuLabel() ? 'bg-white/[0.16] text-white font-semibold' : 'text-white/70 hover:text-white hover:bg-white/10'"
+            class="px-3 py-2 rounded-xl text-[0.84rem] font-medium transition-all inline-flex items-center gap-1.5"
+            aria-haspopup="true" :aria-expanded="navMenuOpen ? 'true' : 'false'"
+            :aria-label="activeMenuLabel() ? 'More — currently on ' + activeMenuLabel() : 'More'">
+            <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/></svg></span>
+            <span x-text="activeMenuLabel() || 'More'"></span>
+          </button>
+          <!-- Hamburger panel -->
+          <div class="nav-menu-panel" x-show="navMenuOpen" x-cloak @click="navMenuOpen = false">
+            <button type="button" @click="goVoucherTypes()"
+              class="nav-menu-item" :class="view==='voucherTypes' && 'active'"
+              :aria-current="view==='voucherTypes' ? 'true' : false">
+              <span class="nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18M8 4v16"/></svg></span>
+              Voucher Types
+            </button>
+            <button type="button" @click="goExport()"
+              class="nav-menu-item" :class="view==='export' && 'active'"
+              :aria-current="view==='export' ? 'true' : false">
+              <span class="nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="m8 11 4 4 4-4"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg></span>
+              Export
+            </button>
+            <!-- Below the divider the hub is left behind entirely. Grouped and
+                 arrow-marked so that is clear before the click, not after it. -->
+            <div class="nav-menu-heading">Other pages</div>
+            <a href="/vouchers/stats.html" class="nav-menu-item">
+              <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M4.5 19.5h15"/><path d="M8 16v-6"/><path d="M13 16V8"/><path d="M18 16v-4"/></svg></span>
+              Stats
+              <span class="nav-menu-away"><svg viewBox="0 0 24 24"><path d="M8.5 15.5 15.5 8.5"/><path d="M9.5 8.5h6v6"/></svg></span>
+            </a>
+            <a href="/vouchers/unsubscribes.html" class="nav-menu-item">
+              <span class="nav-icon"><svg viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3.5 7l8.5 5.5L20.5 7"/></svg></span>
+              Unsubscribes
+              <span class="nav-menu-away"><svg viewBox="0 0 24 24"><path d="M8.5 15.5 15.5 8.5"/><path d="M9.5 8.5h6v6"/></svg></span>
+            </a>
+          </div>
+          <!-- /Hamburger panel -->
+        </div>
         </div>
       </nav>
 
@@ -1027,12 +1127,12 @@
 
     <!-- ── Detail ────────────────────────────────────────────────────────── -->
     <div x-show="view==='detail'">
-      <button @click="view = detailOrigin === 'report' ? 'report' : 'search'"
+      <button @click="view = detailOrigin === 'reports' ? 'reports' : 'search'"
         class="flex items-center gap-1.5 text-sm text-neutral-500 hover:text-neutral-800 mb-5 transition-colors">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M15 19l-7-7 7-7"/>
         </svg>
-        <span x-text="detailOrigin === 'report' ? 'Back to reports' : 'Back to search'"></span>
+        <span x-text="detailOrigin === 'reports' ? 'Back to reports' : 'Back to search'"></span>
       </button>
 
       <div x-show="detailLoading" class="flex flex-col items-center justify-center gap-3 py-16 text-neutral-400 text-sm">
@@ -1474,7 +1574,7 @@
     </div>
 
     <!-- ── Reports ───────────────────────────────────────────────────────── -->
-    <div x-show="view==='report'">
+    <div x-show="view==='reports'">
       <div class="flex flex-wrap items-center gap-3 mb-5">
         <h2 class="text-base font-semibold text-neutral-800 inline-flex items-center gap-2">
           <span class="section-icon"><svg viewBox="0 0 24 24"><path d="M4.5 19.5h15"/><path d="M7 16v-5"/><path d="M12 16V6.5"/><path d="M17 16v-8"/></svg></span>
@@ -1556,7 +1656,7 @@
               </thead>
               <tbody class="divide-y divide-neutral-50">
                 <template x-for="v in pagedReportIssued()" :key="v.voucher_id">
-                  <tr @click="openVoucher(v.voucher_id, 'report')" class="hover:bg-uj/[0.025] cursor-pointer transition-colors">
+                  <tr @click="openVoucher(v.voucher_id, 'reports')" class="hover:bg-uj/[0.025] cursor-pointer transition-colors">
                     <td class="px-4 py-3 font-mono text-xs font-bold text-uj" x-text="v.voucher_id"></td>
                     <td class="px-4 py-3 hidden sm:table-cell">
                       <div class="text-sm text-neutral-800" x-text="v.customer_name||'—'"></div>
@@ -1620,7 +1720,7 @@
               </thead>
               <tbody class="divide-y divide-neutral-50">
                 <template x-for="v in pagedReportRedeemed()" :key="v.voucher_id">
-                  <tr @click="openVoucher(v.voucher_id, 'report')" class="hover:bg-uj/[0.025] cursor-pointer transition-colors">
+                  <tr @click="openVoucher(v.voucher_id, 'reports')" class="hover:bg-uj/[0.025] cursor-pointer transition-colors">
                     <td class="px-4 py-3 font-mono text-xs font-bold text-uj" x-text="v.voucher_id"></td>
                     <td class="px-4 py-3 hidden sm:table-cell text-sm text-neutral-700" x-text="v.customer_name||'—'"></td>
                     <td class="px-4 py-3 text-right text-sm font-semibold text-emerald-700 tabular-nums" x-text="fmtMoney(v.last_redeemed_amount)"></td>
@@ -3213,6 +3313,7 @@
 
       // Navigation
       view: 'search',
+      navMenuOpen: false,
 
       // Export
       exportDataset: 'purchases',
@@ -3257,7 +3358,7 @@
       voucher: null,
       detailLoading: false,
       detailError: '',
-      detailOrigin: 'search', // where the detail view was opened from: 'search' | 'report'
+      detailOrigin: 'search', // where the detail view was opened from: 'search' | 'reports'
 
       // Redeem modal
       redeemOpen: false,
@@ -4228,7 +4329,7 @@
             this.report.redeemed = window.deleteLogic.withoutVoucher(this.report.redeemed, code);
           }
           this.voucher = null;
-          this.view = this.detailOrigin === 'report' ? 'report' : 'search';
+          this.view = this.detailOrigin === 'reports' ? 'reports' : 'search';
           // The dashboard counters we are about to land back on counted this
           // voucher. Re-read them rather than leave visibly wrong totals sitting
           // there until the next five-minute tick.
@@ -4502,10 +4603,20 @@
         }
       },
 
+      // ── Header nav ───────────────────────────────────────────────────────
+      // What the hamburger calls itself: the section it is currently hiding, or
+      // nothing when the open view is one still visible in the header. Read
+      // through window and guarded, so a browser holding a stale cached
+      // nav-menu.js loses the label rather than every render of the header.
+      activeMenuLabel() {
+        const item = window.navMenu?.activeMenuItem?.(this.view);
+        return item ? item.label : '';
+      },
+
       // ── Reports ──────────────────────────────────────────────────────────
-      async goReport() {
+      async goReports() {
         this.stopScannerIfActive();
-        this.view = 'report';
+        this.view = 'reports';
         await this.loadReport();
       },
 
@@ -4534,7 +4645,7 @@
 
       async showTodayReport() {
         this.reportTab = 'today';
-        await this.goReport();
+        await this.goReports();
       },
 
       async loadDashStats() {
@@ -4576,7 +4687,7 @@
             if (recent) p.set('limit', '99');
             this.results = await this.api('/v1/vouchers/search?' + p.toString());
             this.recentListing = recent;
-          } else if (this.view === 'report') {
+          } else if (this.view === 'reports') {
             this.report = await this.api('/v1/vouchers/report?type=' + this.reportTab);
           }
         } catch { /* background refresh — fail silently */ }

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -480,63 +480,39 @@
        that. .day-menu already opts out; the status menu needs a floor. */
     .combo-sm .combo-menu { min-width: 100%; width: max-content; }
     .combo-sm .day-menu { width: 268px; }
-    /* Header hamburger. The trigger itself is a nav button like the ones beside
-       it and keeps their Tailwind classes; only the panel is styled here, and it
-       borrows the combo panel's card so a menu in the dark header still reads as
-       part of the same app. */
+    /* Header hamburger. The trigger is a nav button like the ones beside it and
+       keeps their Tailwind classes. The panel IS the combo dropdown — same card,
+       same rows, same heading — so a menu in the dark header still reads as part
+       of the same app; only what a header menu needs differently is set here. */
     .nav-menu {
       position: relative;
     }
+    /* A combo panel stretches to the width of its trigger. This one hangs off a
+       trigger far narrower than the labels it holds, so it sets its own width
+       and pins to the right, under the right-aligned nav. */
     .nav-menu-panel {
-      position: absolute;
-      z-index: 60;
+      left: auto;
       right: 0;
-      top: calc(100% + 6px);
       min-width: 208px;
-      padding: 6px;
-      border-radius: 14px;
-      border: 1px solid rgba(139, 28, 35, 0.14);
-      background: #fff;
-      box-shadow: 0 18px 36px -26px rgba(15, 23, 42, 0.75);
       text-align: left;
     }
-    /* The header is right-aligned from sm up but starts at the left edge on a
-       phone, where a right-pinned panel would hang off the screen. */
+    /* Except on a phone, where the header starts at the left edge and a
+       right-pinned panel would hang off the screen. */
     @media (max-width: 639px) {
       .nav-menu-panel { right: auto; left: 0; }
     }
+    /* A combo option puts its two ends apart, because the right end is a tick.
+       Here the row is icon-then-label, and only the away arrow wants the far
+       edge — it claims it itself. */
     .nav-menu-item {
-      width: 100%;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      border: 0;
-      border-radius: 10px;
-      padding: 8px 10px;
-      background: transparent;
-      color: #1f2937;
-      font-size: 0.875rem;
+      justify-content: flex-start;
       font-weight: 500;
-      text-align: left;
-      cursor: pointer;
-    }
-    .nav-menu-item:hover,
-    .nav-menu-item.active {
-      background: rgba(139, 28, 35, 0.08);
-      color: var(--uj);
-    }
-    .nav-menu-item.active {
-      font-weight: 700;
+      text-decoration: none;
     }
     .nav-menu-heading {
       padding: 8px 10px 4px;
       margin-top: 4px;
       border-top: 1px solid rgba(31, 41, 55, 0.08);
-      font-size: 0.62rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: #9ca3af;
     }
     /* The "you are leaving the hub" arrow, pushed to the far edge of the row. */
     .nav-menu-away {
@@ -843,31 +819,34 @@
             <span x-text="activeMenuLabel() || 'More'"></span>
           </button>
           <!-- Hamburger panel -->
-          <div class="nav-menu-panel" x-show="navMenuOpen" x-cloak @click="navMenuOpen = false">
+          <div class="combo-menu nav-menu-panel" x-show="navMenuOpen" x-transition.origin.top x-cloak
+            @click="navMenuOpen = false">
             <button type="button" @click="goVoucherTypes()"
-              class="nav-menu-item" :class="view==='voucherTypes' && 'active'"
+              class="combo-option nav-menu-item" :class="view==='voucherTypes' && 'active'"
               :aria-current="view==='voucherTypes' ? 'true' : false">
               <span class="nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18M8 4v16"/></svg></span>
               Voucher Types
             </button>
             <button type="button" @click="goExport()"
-              class="nav-menu-item" :class="view==='export' && 'active'"
+              class="combo-option nav-menu-item" :class="view==='export' && 'active'"
               :aria-current="view==='export' ? 'true' : false">
               <span class="nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="m8 11 4 4 4-4"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg></span>
               Export
             </button>
             <!-- Below the divider the hub is left behind entirely. Grouped and
-                 arrow-marked so that is clear before the click, not after it. -->
-            <div class="nav-menu-heading">Other pages</div>
-            <a href="/vouchers/stats.html" class="nav-menu-item">
+                 arrow-marked so that is clear before the click, not after it —
+                 and the arrow carries a title, so it is clear to a screen reader
+                 too rather than only to the eye. -->
+            <div class="filter-heading nav-menu-heading">Other pages</div>
+            <a href="/vouchers/stats.html" class="combo-option nav-menu-item">
               <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M4.5 19.5h15"/><path d="M8 16v-6"/><path d="M13 16V8"/><path d="M18 16v-4"/></svg></span>
               Stats
-              <span class="nav-menu-away"><svg viewBox="0 0 24 24"><path d="M8.5 15.5 15.5 8.5"/><path d="M9.5 8.5h6v6"/></svg></span>
+              <span class="nav-menu-away"><svg viewBox="0 0 24 24" role="img" aria-label="Opens another page"><title>Opens another page</title><path d="M8.5 15.5 15.5 8.5"/><path d="M9.5 8.5h6v6"/></svg></span>
             </a>
-            <a href="/vouchers/unsubscribes.html" class="nav-menu-item">
+            <a href="/vouchers/unsubscribes.html" class="combo-option nav-menu-item">
               <span class="nav-icon"><svg viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3.5 7l8.5 5.5L20.5 7"/></svg></span>
               Unsubscribes
-              <span class="nav-menu-away"><svg viewBox="0 0 24 24"><path d="M8.5 15.5 15.5 8.5"/><path d="M9.5 8.5h6v6"/></svg></span>
+              <span class="nav-menu-away"><svg viewBox="0 0 24 24" role="img" aria-label="Opens another page"><title>Opens another page</title><path d="M8.5 15.5 15.5 8.5"/><path d="M9.5 8.5h6v6"/></svg></span>
             </a>
           </div>
           <!-- /Hamburger panel -->
@@ -1995,7 +1974,7 @@
        Sized for more than one item on purpose: the build version sits here too
        (vouchers#58), beside the identity rather than under it. -->
   <footer class="max-w-[1100px] mx-auto w-full px-4 pb-8 text-xs text-neutral-500">
-    <div class="border-t border-neutral-200 pt-4 flex flex-wrap items-center gap-x-5 gap-y-1">
+    <div class="border-t border-neutral-200 pt-4 flex flex-wrap items-center justify-between gap-x-5 gap-y-1">
       <!-- Hidden outright when there is no email rather than showing the label
            with a blank after it. Local development authenticates by shared
            secret and carries no Access identity, so that is a real state. -->

--- a/vouchers/nav-menu.js
+++ b/vouchers/nav-menu.js
@@ -1,0 +1,25 @@
+// The header's collapsed navigation.
+//
+// The hub's nav has one pinned secondary item (Reports) and a hamburger holding
+// the rest. This module owns the list behind the hamburger and the question the
+// trigger has to answer — "is the section I am looking at hidden in here?" — so
+// that a menu item and its active state can never disagree. See vouchers#54.
+//
+// Two kinds of item, and the difference is visible to staff:
+//   'view' — switches the hub's view in place, and carries `view`
+//   'page' — leaves for another page, and carries `href`
+
+export const SECONDARY_MENU = [
+  { id: 'voucherTypes', label: 'Voucher Types', kind: 'view', view: 'voucherTypes' },
+  { id: 'export', label: 'Export', kind: 'view', view: 'export' },
+  { id: 'stats', label: 'Stats', kind: 'page', href: '/vouchers/stats.html' },
+  { id: 'unsubscribes', label: 'Unsubscribes', kind: 'page', href: '/vouchers/unsubscribes.html' },
+];
+
+// The item the hub's current view belongs to, or null when the view is one of
+// the ones still visible in the header. Matched on `view` rather than `id`, so
+// the page items — which no value of `view` can ever equal — stay out of it.
+export function activeMenuItem(view) {
+  if (!view) return null;
+  return SECONDARY_MENU.find(item => item.view === view) || null;
+}

--- a/vouchers/nav-menu.js
+++ b/vouchers/nav-menu.js
@@ -10,10 +10,10 @@
 //   'page' — leaves for another page, and carries `href`
 
 export const SECONDARY_MENU = [
-  { id: 'voucherTypes', label: 'Voucher Types', kind: 'view', view: 'voucherTypes' },
-  { id: 'export', label: 'Export', kind: 'view', view: 'export' },
-  { id: 'stats', label: 'Stats', kind: 'page', href: '/vouchers/stats.html' },
-  { id: 'unsubscribes', label: 'Unsubscribes', kind: 'page', href: '/vouchers/unsubscribes.html' },
+  { label: 'Voucher Types', kind: 'view', view: 'voucherTypes' },
+  { label: 'Export', kind: 'view', view: 'export' },
+  { label: 'Stats', kind: 'page', href: '/vouchers/stats.html' },
+  { label: 'Unsubscribes', kind: 'page', href: '/vouchers/unsubscribes.html' },
 ];
 
 // The item the hub's current view belongs to, or null when the view is one of

--- a/vouchers/test/created-by-attribution.test.js
+++ b/vouchers/test/created-by-attribution.test.js
@@ -47,7 +47,7 @@ describe('created-by is not remembered across staff', () => {
   });
 
   test('a successful create clears the name so the next voucher is attributed afresh', () => {
-    const submitCreate = between('async submitCreate()', 'async goReport()');
+    const submitCreate = between('async submitCreate()', 'async goReports()');
     // After the POST, not before it — the value still has to reach the request.
     const posted = submitCreate.indexOf('issued_by: this.createIssuer.trim()');
     const cleared = submitCreate.indexOf("this.createIssuer = '';");

--- a/vouchers/test/nav-menu.test.js
+++ b/vouchers/test/nav-menu.test.js
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { SECONDARY_MENU, activeMenuItem } from '../nav-menu.js';
+
+// The nav itself is markup inside index.html's Alpine component, where no unit
+// test can call it, so it is pinned against the page source the same way the
+// signed-in footer is.
+const page = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+// Slicing on an anchor that has moved yields a one-character string and a
+// failure that reads as a fault in the page rather than in this file.
+function between(startAnchor, endAnchor) {
+  const start = page.indexOf(startAnchor);
+  if (start < 0) throw new Error('could not find ' + startAnchor + ' in index.html');
+  const end = page.indexOf(endAnchor, start);
+  if (end < 0) throw new Error('could not find ' + endAnchor + ' after ' + startAnchor);
+  return page.slice(start, end);
+}
+
+const nav = () => between('<nav', '</nav>');
+const menuPanel = () => between('<!-- Hamburger panel', '<!-- /Hamburger panel');
+// Everything in the nav that is not inside the panel: what staff see without
+// opening anything.
+const navOutsideMenu = () => nav().replace(menuPanel(), '');
+// One entry per row of the open menu, in document order: the markup of the <a>
+// or <button>, and the text staff actually read on it.
+function menuRows() {
+  return menuPanel().split(/(?=<(?:a|button) )/).slice(1).map(chunk => {
+    // Cut at the row's own closing tag: what follows it belongs to the group
+    // heading or to the next row, not to this one's label.
+    const markup = chunk.slice(0, chunk.search(/<\/(?:a|button)>/));
+    return { markup, label: markup.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim() };
+  });
+}
+
+// The hub's header nav grew a second row, one item at a time, until five
+// low-emphasis items sat under the three primary actions. Everything but
+// Reports now collapses behind a hamburger — at every width, so the row cannot
+// re-grow the next time a feature lands. See vouchers#54.
+
+describe('what the hamburger holds', () => {
+  it('holds the four collapsed items, in the order the old row had them', () => {
+    expect(SECONDARY_MENU.map(i => i.label)).toEqual([
+      'Voucher Types', 'Export', 'Stats', 'Unsubscribes',
+    ]);
+  });
+
+  it('does not hold Reports — that one stays pinned in the header', () => {
+    expect(SECONDARY_MENU.map(i => i.label)).not.toContain('Reports');
+  });
+
+  it('separates in-page views from links that leave the page', () => {
+    // Staff should not be surprised by a navigation. Stats and Unsubscribes are
+    // their own pages; the other two switch the view in place.
+    expect(SECONDARY_MENU.filter(i => i.kind === 'view').map(i => i.view))
+      .toEqual(['voucherTypes', 'export']);
+    expect(SECONDARY_MENU.filter(i => i.kind === 'page').map(i => i.href))
+      .toEqual(['/vouchers/stats.html', '/vouchers/unsubscribes.html']);
+  });
+
+  it('gives every item exactly one of a view or an href', () => {
+    for (const item of SECONDARY_MENU) {
+      expect(Boolean(item.view) !== Boolean(item.href)).toBe(true);
+    }
+  });
+});
+
+describe('the header row collapses', () => {
+  it('offers a hamburger', () => {
+    expect(nav()).toMatch(/x-data|navMenuOpen/);
+    expect(navOutsideMenu()).toMatch(/@click="navMenuOpen = !navMenuOpen"/);
+  });
+
+  it('keeps Reports in the header, out of the menu', () => {
+    expect(navOutsideMenu()).toMatch(/Reports/);
+    expect(menuPanel()).not.toMatch(/Reports/);
+  });
+
+  it('keeps the primary actions in the header, out of the menu', () => {
+    for (const label of ['Search & Redeem', 'Create', 'Scan']) {
+      expect(navOutsideMenu()).toMatch(label);
+      expect(menuPanel()).not.toMatch(label);
+    }
+  });
+
+  it('moves every collapsed item into the menu and nowhere else', () => {
+    for (const { label } of SECONDARY_MENU) {
+      expect(menuPanel()).toMatch(label);
+      expect(navOutsideMenu()).not.toMatch(label);
+    }
+  });
+
+  it('collapses at every width, so the row cannot re-grow on desktop', () => {
+    // A responsive visibility class on the menu would let the old row come back
+    // at the wide end — which is the whole failure this replaces.
+    expect(menuPanel()).not.toMatch(/\b(sm|md|lg|xl):(hidden|flex|block|inline-flex)\b/);
+    const trigger = between('@click="navMenuOpen = !navMenuOpen"', '</button>');
+    expect(trigger).not.toMatch(/\b(sm|md|lg|xl):(hidden|flex|block|inline-flex)\b/);
+  });
+});
+
+describe('telling staff where they are', () => {
+  // Collapsing the row hides the label of the section you are standing in. The
+  // trigger has to say it instead, or the menu costs staff their bearings.
+  it('names the section when the current view is one it holds', () => {
+    expect(activeMenuItem('voucherTypes').label).toBe('Voucher Types');
+    expect(activeMenuItem('export').label).toBe('Export');
+  });
+
+  it('names nothing for the views that stay visible in the header', () => {
+    expect(activeMenuItem('search')).toBe(null);
+    expect(activeMenuItem('create')).toBe(null);
+    expect(activeMenuItem('reports')).toBe(null);
+  });
+
+  it('names nothing for a view it has never heard of', () => {
+    expect(activeMenuItem('')).toBe(null);
+    expect(activeMenuItem(undefined)).toBe(null);
+    expect(activeMenuItem('somethingElse')).toBe(null);
+  });
+
+  it('never claims a separate page as the current view', () => {
+    // Stats and Unsubscribes leave the hub entirely, so no value of the hub's
+    // own `view` can ever be one of them — matching on id would wrongly say so.
+    expect(activeMenuItem('stats')).toBe(null);
+    expect(activeMenuItem('unsubscribes')).toBe(null);
+  });
+
+  it('the trigger wears that label, and falls back to More', () => {
+    const trigger = between('@click="navMenuOpen = !navMenuOpen"', '</button>');
+    expect(trigger).toMatch(/x-text="activeMenuLabel\(\) \|\| 'More'"/);
+    // Sighted staff get the label in the button; a screen reader gets it in the
+    // accessible name, which otherwise reads as a bare "More" from anywhere.
+    expect(trigger).toMatch(/:aria-label="activeMenuLabel\(\)/);
+  });
+
+  it('the label the page asks for is the one the module answers', () => {
+    // Guards the binding and the module drifting onto two different functions,
+    // which would leave the trigger permanently reading "More".
+    expect(page).toMatch(/activeMenuLabel\(\)\s*\{[\s\S]*?window\.navMenu\?\.activeMenuItem/);
+    expect(page).toMatch(/import \* as navMenu from '\.\/nav-menu\.js\?v=\d+'/);
+    expect(page).toMatch(/window\.navMenu = navMenu/);
+  });
+
+  it('marks the open section inside the menu too', () => {
+    // The trigger says which section; the menu says which row — without it the
+    // open menu gives no clue where you already are.
+    for (const item of SECONDARY_MENU.filter(i => i.kind === 'view')) {
+      expect(menuPanel()).toMatch(new RegExp(`:class="view==='${item.view}' && 'active'"`));
+      expect(menuPanel()).toMatch(new RegExp(`:aria-current="view==='${item.view}' \\? 'true' : false"`));
+    }
+  });
+});
+
+describe('the menu behaves like the hub\'s other dropdowns', () => {
+  it('closes on a click outside and on Escape', () => {
+    const shell = between('<div class="nav-menu"', '<!-- Hamburger panel');
+    expect(shell).toMatch(/@click\.outside="navMenuOpen = false"/);
+    expect(shell).toMatch(/@keydown\.escape\.window="navMenuOpen = false"/);
+  });
+
+  it('announces itself as a menu button', () => {
+    const trigger = between('@click="navMenuOpen = !navMenuOpen"', '</button>');
+    expect(trigger).toMatch(/aria-haspopup="true"/);
+    expect(trigger).toMatch(/:aria-expanded="navMenuOpen \? 'true' : 'false'"/);
+  });
+
+  it('starts closed', () => {
+    expect(page).toMatch(/navMenuOpen: false,/);
+    expect(menuPanel()).toMatch(/x-show="navMenuOpen"/);
+  });
+
+  it('closes once something in it has been chosen', () => {
+    // Four items, two of which switch the view in place: leaving the panel open
+    // over the view it just opened is the obvious way to get this wrong.
+    expect(menuPanel()).toMatch(/@click="navMenuOpen = false"/);
+  });
+});
+
+describe('leaving the hub is visible before the click', () => {
+  it('groups the separate pages under their own heading', () => {
+    const heading = menuPanel().indexOf('nav-menu-heading');
+    expect(heading).toBeGreaterThan(-1);
+    // Everything after the heading leaves; everything before it stays.
+    for (const item of SECONDARY_MENU) {
+      const at = menuPanel().indexOf(item.label);
+      if (item.kind === 'page') expect(at).toBeGreaterThan(heading);
+      else expect(at).toBeLessThan(heading);
+    }
+  });
+
+  it('marks each of them with an away arrow, and the in-page views with none', () => {
+    for (const item of SECONDARY_MENU) {
+      const row = menuRows().find(r => r.label === item.label);
+      expect(row, `no row for ${item.label}`).toBeTruthy();
+      expect(row.markup.includes('nav-menu-away')).toBe(item.kind === 'page');
+    }
+  });
+
+  it('sends each of them to the href the module records', () => {
+    for (const item of SECONDARY_MENU.filter(i => i.kind === 'page')) {
+      expect(menuPanel()).toMatch(`href="${item.href}"`);
+    }
+  });
+
+  it('opens the in-page views through the hub\'s own handlers', () => {
+    expect(menuPanel()).toMatch(/@click="goVoucherTypes\(\)"/);
+    expect(menuPanel()).toMatch(/@click="goExport\(\)"/);
+    expect(menuPanel()).not.toMatch(/href="\/vouchers\/index\.html/);
+  });
+});
+
+describe('the menu and the page agree on what is in it', () => {
+  it('lists exactly the module\'s items, in the module\'s order', () => {
+    // The rows are written out in the markup, icons and all, rather than looped
+    // from the module — so this is what stops the two drifting apart.
+    expect(menuRows().map(r => r.label)).toEqual(SECONDARY_MENU.map(i => i.label));
+  });
+});
+
+describe('the Reports view is named the way the nav names it', () => {
+  // The nav said "Reports" while the view id and its handler said "report".
+  // Same thing, two spellings, and the reader has to know they are the same.
+  it('has no singular report view or handler left', () => {
+    expect(page).not.toMatch(/view\s*===?\s*'report'/);
+    expect(page).not.toMatch(/view\s*=\s*'report'/);
+    expect(page).not.toMatch(/view==='report'/);
+    expect(page).not.toMatch(/\bgoReport\b(?!s)/);
+  });
+
+  it('pins the plural view to the pinned nav button', () => {
+    expect(navOutsideMenu()).toMatch(/@click="goReports\(\)"/);
+    expect(navOutsideMenu()).toMatch(/view==='reports'/);
+    expect(page).toMatch(/async goReports\(\)\s*\{/);
+    expect(page).toMatch(/<div x-show="view==='reports'">/);
+  });
+
+  it('still calls the report it loads a report', () => {
+    // The plural is the section; the thing the API returns is one report, and
+    // renaming that too would be a rename for its own sake.
+    expect(page).toMatch(/async loadReport\(\)/);
+    expect(page).toMatch(/this\.report = await this\.api/);
+  });
+});

--- a/vouchers/test/nav-menu.test.js
+++ b/vouchers/test/nav-menu.test.js
@@ -29,7 +29,14 @@ function menuRows() {
     // Cut at the row's own closing tag: what follows it belongs to the group
     // heading or to the next row, not to this one's label.
     const markup = chunk.slice(0, chunk.search(/<\/(?:a|button)>/));
-    return { markup, label: markup.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim() };
+    // <title> is what a screen reader reads out, not what the row says — strip
+    // it with the tags so `label` stays the words staff see.
+    const label = markup
+      .replace(/<title>[\s\S]*?<\/title>/g, '')
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return { markup, label };
   });
 }
 
@@ -194,6 +201,16 @@ describe('leaving the hub is visible before the click', () => {
       const row = menuRows().find(r => r.label === item.label);
       expect(row, `no row for ${item.label}`).toBeTruthy();
       expect(row.markup.includes('nav-menu-away')).toBe(item.kind === 'page');
+    }
+  });
+
+  it('says so to a screen reader too, not only to the eye', () => {
+    // An unlabelled arrow is decoration; the row then sounds exactly like the
+    // in-page ones, which is the surprise this is meant to prevent.
+    const away = menuRows().filter(r => r.markup.includes('nav-menu-away'));
+    expect(away).toHaveLength(SECONDARY_MENU.filter(i => i.kind === 'page').length);
+    for (const row of away) {
+      expect(row.markup).toMatch(/<title>Opens another page<\/title>/);
     }
   });
 

--- a/vouchers/test/signed-in-footer.test.js
+++ b/vouchers/test/signed-in-footer.test.js
@@ -36,6 +36,12 @@ describe('the hub has a footer', () => {
     expect(page).toMatch(/<footer[\s>]/);
   });
 
+  test('its two items sit at opposite ends of the line', () => {
+    // Who you are on the left, which build you are on at the right. They answer
+    // unrelated questions and reading them as one run-on phrase helps nobody.
+    expect(footer()).toMatch(/justify-between/);
+  });
+
   test('the footer is in document flow after the main content', () => {
     // The modals and the toast are fixed overlays and are not in flow, so the
     // footer has nothing to displace — but only if it is not fixed itself. A


### PR DESCRIPTION
Closes urbanjungleirc/vouchers#54.

The header's second row had grown to five low-emphasis items and wrapped. **Reports** stays pinned; **Voucher Types, Export, Stats, Unsubscribes** move into a hamburger.

- **Collapses at every width**, not just narrow ones — a desktop-only escape hatch would let the row re-grow the next time a feature area lands, which is the failure being fixed rather than a cosmetic detail.
- **The trigger names the section it is hiding** ("☰ Voucher Types" rather than "☰ More") and highlights, so collapsing doesn't cost staff their bearings. The open row is marked inside the menu too (`aria-current`).
- **Stats and Unsubscribes leave the hub**, so they sit under an "Other pages" heading with an away arrow that carries a title — the distinction is made before the click, and to a screen reader as well as to the eye.
- **`nav-menu.js`** owns the list and the active-section question, unit tested like `delete-logic.js` / `type-surfaces.js`. The rows stay written out in the markup with their icons; a test pins the two lists together in both directions so they cannot drift.
- **Plural rename** the issue asked for: view `'report'` → `'reports'`, `goReport` → `goReports`. Verified complete across the repo, including `detailOrigin` and the background-refresh branch. `loadReport`/`this.report` stay singular — the section is plural, the report the API returns is one report.
- **Footer** (asked for alongside): its two items now sit at opposite ends of the line.

## Verification

- `npx vitest run` in `vouchers/` — **170 passed**, 10 files (28 new).
- The new markup tests were run against the pre-change page to confirm they discriminate: **19 of 28 failed**, as they should.
- Rendered headless at 1280px and 390px, over HTTP so the ES modules resolve: menu opens correctly at both, stays on screen on a phone, and the trigger reads "Voucher Types" with the highlight when that view is open.
- Header markup checked balanced; `nav-menu.js` syntax-checked.

Reviewed on both axes with `/code-review`. No live bugs found; the CSS duplication, the unused `id`, and the missing accessible name it did find are fixed in f76e77e.

⚠️ Merging this deploys to Pages — over to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)