### PR TITLE
Unify the hero crop control, and give the backdrop a phone frame

### DIFF
--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -2660,9 +2660,9 @@
                      bubble. A bubble has to be opened to be read, and a second copy of
                      the rule is what let the old one drift into naming the wrong band.
                      Same constant renders in the image picker. -->
-                <p class="text-[0.7rem] text-neutral-500 leading-relaxed">
+                <p x-show="heroArtworkCompositionRule()" class="text-[0.7rem] text-neutral-500 leading-relaxed">
                   <span class="font-semibold text-neutral-600">Composing artwork:</span>
-                  <span x-text="heroCompositionRule()"></span>
+                  <span x-text="heroArtworkCompositionRule()"></span>
                 </p>
                 <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
                   <div class="flex-1 min-w-[11rem]">
@@ -3357,7 +3357,7 @@
     // here and taking the whole component with it.
     const IMAGE_ROLES = {
       hero:       { field: 'hero_image_url',      title: 'Hero artwork library',
-                    rule: window.typeSurfaces?.HERO_COMPOSITION_RULE },
+                    rule: window.typeSurfaces?.HERO_ARTWORK_COMPOSITION_RULE },
       background: { field: 'hero_background_url', title: 'Hero background library' },
     };
 
@@ -5269,7 +5269,7 @@
 
       // The one rule string, for the crop control under the frames. The picker
       // reads the same constant off IMAGE_ROLES.hero.
