### PR TITLE
Draw the stats charts once, and stop them vanishing

### DIFF
--- a/vouchers/stats.html
+++ b/vouchers/stats.html
@@ -401,8 +401,12 @@
     ::-webkit-scrollbar-thumb { background: rgba(139, 28, 35, 0.2); border-radius: 3px; }
   </style>
 </head>
+<!-- No x-init here. Alpine calls a component's own init() for us, so naming it
+     in x-init as well ran the whole bootstrap twice: two fetches, and a second
+     draw() that destroyed four charts while their opening animation was still
+     running. See vouchers#69. -->
 <body class="bg-neutral-100 text-neutral-900 min-h-screen antialiased font-sans"
-  x-data="voucherStats()" x-init="init()" x-cloak>
+  x-data="voucherStats()" x-cloak>
 
   <!-- ── Header ──────────────────────────────────────────────────────────── -->
   <header class="hub-header text-white">
@@ -904,6 +908,13 @@
       },
     };
 
+    // The live Chart.js instances, deliberately held in this closure rather than
+    // on the component below. Alpine deep-proxies everything the component
+    // holds, and Chart.js resolving its options through that proxy recurses
+    // until the stack gives out. Nothing in the template reads them, so they
+    // have no business being reactive.
+    const charts = {};
+
     return {
       WORKER,
       IS_LOCAL,
@@ -913,7 +924,6 @@
       rangeError: '',
       types: [],
       data: null,
-      charts: {},
       warnedClasses: new Set(),
       moneyMode: 'dollars',
       filters: { from: '', to: '', type: '', class: '' },
@@ -1105,11 +1115,10 @@
         } catch (e) {
           this.error = e.message;
           // A failed refetch must not leave the previous slice on screen under
-          // a filter bar that no longer describes it — drop the data and the
-          // charts so the page shows the error state, not a mislabelled one.
+          // a filter bar that no longer describes it — drop the data and empty
+          // the charts so the page shows the error state, not a mislabelled one.
           this.data = null;
-          Object.values(this.charts).forEach((c) => c?.destroy());
-          this.charts = {};
+          this.blankCharts();
         } finally {
           this.loading = false;
           this.refreshing = false;
@@ -1309,12 +1318,49 @@
         return '$' + n;
       },
 
+      // Put a chart on screen, reusing the one already on that canvas.
+      //
+      // Chart.js runs every animating chart through ONE shared rAF loop. A chart
+      // destroyed while it still has animations queued stays in that loop, which
+      // then calls draw() on the canvas it has just released — and the resulting
+      // exception escapes mid-iteration, taking the loop down for EVERY chart on
+      // the page, not just that one. Nothing restarts it. That is how a single
+      // fast re-render used to leave all four cards blank until a reload.
+      //
+      // So nothing here destroys a chart: a redraw updates the existing one in
+      // place, which is also what makes the transition animate instead of
+      // blinking. See vouchers#69.
+      paint(key, canvas, config) {
+        const chart = charts[key];
+        // canvas identity, not mere presence: a chart whose canvas has gone is
+        // no use to us, and reusing it would draw into nothing.
+        if (chart && chart.canvas === canvas) {
+          chart.data = config.data;
+          chart.options = config.options;
+          chart.update();
+          return;
+        }
+        charts[key] = new Chart(canvas, config);
+      },
+
+      // Leave the charts empty but alive. The alternative — destroying them —
+      // is the crash described on paint(), and it would have to happen on
+      // exactly the paths that are already going wrong. An empty chart on a
+      // hidden canvas costs nothing and is refilled in place by the next paint.
+      // 'none' skips the animation, so this queues nothing for the shared loop.
+      blankCharts() {
+        for (const chart of Object.values(charts)) {
+          if (!chart?.canvas) continue;
+          chart.data = { labels: [], datasets: [] };
+          chart.update('none');
+        }
+      },
+
       draw() {
         // Nothing in the window: the empty state is showing and the canvases are
         // display:none, so there is nothing to size a chart against.
         if (!this.hasRows()) {
-          Object.values(this.charts).forEach((c) => c?.destroy());
-          this.charts = {};
+          this.blankCharts();
           return;
         }
         const rows = this.byMonth();
@@ -1377,8 +1423,7 @@
             return `${ctx.dataset.label}: ${Math.round(n)} voucher${Math.round(n) === 1 ? '' : 's'}`;
           },
         };
