### PR TITLE
Refresh the search list on the way back in, and flag vouchers expiring soon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ vouchers/unsubscribes-logic.js - pure suppression rules behind that page (unit t
 vouchers/delete-logic.js - pure confirmation rules behind the hard-delete action (unit tested)
 vouchers/type-surfaces.js - which voucher-type fields feed which output surface (unit tested)
 vouchers/nav-menu.js    - what the header hamburger holds, and which section it is hiding (unit tested)
+vouchers/expiry-flag.js - whether a voucher counts as "expiring soon" (unit tested)
 vouchers/scripts/version.mjs - derives the hub's build version from git at deploy time (unit tested)
 vouchers/version-display.js - formats that version for the footer, in Perth time (unit tested)
 .github/workflows/pages.yml - publishes the site to Pages; the repo's only build step

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,6 +161,34 @@ usually has no null columns to inherit through — it holds copies instead. The
 chip therefore appears mainly on types created before seeding, or through the
 API. See [ADR 0003](docs/adr/0003-voucher-type-editor-organised-by-surface.md).
 
+## Voucher expiry
+
+Terms describing how close a voucher is to its expiry date. Implemented in
+`vouchers/expiry-flag.js` and, for the dashboard counter, in the payments
+Worker's `GET /v1/vouchers/stats`.
+
+### Expiring soon
+
+A voucher that is **still usable** and whose expiry falls within the next **30
+days**, counting from today in Perth. Both halves are load-bearing: a cancelled
+or fully redeemed voucher is not usable and never qualifies, a voucher with no
+expiry date never qualifies, and one that has *already* expired is **expired**,
+not expiring — it has its own status and must not read as a caution about
+something yet to happen.
+
+A voucher expiring **today** is expiring soon, not expired: it is redeemable all
+day. That boundary is why the comparison is `>=` today rather than `>`.
+
+There is exactly **one** definition, deliberately. It is stated twice — the
+dashboard counter derives it in the Worker, the detail-view flag derives it in
+the browser — and the two are matched down to the boundary. A page that counted
+"3 vouchers expiring in the next 30 days" and then showed a voucher inside that
+window without the flag would undermine both numbers, so the window moves in
+both places or neither.
+
+*Avoid*: "expiring", "nearly expired", "due" when you mean this. The dashboard,
+the detail flag and this glossary all read *expiring soon*.
+
 ## Voucher hub build version
 
 Terms describing how the hub identifies itself. Implemented in

--- a/vouchers/expiry-flag.js
+++ b/vouchers/expiry-flag.js
@@ -1,0 +1,47 @@
+// vouchers/expiry-flag.js
+// Whether a voucher is close enough to expiry that the detail view should say
+// so. Pure on purpose — no DOM, no clock — so the caller supplies "today" and
+// the boundaries are unit-testable.
+//
+// This deliberately answers the same question, the same way, as the dashboard's
+// "expiring in the next 30 days" counter, which the payments Worker computes in
+// GET /v1/vouchers/stats. Two places on the same page disagreeing about what
+// "soon" means is worse than only one of them saying anything, so the window and
+// the predicate below are both matched to it. If either moves, the Worker's
+// expiringSoonCount moves with it.
+
+export const EXPIRING_SOON_DAYS = 30;
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+// 'YYYY-MM-DD' is fixed-width and zero-padded, so a string compare is a date
+// compare — the same reason the search filters use one. UTC arithmetic is safe
+// here because Western Australia has never observed daylight saving: the Perth
+// date 30×24h from now (what the Worker computes) and today's Perth date plus
+// 30 calendar days are always the same day.
+export function addDays(isoDate, days) {
+  if (!ISO_DATE.test(isoDate)) return '';
+  const d = new Date(`${isoDate}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export function isExpiringSoon(voucher, today) {
+  if (!voucher || !ISO_DATE.test(String(today))) return false;
+
+  // Cancelled and fully redeemed vouchers carry their own status and are not
+  // usable, so they never read as expiring — matching the Worker, which counts
+  // only status=eq.active. The stored status is NOT trusted for expiry itself:
+  // the book is full of rows still marked 'active' that lapsed years ago, and
+  // the window below is what excludes them.
+  if (voucher.status !== 'active') return false;
+
+  // The column is a date, but tolerate a timestamp the way the rest of the page
+  // does rather than silently dropping the flag if the API ever sends one.
+  const expiry = String(voucher.expiry_date || '').slice(0, 10);
+  if (!ISO_DATE.test(expiry)) return false;
+
+  // >= today, not > : a voucher expiring today is redeemable all day, so it is
+  // still expiring rather than already expired. Same boundary as the Worker's.
+  return expiry >= today && expiry <= addDays(today, EXPIRING_SOON_DAYS);
+}

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -57,6 +57,12 @@
     // file.
     import * as versionDisplay from './version-display.js?v=1';
     window.versionDisplay = versionDisplay;
+    // Same rule for the ?v= here. A stale cached copy of this one costs the
+    // "expiring soon" flag beside the expiry date and nothing else, so
+    // isExpiringSoon() treats a missing export as "do not flag" rather than
+    // throwing on every render of the detail view.
+    import * as expiryFlag from './expiry-flag.js?v=1';
+    window.expiryFlag = expiryFlag;
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
@@ -1206,7 +1212,8 @@
                     <div><dt class="text-[0.62rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1">Type</dt><dd class="text-neutral-700" x-text="voucher?._type_name || voucher?.voucher_type_id || '—'"></dd></div>
                     <div x-show="voucher?._item_name || voucher?.voucher_item_id"><dt class="text-[0.62rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1">Item</dt><dd class="text-neutral-700" x-text="voucher?._item_name || voucher?.voucher_item_id"></dd></div>
                     <div><dt class="text-[0.62rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1">Issued</dt><dd class="text-neutral-700" x-text="fmtDate(voucher?.issued_date)"></dd></div>
-                    <div><dt class="text-[0.62rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1">Expires</dt><dd class="text-neutral-700" x-text="fmtDate(voucher?.expiry_date)"></dd></div>
+                    <div><dt class="text-[0.62rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1">Expires</dt><dd class="text-neutral-700 flex items-center gap-2 flex-wrap"><span x-text="fmtDate(voucher?.expiry_date)"></span><span x-show="isExpiringSoon(voucher)"
+                      class="inline-flex items-center px-2 py-0.5 rounded-full text-[0.67rem] font-semibold uppercase tracking-wide bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/20">Expiring soon</span></dd></div>
                     <div x-show="voucher?.reason"><dt class="text-[0.62rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1">Reason</dt><dd class="text-neutral-700" x-text="voucher?.reason"></dd></div>
                   </dl>
                 </section>
@@ -4928,6 +4935,14 @@
           expired:   'bg-amber-50 text-amber-700 ring-amber-600/20',
           cancelled: 'bg-rose-50 text-rose-700 ring-rose-600/20',
         })[s] || 'bg-neutral-100 text-neutral-500 ring-neutral-500/20';
+      },
+
+      // Caution beside the expiry date when a still-usable voucher is inside the
+      // dashboard's 30-day expiring-soon window. The rule lives in expiry-flag.js
+      // so it can be unit tested against the Worker's; read through window and
+      // guarded, so a stale cached copy loses the flag rather than the panel.
+      isExpiringSoon(v) {
+        return !!window.expiryFlag?.isExpiringSoon?.(v, this.perthToday());
       },
 
       // A voucher is "partially redeemed" when it's still usable (active) but some

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -775,7 +775,7 @@
            holding everything else. See vouchers#54. -->
       <nav class="flex flex-col gap-1.5 sm:items-end">
         <div class="flex items-center gap-1.5 flex-wrap sm:justify-end">
-        <button @click="view='search'; stopScannerIfActive()"
+        <button @click="goSearch()"
           :class="view==='search' ? 'bg-white/25 border-white/50 text-white font-semibold' : 'bg-white/[0.12] border-white/30 text-white hover:bg-white/[0.22]'"
           class="px-4 py-2 rounded-xl border text-[0.9rem] font-semibold transition-all inline-flex items-center gap-1.5">
           <span class="nav-icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="6.5"/><path d="m16 16 4 4"/></svg></span>
@@ -1106,7 +1106,7 @@
 
     <!-- ── Detail ────────────────────────────────────────────────────────── -->
     <div x-show="view==='detail'">
-      <button @click="view = detailOrigin === 'reports' ? 'reports' : 'search'"
+      <button @click="backFromDetail()"
         class="flex items-center gap-1.5 text-sm text-neutral-500 hover:text-neutral-800 mb-5 transition-colors">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M15 19l-7-7 7-7"/>
@@ -1733,7 +1733,7 @@
     <!-- ── QR scan ────────────────────────────────────────────────────────── -->
     <div x-show="view==='scan'">
       <div class="flex items-center gap-3 mb-5">
-        <button @click="stopScannerIfActive(); view='search'"
+        <button @click="goSearch()"
           class="flex items-center gap-1.5 text-sm text-neutral-500 hover:text-neutral-800 transition-colors">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M15 19l-7-7 7-7"/>
@@ -3518,6 +3518,11 @@
       // Background refresh
       _lastRefresh: 0,
       _refreshTimer: null,
+      // Raised when something we did makes the held search results wrong — today
+      // that is issuing a voucher, which belongs at the top of the default
+      // listing the moment staff go looking for it. Landing on the search view
+      // with this up refreshes past the one-minute throttle. See vouchers#67.
+      _searchStale: false,
 
       // Reports
       reportTab: 'today',
@@ -4308,7 +4313,7 @@
             this.report.redeemed = window.deleteLogic.withoutVoucher(this.report.redeemed, code);
           }
           this.voucher = null;
-          this.view = this.detailOrigin === 'reports' ? 'reports' : 'search';
+          this.backFromDetail();
           // The dashboard counters we are about to land back on counted this
           // voucher. Re-read them rather than leave visibly wrong totals sitting
           // there until the next five-minute tick.
@@ -4564,6 +4569,10 @@
             }),
           });
           this.showToast(this.createdVoucher.voucher_id + ' created');
+          // The list behind us no longer has everything in it. Set here rather
+          // than refreshing now: the create form stays open for the next
+          // voucher, and refreshData() declines to run while it is.
+          this._searchStale = true;
           // Cleared with the customer fields, not kept for the next voucher: the
           // form stays open and usable after a create, so whoever steps up next
           // would otherwise inherit this name without it ever leaving the box.
@@ -4583,6 +4592,24 @@
       },
 
       // ── Header nav ───────────────────────────────────────────────────────
+      // The one way into the search view. Switching views does not re-fetch on
+      // its own, so anything that landed here after issuing a voucher used to
+      // show a list from before it existed — see vouchers#67. refreshData()
+      // rather than search(): it sends the filters that are in the bar and
+      // leaves the current page alone, where search() resets both.
+      goSearch() {
+        this.stopScannerIfActive();
+        this.view = 'search';
+        this.refreshData({ force: this._searchStale });
+      },
+
+      // Leaving the detail view returns to whichever list opened it. Shared by
+      // the back button and the post-delete return so the two cannot drift.
+      backFromDetail() {
+        if (this.detailOrigin === 'reports') { this.view = 'reports'; return; }
+        this.goSearch();
+      },
+
       // What the hamburger calls itself: the section it is currently hiding, or
       // nothing when the open view is one still visible in the header. Read
       // through window and guarded, so a browser holding a stale cached
@@ -4649,9 +4676,15 @@
 
       // Quietly re-fetch what's on screen: no spinners, no pagination reset,
       // never while a modal is open or the create form is in use.
-      async refreshData() {
+      //
+      // force skips the throttle, for the one case the throttle gets wrong: a
+      // voucher issued seconds ago, where waiting out the minute means staff
+      // look at a list that is missing it. It does not skip the modal and
+      // create-form guards — those are about not moving the ground under
+      // someone mid-task, which a deliberate navigation does not change.
+      async refreshData({ force = false } = {}) {
         if (!this.isAuthed()) return;
-        if (Date.now() - this._lastRefresh < 60 * 1000) return;
+        if (!force && Date.now() - this._lastRefresh < 60 * 1000) return;
         if (this._anyModalOpen() || this.view === 'create') return;
         this._lastRefresh = Date.now();
         this.loadDashStats();
@@ -4666,6 +4699,9 @@
             if (recent) p.set('limit', '99');
             this.results = await this.api('/v1/vouchers/search?' + p.toString());
             this.recentListing = recent;
+            // Only now: a refresh that threw still holds the old list, so the
+            // flag has to survive it and try again on the next landing.
+            this._searchStale = false;
           } else if (this.view === 'reports') {
             this.report = await this.api('/v1/vouchers/report?type=' + this.reportTab);
           }

--- a/vouchers/test/expiry-flag.test.js
+++ b/vouchers/test/expiry-flag.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { addDays, EXPIRING_SOON_DAYS, isExpiringSoon } from '../expiry-flag.js';
+
+const TODAY = '2026-08-10';
+const active = (expiry_date) => ({ status: 'active', expiry_date });
+
+describe('addDays', () => {
+  test('crosses a month end', () => {
+    expect(addDays('2026-08-10', 30)).toBe('2026-09-09');
+  });
+
+  test('crosses a year end', () => {
+    expect(addDays('2026-12-20', 30)).toBe('2027-01-19');
+  });
+
+  test('handles a leap day', () => {
+    expect(addDays('2028-02-01', 30)).toBe('2028-03-02');
+  });
+
+  test('refuses anything that is not a plain date', () => {
+    for (const bad of ['', '2026-8-10', '10/08/2026', '2026-08-10T00:00:00Z', null, undefined]) {
+      expect(addDays(bad, 30)).toBe('');
+    }
+  });
+});
+
+describe('isExpiringSoon — the window', () => {
+  test('a voucher expiring today still counts: it is redeemable all day', () => {
+    expect(isExpiringSoon(active(TODAY), TODAY)).toBe(true);
+  });
+
+  test('the far edge of the window is inside it', () => {
+    expect(isExpiringSoon(active(addDays(TODAY, EXPIRING_SOON_DAYS)), TODAY)).toBe(true);
+  });
+
+  test('one day past the window is not', () => {
+    expect(isExpiringSoon(active(addDays(TODAY, EXPIRING_SOON_DAYS + 1)), TODAY)).toBe(false);
+  });
+
+  test('yesterday has already expired, and expired is not "expiring"', () => {
+    // The whole point of the separation: an expired voucher has its own status
+    // and must not also read as a caution about something yet to happen.
+    expect(isExpiringSoon(active(addDays(TODAY, -1)), TODAY)).toBe(false);
+  });
+
+  test('a voucher that lapsed years ago is not dragged back in by a stale status', () => {
+    expect(isExpiringSoon(active('2019-01-01'), TODAY)).toBe(false);
+  });
+
+  test('the window is the 30 days the dashboard counts', () => {
+    expect(EXPIRING_SOON_DAYS).toBe(30);
+  });
+});
+
+describe('isExpiringSoon — which vouchers qualify', () => {
+  test('no expiry never qualifies', () => {
+    for (const nothing of [null, '', undefined]) {
+      expect(isExpiringSoon(active(nothing), TODAY)).toBe(false);
+    }
+  });
+
+  test.each(['cancelled', 'redeemed', 'expired'])('a %s voucher is not usable, so it never flags', (status) => {
+    expect(isExpiringSoon({ status, expiry_date: addDays(TODAY, 5) }, TODAY)).toBe(false);
+  });
+
+  test('a partly spent but still active voucher does flag — it is still usable', () => {
+    expect(isExpiringSoon({ status: 'active', expiry_date: addDays(TODAY, 5), balance: 20, value: 50 }, TODAY))
+      .toBe(true);
+  });
+
+  test('a timestamp in the expiry column is read as its date', () => {
+    expect(isExpiringSoon(active(addDays(TODAY, 5) + 'T00:00:00+08:00'), TODAY)).toBe(true);
+  });
+
+  test('nothing is flagged without a voucher or a usable today', () => {
+    expect(isExpiringSoon(null, TODAY)).toBe(false);
+    expect(isExpiringSoon(active(TODAY), '')).toBe(false);
+    expect(isExpiringSoon(active(TODAY), undefined)).toBe(false);
+  });
+});
+
+describe('wiring into the page', () => {
+  const page = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+  test('the module is imported and published like the others', () => {
+    expect(page).toMatch(/import \* as expiryFlag from '\.\/expiry-flag\.js\?v=1';/);
+    expect(page).toMatch(/window\.expiryFlag = expiryFlag;/);
+  });
+
+  test('the flag degrades to nothing if that module is missing', () => {
+    // A stale cached copy costs the flag and nothing else — it must never be
+    // able to throw on every render of the detail view.
+    const method = page.slice(page.indexOf('isExpiringSoon(v) {'));
+    expect(method.slice(0, 200)).toMatch(/window\.expiryFlag\?\.isExpiringSoon\?\./);
+  });
+
+  test('today is Perth today, not the machine clock', () => {
+    const method = page.slice(page.indexOf('isExpiringSoon(v) {'));
+    expect(method.slice(0, 200)).toMatch(/this\.perthToday\(\)/);
+  });
+
+  test('it renders beside the expiry date', () => {
+    const start = page.indexOf('>Expires</dt>');
+    expect(start).toBeGreaterThan(-1);
+    const expiresRow = page.slice(start, page.indexOf('</div>', start));
+    expect(expiresRow).toMatch(/fmtDate\(voucher\?\.expiry_date\)/);
+    expect(expiresRow).toMatch(/x-show="isExpiringSoon\(voucher\)"/);
+    expect(expiresRow).toMatch(/Expiring soon/);
+    // Amber: a caution, matching the dashboard's expiring-soon counter. Not
+    // rose — nothing has gone wrong yet.
+    expect(expiresRow).toMatch(/amber/);
+    expect(expiresRow).not.toMatch(/rose|red-/);
+  });
+});

--- a/vouchers/test/search-freshness.test.js
+++ b/vouchers/test/search-freshness.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Landing on the search view must not show a list that predates the voucher you
+// just issued. The wiring lives inline in index.html's Alpine component where no
+// unit test can call it, so it is pinned against the page source instead — the
+// same approach as created-by-attribution.test.js.
+//
+// The fetch itself was never the problem: refreshData() already sends the
+// filters that are in the search bar and leaves the current page alone. What
+// this pins is *when* it runs. See vouchers#67.
+
+const page = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+// Slicing on an anchor that has moved yields a one-character string and a
+// failure that reads as a fault in the page rather than in this file.
+function between(startAnchor, endAnchor) {
+  const start = page.indexOf(startAnchor);
+  if (start < 0) throw new Error('could not find ' + startAnchor + ' in index.html');
+  const end = page.indexOf(endAnchor, start);
+  if (end < 0) throw new Error('could not find ' + endAnchor + ' after ' + startAnchor);
+  return page.slice(start, end);
+}
+
+describe('a create marks the search list stale', () => {
+  test('the flag is raised after the POST resolves, not before it', () => {
+    const submitCreate = between('async submitCreate()', '// ── Header nav');
+    const posted = submitCreate.indexOf("this.createdVoucher = await this.api('/v1/vouchers'");
+    const flagged = submitCreate.search(/this\._searchStale = true;/);
+    expect(posted).toBeGreaterThan(-1);
+    expect(flagged).toBeGreaterThan(posted);
+  });
+
+  test('the flag starts down, so a first load does not double-fetch', () => {
+    expect(page).toMatch(/_searchStale: false,/);
+  });
+});
+
+describe('landing on search refreshes a stale list', () => {
+  test('goSearch() forces past the throttle exactly when the list is stale', () => {
+    // The method definition, not the click handlers that call it.
+    const goSearch = between('goSearch() {', '},');
+    expect(goSearch).toMatch(/this\.view = 'search';/);
+    expect(goSearch).toMatch(/refreshData\(\{ force: this\._searchStale \}\)/);
+  });
+
+  test('it refreshes rather than re-running the search', () => {
+    // search() resets the pagination and re-reads the filter inputs; refreshData
+    // deliberately does neither. Landing on the view must not throw away the
+    // page the user was on.
+    expect(between('goSearch() {', '},')).not.toMatch(/this\.search\(/);
+  });
+
+  test('the throttle is bypassed only when forced', () => {
+    const refreshData = between('async refreshData(', '// ── Sort & pagination');
+    expect(refreshData).toMatch(/async refreshData\(\{ force = false \} = \{\}\)/);
+    expect(refreshData).toMatch(/if \(!force && Date\.now\(\) - this\._lastRefresh < 60 \* 1000\) return;/);
+  });
+
+  test('the flag comes down only after a search fetch that actually succeeded', () => {
+    const refreshData = between('async refreshData(', '// ── Sort & pagination');
+    const fetched = refreshData.indexOf("this.results = await this.api('/v1/vouchers/search?'");
+    const cleared = refreshData.search(/this\._searchStale = false;/);
+    expect(fetched).toBeGreaterThan(-1);
+    // After the await: a refresh that threw leaves the flag up so the next
+    // landing tries again, rather than settling on a list it never replaced.
+    expect(cleared).toBeGreaterThan(fetched);
+  });
+});
+
+describe('every route into the search view goes through goSearch()', () => {
+  test('no click handler sets the view directly', () => {
+    // A future button that assigns view='search' itself would skip the refresh
+    // and reopen this bug on one path while the others stayed fixed.
+    const direct = [...page.matchAll(/@click="([^"]*\bview\s*=\s*['"]search['"][^"]*)"/g)].map((m) => m[1]);
+    expect(direct).toEqual([]);
+  });
+
+  test('the header nav and the scanner both call it', () => {
+    const navButton = between('<nav class="flex flex-col gap-1.5 sm:items-end">', 'goCreate()');
+    expect(navButton).toMatch(/@click="goSearch\(\)/);
+    expect(between("<div x-show=\"view==='scan'\">", '</button>')).toMatch(/goSearch\(\)/);
+  });
+
+  test('leaving the detail view returns through one shared path', () => {
+    // The back button and the post-delete return both land on whichever list
+    // opened the detail view; sharing the method keeps them from drifting.
+    expect(between("<div x-show=\"view==='detail'\">", '</button>')).toMatch(/@click="backFromDetail\(\)"/);
+    expect(between('async submitDelete()', 'catch (e)')).toMatch(/this\.backFromDetail\(\);/);
+    const backFromDetail = between('backFromDetail() {', '},');
+    expect(backFromDetail).toMatch(/this\.view = 'reports';/);
+    expect(backFromDetail).toMatch(/this\.goSearch\(\);/);
+  });
+});


### PR DESCRIPTION
Two small voucher hub items from QA. Separate commits; either can be dropped without touching the other.

### vouchers#67 — a new voucher was missing from the search list

Switching views only changed which one was on screen, so returning to search after issuing a voucher showed a list fetched before that voucher existed. The background refresh would have caught it eventually, but it is throttled to a minute and deliberately skipped while the create form is open — the two windows staff are most likely to be looking in.

Issuing a voucher now marks the held list stale, and landing on the search view refreshes past the throttle when it is. It calls `refreshData()`, not `search()`, so the filters in the bar are sent as they are and the current page is left alone — the issue's two "don't break this" notes.

Every route into the view goes through `goSearch()`, and the two ways out of the detail view now share `backFromDetail()`, so no path keeps the old behaviour on its own. A test asserts no click handler sets `view='search'` directly, which is how a future button would quietly reopen this on one path.

### vouchers#68 — "expiring soon" on the detail view

A still-usable voucher expiring within 30 days now carries an amber pill beside its expiry date.

The rule is the dashboard's rather than a second one: same window, same boundaries as the payments Worker's `expiring_soon_count`, including that a voucher expiring **today** is expiring rather than expired — it is redeemable all day. Cancelled and redeemed vouchers never flag; nor does a voucher with no expiry; nor does one that already lapsed, which has its own status.

It is extracted to `expiry-flag.js` so those boundaries are unit tested, and read through `window` like the other modules — a stale cached copy costs the flag, not the panel. Added to `CONTEXT.md` as one definition, since it is now stated in two codebases.

### Verification

- `npx vitest run` — 199 pass. The one failure, `version.test.js › falls back to dev outside a git repository`, **fails identically on a clean `main`** on this machine: `$HOME` is itself a git repo, so the "outside a repo" temp dir isn't one. Unrelated to this branch, though it may be worth pinning the test's temp dir.
- Driven in a real browser against a local copy of the page: with nothing stale, landing on search makes no request; after a create it refetches immediately, carries the active filter (`?q=alice`) and stays on page 3. The flag was checked at every boundary in the live DOM — 30 days shows, 31 does not, today shows, yesterday does not, and cancelled/redeemed/no-expiry never do.
- Not verified against the live site — the zone is behind Access.

### Note on deploying

`main` is production here, so merging publishes. Both changes are staff-facing only.

Closes urbanjungleirc/vouchers#67
Closes urbanjungleirc/vouchers#68

🤖 Generated with [Claude Code](https://claude.com/claude-code)