-      heroCompositionRule() {
+      heroArtworkCompositionRule() {
         return IMAGE_ROLES.hero.rule || '';
       },
 

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -42,7 +42,7 @@
     window.deleteLogic = deleteLogic;
     // And here: bump it whenever type-surfaces.js gains or renames an export.
     // A stale cached copy would leave the type editor with no tabs to render.
-    import * as typeSurfaces from './type-surfaces.js?v=1';
+    import * as typeSurfaces from './type-surfaces.js?v=2';
     window.typeSurfaces = typeSurfaces;
     // Same rule again for the ?v= here. A stale cached copy of this one costs
     // only the label on the hamburger, so activeMenuLabel() degrades to '' and
@@ -2506,12 +2506,17 @@
             <!-- Preview first at the full width available, details under it. This
                  is the field where the judgement call is "does white type stay
                  readable over this photo", and a thumbnail cannot answer it. -->
-            <div class="rounded-xl border border-neutral-200 bg-white p-4">
+            <div class="rounded-xl border border-neutral-200 bg-white p-4 grid gap-3">
+              <!-- Both viewport shapes side by side, as the hero artwork control does,
+                   with the details on their own row underneath. The backdrop needs no
+                   composition rule — `cover` runs against a box whose height is
+                   content, so there is no fixed band to name — but the phone crop was
+                   only ever described, and describing a crop is not showing it. -->
               <div class="flex flex-wrap gap-4 items-start">
                 <!-- Capped by WIDTH, not height: a max-height would fight the aspect
                      ratio and crop the preview. 500px at 16:9 is 281px tall, which
                      is enough to judge the photo without owning the tab — and it
-                     leaves room for the details beside it rather than beneath. -->
+                     leaves room for the narrow frame beside it. -->
                 <div class="flex-1 min-w-[18rem] max-w-[500px]">
                   <div class="w-full aspect-[16/9] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
                     <img :src="typeForm.hero_background_url" x-show="typeForm.hero_background_url" alt=""
@@ -2523,8 +2528,28 @@
                     <div x-show="!typeForm.hero_background_url" class="w-full h-full"
                       :style="`background-image:${backdropFallbackCss()}`"></div>
                   </div>
-                  <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Backdrop · 16:9</p>
+                  <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Desktop · 16:9</p>
                 </div>
+                <!-- 4:5 is roughly the hero section's shape on a phone once the copy
+                     stack and the 21:9 artwork are stacked inside it (~390 x 460 CSS
+                     px at 390px wide; taller still without artwork). Deliberately a
+                     touch taller than measured, because this frame's whole job is to
+                     show the worse case, and a preview that flatters is the failure
+                     the crop map exists to fix.
+                     The label carries NO ratio: the real box is content-height, so
+                     there is not one to name, and inventing one for symmetry with the
+                     16:9 frame would be a number staff could not act on. -->
+                <div class="w-[10rem] shrink-0">
+                  <div class="w-full aspect-[4/5] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
+                    <img :src="typeForm.hero_background_url" x-show="typeForm.hero_background_url" alt=""
+                      class="w-full h-full object-cover" />
+                    <div x-show="!typeForm.hero_background_url" class="w-full h-full"
+                      :style="`background-image:${backdropFallbackCss()}`"></div>
+                  </div>
+                  <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Phone</p>
+                </div>
+              </div>
+              <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
                 <div class="flex-1 min-w-[11rem]">
                   <p class="text-sm font-semibold text-neutral-700 truncate"
                     x-text="imgMeta('hero_background_url').name || 'Brand colour gradient'"></p>
@@ -2533,13 +2558,13 @@
                   </p>
                   <p class="text-xs text-neutral-400" x-text="imgMeta('hero_background_url').size"></p>
                   <p class="text-xs text-neutral-400 mt-0.5" x-text="imgMeta('hero_background_url').used"></p>
-                  <div class="flex gap-2 mt-3">
-                    <button type="button" @click="openImgModal('background')"
-                      class="text-xs font-semibold px-3 py-1.5 rounded-lg bg-uj text-white hover:bg-uj-dark">Change image</button>
-                    <button type="button" @click="typeForm.hero_background_url = ''; refreshPreview()"
-                      x-show="typeForm.hero_background_url"
-                      class="text-xs font-semibold px-3 py-1.5 rounded-lg border border-neutral-200 text-neutral-600 hover:bg-neutral-50">Remove</button>
-                  </div>
+                </div>
+                <div class="flex gap-2 shrink-0">
+                  <button type="button" @click="openImgModal('background')"
+                    class="text-xs font-semibold px-3 py-1.5 rounded-lg bg-uj text-white hover:bg-uj-dark">Change image</button>
+                  <button type="button" @click="typeForm.hero_background_url = ''; refreshPreview()"
+                    x-show="typeForm.hero_background_url"
+                    class="text-xs font-semibold px-3 py-1.5 rounded-lg border border-neutral-200 text-neutral-600 hover:bg-neutral-50">Remove</button>
                 </div>
               </div>
               <p x-show="typeForm.hero_background_url && imgBroken['hero_background_url']"
@@ -2582,35 +2607,69 @@
 
             <!-- Hero artwork (sits beside the copy) -->
             <div>
-              <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero artwork<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Artwork shown beside the hero copy. Leave blank to show no artwork. Aim for 1200 × 900 — it's cropped to a wide strip on phones, so keep the subject in the middle.</span></span></label>
+              <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">Hero artwork<span class="help-tip" tabindex="0" role="note" aria-label="Help">?<span class="help-bubble">Artwork shown beside the hero copy. Leave blank to show no artwork. Aim for 1200 × 900.</span></span></label>
               <div class="rounded-xl border border-neutral-200 bg-white p-4 grid gap-3">
                 <!-- The crops stay side by side at every width — seeing them together
                      is the whole point — and they take the full width of the control,
-                     with the details on their own row underneath. -->
+                     with the details on their own row underneath.
+                     TWO frames, not three: the phone and the email render the same
+                     pixels now, so a third would repeat one of these and cut the
+                     desktop frame to a third of the width. -->
                 <div class="grid grid-cols-2 gap-3">
-                  <!-- desktop crop -->
+                  <!-- desktop crop: 4:3, centre-anchored, as the page renders it at
+                       md+. It is also the only frame that can honestly show what the
+                       narrow band discards, because it is the only one holding both
+                       regions — hence the band overlay below rather than on the 21:9
+                       frame, which would stop being a preview the moment it drew it. -->
                   <div>
-                    <div class="w-full aspect-[4/3] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
+                    <div class="relative w-full aspect-[4/3] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
                       <img :src="typeForm.hero_image_url" x-show="typeForm.hero_image_url" alt=""
                         class="w-full h-full object-cover"
                         x-on:load="imgBroken['hero_image_url'] = false"
                         x-on:error="imgBroken['hero_image_url'] = true" />
+                      <!-- A 21:9 band off the top of a 4:3 frame is exactly 57.14% of
+                           its height, whatever size the frame renders at — so the
+                           hairline is a constant, not a measurement. Absent on a blank
+                           frame: there is nothing there to annotate. -->
+                      <div x-show="typeForm.hero_image_url"
+                        class="absolute inset-x-0 bottom-0 top-[57.14%] bg-black/45 border-t border-dashed border-white/85 flex items-center justify-center">
+                        <span class="text-[0.6rem] font-semibold text-white px-1.5 text-center leading-tight">Cut on phones &amp; email</span>
+                      </div>
+                      <!-- Blank is the DEFAULT state on every type now, not an edge
+                           case, so a bare grey rectangle would read as broken. -->
+                      <div x-show="!typeForm.hero_image_url"
+                        class="absolute inset-0 flex items-center justify-center text-[0.65rem] text-neutral-400">No artwork</div>
                     </div>
                     <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Desktop · 4:3</p>
                   </div>
-                  <!-- mobile crop -->
+                  <!-- phone & email crop: 21:9 anchored to the TOP, matching both the
+                       live page (object-top) and the email banner. Centring this would
+                       be the original bug in miniature — a preview pointing one way
+                       while the surfaces crop the other. -->
                   <div>
-                    <div class="w-full aspect-[21/9] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
+                    <div class="relative w-full aspect-[21/9] rounded-xl overflow-hidden ring-1 ring-neutral-200 bg-neutral-100">
                       <img :src="typeForm.hero_image_url" x-show="typeForm.hero_image_url" alt=""
-                        class="w-full h-full object-cover" />
+                        class="w-full h-full object-cover object-top" />
+                      <div x-show="!typeForm.hero_image_url"
+                        class="absolute inset-0 flex items-center justify-center text-[0.65rem] text-neutral-400">No artwork</div>
                     </div>
-                    <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Phone · 21:9</p>
+                    <p class="text-[0.6rem] text-neutral-400 mt-1 text-center">Phone &amp; email · 21:9</p>
                   </div>
                 </div>
+                <!-- The rule sits on the page permanently rather than in the help
+                     bubble. A bubble has to be opened to be read, and a second copy of
+                     the rule is what let the old one drift into naming the wrong band.
+                     Same constant renders in the image picker. -->
+                <p class="text-[0.7rem] text-neutral-500 leading-relaxed">
+                  <span class="font-semibold text-neutral-600">Composing artwork:</span>
+                  <span x-text="heroCompositionRule()"></span>
+                </p>
                 <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
                   <div class="flex-1 min-w-[11rem]">
+                    <!-- An em dash, not "No artwork": the two frames already say that,
+                         and a third copy of the same fact is noise. -->
                     <p class="text-sm font-semibold text-neutral-700 truncate"
-                      x-text="imgMeta('hero_image_url').name || 'No artwork'"></p>
+                      x-text="imgMeta('hero_image_url').name || '—'"></p>
                     <!-- Unlike the backdrop, artwork has no colour fallback. -->
                     <p x-show="!typeForm.hero_image_url" class="text-xs text-neutral-400">
                       Blank shows nothing — no colour fallback.
@@ -2629,7 +2688,6 @@
               </div>
               <p x-show="typeForm.hero_image_url && imgBroken['hero_image_url']"
                 class="text-xs text-rose-600 mt-1.5">Image didn't load — check the URL is public and points directly at an image file.</p>
-              <p class="text-[0.7rem] text-neutral-500 mt-1.5">Both crops come from the same image — keep the subject in the middle.</p>
             </div>
           </div>
 
@@ -2710,6 +2768,14 @@
           class="ml-auto w-48 max-w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
         <button @click="imgModal = null" class="text-neutral-400 hover:text-neutral-700 text-xl leading-none">&times;</button>
       </div>
+
+      <!-- The editor's rule line is read after the choice has been made; the
+           picker is where it is made. Same constant, not a shortened variant.
+           Role-conditional on purpose: this modal is shared between hero and
+           background, and the backdrop has no composition rule to state, so an
+           unconditional line would assert one for half its uses. -->
+      <p x-show="imgRoleInfo().rule" x-text="imgRoleInfo().rule"
+        class="shrink-0 px-5 pt-3 text-[0.7rem] text-neutral-500 leading-relaxed"></p>
 
       <!-- Library -->
       <div x-show="imgTab === 'Library'" class="p-5 overflow-y-auto grid grid-cols-3 gap-3">
@@ -3285,8 +3351,13 @@
     // the Worker uses — so the difference lives in one place rather than in a
     // ternary at every site that needs it. Mirrors ROLE_TARGETS in
     // image-pipeline.js, which is keyed the same way.
+    // `rule` is present on hero and ABSENT on background — the picker renders it
+    // conditionally on exactly that. Optional chaining so a stale cached copy of
+    // type-surfaces.js costs the rule line and nothing else, rather than throwing
+    // here and taking the whole component with it.
     const IMAGE_ROLES = {
-      hero:       { field: 'hero_image_url',      title: 'Hero artwork library' },
+      hero:       { field: 'hero_image_url',      title: 'Hero artwork library',
+                    rule: window.typeSurfaces?.HERO_COMPOSITION_RULE },
       background: { field: 'hero_background_url', title: 'Hero background library' },
     };
 
@@ -5196,6 +5267,12 @@
         return IMAGE_ROLES[this.imgRole()];
       },
 