-        this.charts.money?.destroy();
-        this.charts.money = new Chart(this.$refs.moneyChart, {
+        this.paint('money', this.$refs.moneyChart, {
           type: 'bar',
           data: { labels, datasets: moneyDatasets },
           options: moneyOpts,
@@ -1393,8 +1438,7 @@
           title: titleCb,
           label: (ctx) => `${ctx.dataset.label}: ${self.money(ctx.raw)}`,
         };
-        this.charts.liability?.destroy();
-        this.charts.liability = new Chart(this.$refs.liabilityChart, {
+        this.paint('liability', this.$refs.liabilityChart, {
           type: 'bar',
           data: {
             labels,
@@ -1436,8 +1480,7 @@
           title: titleCb,
           label: (ctx) => `${ctx.dataset.label}: ${self.money(ctx.raw)}`,
         };
-        this.charts.redeemed?.destroy();
-        this.charts.redeemed = new Chart(this.$refs.redeemedChart, {
+        this.paint('redeemed', this.$refs.redeemedChart, {
           type: 'bar',
           data: {
             labels,
@@ -1500,8 +1543,7 @@
             return out;
           },
         };
-        this.charts.cohort?.destroy();
-        this.charts.cohort = new Chart(this.$refs.cohortChart, {
+        this.paint('cohort', this.$refs.cohortChart, {
           type: 'bar',
           data: {
             labels: cohorts.map((c) => self.cohortLabel(c)),

--- a/vouchers/test/stats-chart-lifecycle.test.js
+++ b/vouchers/test/stats-chart-lifecycle.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// The stats page draws four Chart.js charts. Three properties keep them on
+// screen, and all three are invisible in review — each one, broken, produces the
+// same symptom: cards that flash and then sit blank until a reload. They live
+// inline in stats.html where no unit test can call them, so they are pinned
+// against the page source. See vouchers#69.
+
+const page = readFileSync(new URL('../stats.html', import.meta.url), 'utf8');
+
+describe('the page bootstraps exactly once', () => {
+  test('x-init does not call init() as well as Alpine', () => {
+    // Alpine calls a component's own init() for us. Naming it in x-init too ran
+    // the whole bootstrap twice — two fetches, and a second draw() that
+    // destroyed four charts mid-animation.
+    const body = page.slice(page.indexOf('<body'), page.indexOf('>', page.indexOf('<body')));
+    expect(body).toMatch(/x-data="voucherStats\(\)"/);
+    expect(body).not.toMatch(/x-init/);
+  });
+
+  test('the component still defines the init() Alpine calls', () => {
+    // The other half of the pair: if init() were renamed, removing x-init would
+    // stop the page bootstrapping at all.
+    expect(page).toMatch(/\n\s+async init\(\) \{/);
+  });
+});
+
+describe('a redraw never releases a canvas', () => {
+  test('nothing destroys a chart', () => {
+    // Chart.js runs every animating chart through one shared rAF loop. A chart
+    // destroyed while it still has animations queued stays in that loop, which
+    // then calls draw() on the canvas it just released; the exception escapes
+    // mid-iteration and kills the loop for EVERY chart on the page, with
+    // nothing to restart it. One fast re-render blanked all four cards.
+    expect(page).not.toMatch(/\.destroy\(\)/);
+  });
+
+  test('paint() updates the chart already on that canvas', () => {
+    const paint = page.slice(page.indexOf('paint(key, canvas, config) {'));
+    const body = paint.slice(0, paint.indexOf('\n      },'));
+    // Canvas identity, not mere presence — a chart whose canvas has gone would
+    // otherwise be reused to draw into nothing.
+    expect(body).toMatch(/chart\.canvas === canvas/);
+    expect(body).toMatch(/chart\.update\(\)/);
+    expect(body).toMatch(/new Chart\(canvas, config\)/);
+  });
+
+  test('every chart goes through paint()', () => {
+    const created = [...page.matchAll(/new Chart\(/g)].length;
+    expect(created).toBe(1);            // the one inside paint()
+    for (const key of ['money', 'liability', 'redeemed', 'cohort']) {
+      expect(page).toMatch(new RegExp(`this\\.paint\\('${key}',`));
+    }
+  });
+
+  test('clearing the charts empties them instead, without animating', () => {
+    const blank = page.slice(page.indexOf('blankCharts() {'));
+    const body = blank.slice(0, blank.indexOf('\n      },'));
+    expect(body).toMatch(/datasets: \[\]/);
+    // 'none' queues nothing for the shared loop.
+    expect(body).toMatch(/update\('none'\)/);
+  });
+
+  test('both teardown paths use it', () => {
+    // The empty window, and a refetch that failed — the second must still drop
+    // the stale slice, or the page shows one filter bar describing another.
+    const draw = page.slice(page.indexOf('      draw() {'));
+    expect(draw.slice(0, 400)).toMatch(/if \(!this\.hasRows\(\)\) \{\s*\n\s*this\.blankCharts\(\);/);
+    const load = page.slice(page.indexOf('async load() {'), page.indexOf('// ── Shaping'));
+    expect(load).toMatch(/this\.data = null;\s*\n\s*this\.blankCharts\(\);/);
+  });
+});
+
+describe('the chart instances stay out of Alpine', () => {
+  test('they live in the factory closure, not on the component', () => {
+    // Alpine deep-proxies everything the component holds, and Chart.js
+    // resolving its options through that proxy recurses until the stack gives
+    // out — a hard crash on the first in-place update.
+    expect(page).toMatch(/\n    const charts = \{\};/);
+    const returned = page.slice(page.indexOf('    return {\n      WORKER,'));
+    expect(returned.slice(0, 600)).not.toMatch(/^\s*charts: \{\},$/m);
+  });
+});


### PR DESCRIPTION
Fixes vouchers#69. Reproduced deterministically, then fixed and re-verified in a real browser.

### What was happening

Two separate faults, one symptom each.

**The flicker.** The page bootstrapped twice. Alpine calls a component's own `init()` automatically, and `<body>` named it in `x-init` as well — so every load ran two `voucher-types` fetches, two `analytics` fetches, and two `draw()` passes. The second pass destroyed all four charts and rebuilt them.

**The blank cards.** The second draw landed while the first was still animating. Chart.js runs every animating chart through **one shared rAF loop**; a chart destroyed with animations still queued stays in that loop, which then calls `draw()` → `clear()` on the canvas it has just released:

```
TypeError: Cannot read properties of null (reading 'getContext')
    at Te (chart.umd.min.js)          <- clearCanvas
    at An.clear (chart.umd.min.js)
    at An.draw  (chart.umd.min.js)
    at chart.umd.min.js:13:6948       <- the animator
    at Map.forEach (<anonymous>)
```

The throw escapes mid-iteration, so the loop dies for **every** chart on the page, not just the destroyed one. Nothing restarts it. That is why the failure is all-or-nothing and survives until a reload — and why it looked intermittent: it only bites when the second draw lands inside the first animation.

### What changed

1. **Removed the duplicate `x-init="init()"`.** This alone fixes the reported load path.
2. **A redraw no longer releases a canvas.** Removing the double init does *not* fix the mechanism — I confirmed the same crash is reachable today by clicking Dollars/Vouchers twice inside the opening animation, which leaves all four cards blank. So `paint()` updates the chart already on that canvas, and the two teardown paths (empty window, failed refetch) empty the charts instead of destroying them. There is now no `destroy()` on the page.
3. **The instances moved into the factory closure.** Alpine deep-proxies whatever the component holds, and Chart.js resolving options through that proxy recurses until the stack gives out. The in-place update is what made that reachable; nothing in the template reads them.

Both behaviours the issue asked to preserve are untouched — verified, not assumed. Re-applying a filter still holds the previous render, and a failed refetch still drops the stale slice.

### Verification

Driven against a local stub of the Worker, with a frame-by-frame recorder sampling actual canvas pixels.

| | before | after |
|---|---|---|
| fetches per load | 2 + 2 | 1 + 1 |
| charts destroyed on load | 4 | 0 |
| exceptions | 1 | 0 |
| cards drawn, then blank forever | yes | no |
| rapid Dollars/Vouchers toggle | all 4 blank, animator dead | all 4 drawn, no errors |
| empty window → back to data | — | clears, refills |
| failed refetch | — | `data: null`, charts hidden and emptied (`datasets: 0`), recovers on the next success |

Regression tests are in `test/stats-chart-lifecycle.test.js`; 7 of its 8 fail against the unfixed page (the 8th is a both-ways invariant). Full suite: 177 pass. The one failure, `version.test.js › falls back to dev outside a git repository`, **fails identically on a clean `main`** on this machine — `$HOME` is itself a git repo, so the "outside a repo" temp dir isn't one. Unrelated to this branch.

Not verified against the live site — the zone is behind Access.

### Note

`main` is production here, so merging publishes. The hub (`vouchers/index.html`) has the **same** duplicate `x-init="init()"`, which double-fetches on every load; it has no canvases so it never showed this symptom. Filed separately rather than widened into this PR.

Closes urbanjungleirc/vouchers#69

🤖 Generated with [Claude Code](https://claude.com/claude-code)