+      // The one rule string, for the crop control under the frames. The picker
+      // reads the same constant off IMAGE_ROLES.hero.
+      heroCompositionRule() {
+        return IMAGE_ROLES.hero.rule || '';
+      },
+
       imgField() {
         return this.imgRoleInfo().field;
       },
@@ -5340,7 +5417,10 @@
           // stays open at the end to show it.
           let advisory = '';
           if (P.isTooSmall({ role, width })) {
-            advisory = `This is only ${width} px wide, so it'll look soft on phones. Aim for 1200 × 900.`;
+            // "phones and the emailed voucher" is the same phrase the hero
+            // composition rule uses, deliberately: the two read as one voice,
+            // and a future surface change greps to both.
+            advisory = `This is only ${width} px wide, so it'll look soft on phones and in the emailed voucher. Aim for 1200 × 900.`;
             this.setImgMsg(advisory, 'warning');
           }
 

--- a/vouchers/test/type-surfaces.test.js
+++ b/vouchers/test/type-surfaces.test.js
@@ -2,11 +2,15 @@ import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import {
   SURFACES, EMAIL_CUSTOMISABLE_FIELDS, PUBLIC_PAGE_FIELDS, DEFAULT_ACCENT,
-  HERO_COMPOSITION_RULE,
+  HERO_ARTWORK_COMPOSITION_RULE,
   surfaceOf, isUntouched, chipFor, unreviewedSurfaces, backdropFallbackCss,
 } from '../type-surfaces.js';
 
-const indexHtml = () => readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+// Read once — several tests below check the editor's markup, and re-reading a
+// 200KB file per assertion buys nothing.
+let cachedIndexHtml;
+const indexHtml = () => (cachedIndexHtml ??= readFileSync(
+  new URL('../index.html', import.meta.url), 'utf8'));
 
 // The columns blankTypeForm() actually seeds, read out of index.html rather
 // than copied. A field added to the editor and to no surface has to fail the
@@ -200,18 +204,18 @@ describe('backdrop fallback', () => {
 // copies is how the previous guidance drifted — the help bubble ended up
 // naming a band the page never cropped to — so "defined once, hero only" is
 // checked here rather than left to review.
-describe('the hero composition rule', () => {
+describe('the hero artwork composition rule', () => {
   it('names the band, both narrow surfaces, and what happens below it', () => {
-    expect(HERO_COMPOSITION_RULE).toBe(
+    expect(HERO_ARTWORK_COMPOSITION_RULE).toBe(
       'Keep faces, logos and any words in the top 57% of your image — phones and '
       + 'the emailed voucher show only that band, and everything below it is '
       + 'cropped away.');
   });
 
   // The upload advisory shares this phrase deliberately, so a future surface
-  // change greps to both.
+  // change greps to both. Asserted on index.html because that is the copy the
+  // shared phrase could drift away from.
   it('shares its wording with the upload advisory', () => {
-    expect(HERO_COMPOSITION_RULE).toContain('phones and the emailed voucher');
     expect(indexHtml()).toContain("so it'll look soft on phones and in the emailed voucher");
   });
 
@@ -221,9 +225,18 @@ describe('the hero composition rule', () => {
 
   it('reaches the crop control and the picker from that one constant', () => {
     const html = indexHtml();
-    expect(html).toContain('x-text="heroCompositionRule()"');
+    expect(html).toContain('x-text="heroArtworkCompositionRule()"');
     expect(html).toContain('x-text="imgRoleInfo().rule"');
-    expect(html).toMatch(/rule:\s*window\.typeSurfaces\?\.HERO_COMPOSITION_RULE/);
+    expect(html).toMatch(/rule:\s*window\.typeSurfaces\?\.HERO_ARTWORK_COMPOSITION_RULE/);
+  });
+
+  // Both render sites hide themselves when the rule is missing. Without this the
+  // editor would show a bolded "Composing artwork:" introducing nothing — which
+  // is precisely the stale-cache case the optional chaining exists for.
+  it('takes its lead-in with it when the constant cannot be read', () => {
+    const html = indexHtml();
+    expect(html).toContain('x-show="heroArtworkCompositionRule()"');
+    expect(html).toContain('x-show="imgRoleInfo().rule"');
   });
 
   // The picker is shared between the two roles, and the backdrop has no
@@ -242,9 +255,14 @@ describe('the hero composition rule', () => {
 // surfaces they claim to show, the rule above is being read beside a lie.
 describe('the hero crop frames', () => {
   it('anchors the narrow frame to the top, as the page and the email do', () => {
-    // voucher-site renders aspect-[21/9] ... object-top on phones; the email
-    // banner clips from the top and cannot move.
-    expect(indexHtml()).toMatch(/aspect-\[21\/9\][\s\S]{0,600}?object-cover object-top/);
+    // voucher-site renders aspect-[21/9] object-cover object-top on phones; the
+    // email banner clips from the top and cannot move. A centred preview here
+    // would point the opposite way to both.
+    const html = indexHtml();
+    const start = html.indexOf('aspect-[21/9]');
+    expect(start, 'no 21:9 frame in the hero crop control').toBeGreaterThan(-1);
+    const frame = html.slice(start, html.indexOf('</div>', start));
+    expect(frame).toContain('object-cover object-top');
   });
 
   it('marks the discarded region on the 4:3 frame, at the 21:9 boundary', () => {

--- a/vouchers/test/type-surfaces.test.js
+++ b/vouchers/test/type-surfaces.test.js
@@ -2,14 +2,17 @@ import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import {
   SURFACES, EMAIL_CUSTOMISABLE_FIELDS, PUBLIC_PAGE_FIELDS, DEFAULT_ACCENT,
+  HERO_COMPOSITION_RULE,
   surfaceOf, isUntouched, chipFor, unreviewedSurfaces, backdropFallbackCss,
 } from '../type-surfaces.js';
+
+const indexHtml = () => readFileSync(new URL('../index.html', import.meta.url), 'utf8');
 
 // The columns blankTypeForm() actually seeds, read out of index.html rather
 // than copied. A field added to the editor and to no surface has to fail the
 // partition test below, and it only can if this list comes from the source.
 function editorDraftFields() {
-  const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const html = indexHtml();
   const body = html.match(/blankTypeForm\(\)\s*\{\s*return\s*\{([\s\S]*?)\n\s*\};/);
   if (!body) throw new Error('could not find blankTypeForm() in index.html');
   return [...body[1].matchAll(/(?:^|[{,])\s*([a-z_][a-z0-9_]*)\s*:/gi)].map(m => m[1]);
@@ -190,5 +193,72 @@ describe('backdrop fallback', () => {
     expect(DEFAULT_ACCENT).toBe('#ae222a');
     expect(backdropFallbackCss('')).toContain(DEFAULT_ACCENT);
     expect(backdropFallbackCss(null)).toContain(DEFAULT_ACCENT);
+  });
+});
+
+// The rule renders in two places and must stay ONE string. Two hand-typed
+// copies is how the previous guidance drifted — the help bubble ended up
+// naming a band the page never cropped to — so "defined once, hero only" is
+// checked here rather than left to review.
+describe('the hero composition rule', () => {
+  it('names the band, both narrow surfaces, and what happens below it', () => {
+    expect(HERO_COMPOSITION_RULE).toBe(
+      'Keep faces, logos and any words in the top 57% of your image — phones and '
+      + 'the emailed voucher show only that band, and everything below it is '
+      + 'cropped away.');
+  });
+
+  // The upload advisory shares this phrase deliberately, so a future surface
+  // change greps to both.
+  it('shares its wording with the upload advisory', () => {
+    expect(HERO_COMPOSITION_RULE).toContain('phones and the emailed voucher');
+    expect(indexHtml()).toContain("so it'll look soft on phones and in the emailed voucher");
+  });
+
+  it('is not hand-copied into the editor', () => {
+    expect(indexHtml()).not.toContain('top 57% of your image');
+  });
+
+  it('reaches the crop control and the picker from that one constant', () => {
+    const html = indexHtml();
+    expect(html).toContain('x-text="heroCompositionRule()"');
+    expect(html).toContain('x-text="imgRoleInfo().rule"');
+    expect(html).toMatch(/rule:\s*window\.typeSurfaces\?\.HERO_COMPOSITION_RULE/);
+  });
+
+  // The picker is shared between the two roles, and the backdrop has no
+  // composition rule to state — it is `cover` against a content-height box.
+  it('is carried by the hero role and not by the background role', () => {
+    const roles = indexHtml().match(/const IMAGE_ROLES = \{([\s\S]*?)\n\s*\};/);
+    expect(roles, 'could not find IMAGE_ROLES in index.html').toBeTruthy();
+    const hero = roles[1].match(/hero:\s*\{([\s\S]*?)\}/)[1];
+    const background = roles[1].match(/background:\s*\{([\s\S]*?)\}/)[1];
+    expect(hero).toContain('rule:');
+    expect(background).not.toContain('rule:');
+  });
+});
+
+// The frames are the preview the rule describes. If they stop matching the
+// surfaces they claim to show, the rule above is being read beside a lie.
+describe('the hero crop frames', () => {
+  it('anchors the narrow frame to the top, as the page and the email do', () => {
+    // voucher-site renders aspect-[21/9] ... object-top on phones; the email
+    // banner clips from the top and cannot move.
+    expect(indexHtml()).toMatch(/aspect-\[21\/9\][\s\S]{0,600}?object-cover object-top/);
+  });
+
+  it('marks the discarded region on the 4:3 frame, at the 21:9 boundary', () => {
+    const html = indexHtml();
+    expect(html).toContain('top-[57.14%]');
+    expect(html).toContain('Cut on phones &amp; email');
+  });
+
+  it('labels the two frames for the surfaces they show', () => {
+    const html = indexHtml();
+    expect(html).toContain('Desktop · 4:3');
+    expect(html).toContain('Phone &amp; email · 21:9');
+    // The backdrop's narrow frame carries no ratio: its box is content-height.
+    expect(html).toContain('Desktop · 16:9');
+    expect(html).not.toContain('Backdrop · 16:9');
   });
 });

--- a/vouchers/type-surfaces.js
+++ b/vouchers/type-surfaces.js
@@ -73,7 +73,7 @@ const UNTOUCHED_TEST_FIELDS = {
 // than inlining a fourth copy of the literal.
 export const DEFAULT_ACCENT = '#ae222a';
 
-// What staff need to know before they choose hero artwork: the narrow surfaces
+// What staff need to know before they choose hero ARTWORK: the narrow surfaces
 // keep a 21:9 band off the top, which is 57% of the 4:3 the desktop shows.
 //
 // It lives here, as ONE constant, because it renders in two places — under the
@@ -81,10 +81,11 @@ export const DEFAULT_ACCENT = '#ae222a';
 // precisely how the old guidance drifted: the help bubble ended up naming the
 // wrong band and omitting the email altogether.
 //
-// The hero only. The backdrop has no composition rule to state (see
-// docs/adr/0003 and issue #85): it is `cover` against a box whose height is
-// content, so there is no fixed band to name.
-export const HERO_COMPOSITION_RULE =
+// Named for the artwork, never the bare "hero", because the hero BACKDROP has
+// no composition rule to state (issue #85): it is `cover` against a box whose
+// height is content, so there is no fixed band to name. CONTEXT.md keeps those
+// two images sharing no word, and this is exactly the pair it protects.
+export const HERO_ARTWORK_COMPOSITION_RULE =
   'Keep faces, logos and any words in the top 57% of your image — phones and '
   + 'the emailed voucher show only that band, and everything below it is '
   + 'cropped away.';

--- a/vouchers/type-surfaces.js
+++ b/vouchers/type-surfaces.js
@@ -73,6 +73,22 @@ const UNTOUCHED_TEST_FIELDS = {
 // than inlining a fourth copy of the literal.
 export const DEFAULT_ACCENT = '#ae222a';
 
+// What staff need to know before they choose hero artwork: the narrow surfaces
+// keep a 21:9 band off the top, which is 57% of the 4:3 the desktop shows.
+//
+// It lives here, as ONE constant, because it renders in two places — under the
+// editor's crop frames and in the image picker — and two hand-typed copies is
+// precisely how the old guidance drifted: the help bubble ended up naming the
+// wrong band and omitting the email altogether.
+//
+// The hero only. The backdrop has no composition rule to state (see
+// docs/adr/0003 and issue #85): it is `cover` against a box whose height is
+// content, so there is no fixed band to name.
+export const HERO_COMPOSITION_RULE =
+  'Keep faces, logos and any words in the top 57% of your image — phones and '
+  + 'the emailed voucher show only that band, and everything below it is '
+  + 'cropped away.';
+
 export function surfaceOf(field) {
   const surface = SURFACES.find(s => s.fields.includes(field));
   return surface ? surface.id : null;


### PR DESCRIPTION
Implements **urbanjungleirc/vouchers#90** (§2 and §3 of the crop map #86) and **urbanjungleirc/vouchers#89** (§4 and §5).

Batched into one branch because both tickets edit the same region of the voucher type editor, as #89 anticipated.

> ⚠️ **Merging this deploys.** `main` publishes to `ujstaff.happyk.au` on push. #88 is already live, so the ordering constraint that blocked #90 is discharged — but this still goes live the moment it merges.

## The hero crop control (#90)

Two frames, not three: since #88 re-anchored the live page, the phone and the email render identical pixels, so a third frame would repeat one of them and cut the desktop frame to a third of the width.

| Frame | Anchor |
|---|---|
| `Desktop · 4:3` | default (centre) |
| `Phone & email · 21:9` | **top** |

The 21:9 frame was previously centre-anchored while the surfaces cropped from the top — a preview pointing the opposite way to the thing it previewed. It now carries `object-top`, matching `aspect-[21/9] object-cover object-top` on the live page and the email's fixed top clip.

The band indicator lives on the **4:3** frame, because that is the only frame holding both regions — the 21:9 frame cannot show what it discards without ceasing to be a preview. A dashed hairline at `57.14%`, the region below dimmed, tagged `Cut on phones & email`, absent when there is no artwork to annotate.

<sub>The maths: a 21:9 band is `9/21 = 0.4286w` tall; a 4:3 frame is `0.75w`. `0.4286 / 0.75 = 57.14%` of the frame, at any rendered size — so the hairline is a constant, not a measurement.</sub>

Both frames read `No artwork` when blank. After #87 that is the **default** state on every type, so two bare grey rectangles would have read as broken or still-loading everywhere. The details column's name slot drops to an em dash, so the control no longer states the same fact three times.

## One rule string, two render sites

`HERO_ARTWORK_COMPOSITION_RULE` is exported from `type-surfaces.js` and rendered under the crop frames and in the image picker. Two hand-typed copies is how the guidance drifted in the first place — the old help bubble ended up naming a band the page never cropped to — so tests assert the string is **not** hand-copied into `index.html` and that both sites read the constant.

In the picker it is role-conditional: `IMAGE_ROLES.hero` carries `rule`, `IMAGE_ROLES.background` does not, and a test pins that partition. The modal is shared between the two roles, and #85 ruled the backdrop has no composition rule to state.

The help bubble **sheds** the crop clause rather than carrying the new rule — a second copy is the same drift risk that made the old one wrong.

`type-surfaces.js?v=` bumped to `2`, as its header comment requires.

## The backdrop's phone frame (#89)

The backdrop's phone crop was described but never shown. It gains a portrait frame beside the existing 16:9, relabelled `Desktop · 16:9` now that it is no longer the sole frame. The narrow one is `Phone`, deliberately with **no ratio**: `cover` runs against a box whose height is content, so there is not one to name.

4:5 is roughly the hero section's shape on a phone with the copy stack and the 21:9 artwork inside it, and is deliberately a touch taller than measured — this frame's job is to show the worse case, and a preview that flatters is the failure the crop map exists to fix.

Help bubble, `ROLE_TARGETS.background` and `background-position` are untouched, per #85. `image-pipeline.js` is not in the diff at all.

## The upload advisory (#89)

Now names the email, and shares the phrase *"phones and the emailed voucher"* with the composition rule verbatim, so the two read as one voice and a future surface change greps to both. `ROLE_TARGETS` and `isTooSmall` unchanged.

## Verification

- `npm test` in `vouchers/`: **217 passing, 13 files** (9 new).
- Every user-facing string checked character for character against #86, including that `&amp;` resolves to `&` and `×` is the multiplication sign.
- Tests **mutation-verified**: dropping `object-top`, moving the hairline off `57.14%`, adding a `rule` to `IMAGE_ROLES.background`, and removing the lead-in guard each fail exactly one test and no others.
- HTML nesting validated against `main` — no unclosed or mismatched tags introduced.

## Note for a follow-up ticket — not fixed here

The upload advisory is shared between **both** image roles. For a *backdrop* upload it now reads *"…soft on phones and in the emailed voucher. Aim for 1200 × 900"*, but:

- the backdrop appears in **no email** (#85, confirmed in #82), so the email clause is newly wrong for that role; and
- `ROLE_TARGETS.background.minWidth` is **1400**, so it recommends 1200 px — *below* the threshold that just triggered the warning. That half is pre-existing.

#86 §5 mandates this string verbatim at that line and rules `ROLE_TARGETS`/`isTooSmall` unchanged, so this branch is compliant as written. Making it role-conditional needs copy that #84/#85 never settled, so it belongs upstream rather than here.

Closes urbanjungleirc/vouchers#89 and urbanjungleirc/vouchers#90 — but those live in the hub repo, so they need closing by hand once this deploys.
