### PR TITLE
ADR 0003 — record the tenth email column as a named exception

### DIFF
--- a/docs/adr/0003-voucher-type-editor-organised-by-surface.md
+++ b/docs/adr/0003-voucher-type-editor-organised-by-surface.md
@@ -152,3 +152,30 @@ providing it.
 and tab strip; scrolling body; pinned footer carrying Cancel and Save. That
 fixes a pre-existing fault where Save sat below the fold on tall types, and it
 keeps the error banner visible on any tab at any scroll position.
+
+## Amendment — 2026-08-12 (#82)
+
+The voucher email banner (#27) added `hero_image_url` to the email renderer
+after this ADR was accepted. The renderer now consumes **ten** type columns, not
+nine: `email.js:96` takes `heroImageUrl` and `email.js:171` renders it as the
+banner across the top of the email.
+
+The field nevertheless stays homed on the **Public page** surface. The
+derivation rule — membership follows what the code consumes — yields here to a
+named exception.
+
+The brand colour is mirrored onto Public page because that tab has **no
+preview**; the mirror was the only way to see the colour while writing the page
+it themes. That rationale does not transfer. The Email tab *does* have a
+preview, `previewVoucherType()` passes `hero_image_url` from the draft
+(`index.js:799`), and the picker refreshes it across tabs (`applyImage()` →
+`refreshPreview()` → the dirty re-render in `setTypeTab()`). A staff member on
+the Email tab already sees the banner, live, so a read-only mirror would
+duplicate the preview sitting beneath it.
+
+`hero_background_url` is genuinely public-page-only and stays with Public page,
+so the field group does not split.
+
+The Email tab's membership is therefore "the nine columns homed here", not
+"everything the renderer consumes". If that sentence is ever re-derived from the
+code, this exception is why the tenth column is missing.

--- a/vouchers/test/type-surfaces.test.js
+++ b/vouchers/test/type-surfaces.test.js
@@ -68,10 +68,13 @@ describe('the surface partition', () => {
     }
   });
 
-  // The email renderer in payments-worker consumes exactly these nine columns.
-  // That count is what fixes the Email tab's membership, and is why branding
-  // sits with the email rather than with the public page.
-  it('gives the email surface the nine fields the email renderer consumes', () => {
+  // The nine columns homed on this surface, which is what fixes the Email tab's
+  // membership and why branding sits with the email rather than the public page.
+  // NOT the same as what the renderer consumes: it also takes hero_image_url,
+  // which stays on Public page by deliberate exception — see the 2026-08-12
+  // amendment in ADR 0003. Re-deriving this count from the renderer would move
+  // that field and undo a decision without knowing it was made.
+  it('gives the email surface the nine columns homed there', () => {
     expect(surfaceOf('email_subject')).toBe('email');
     expect(surfaceOf('email_body')).toBe('email');
     expect(surfaceOf('terms_conditions')).toBe('email');

--- a/vouchers/type-surfaces.js
+++ b/vouchers/type-surfaces.js
@@ -31,7 +31,9 @@ export const SURFACES = [
   {
     id: 'email',
     label: 'Email',
-    // Exactly the nine columns the email renderer consumes.
+    // The nine columns homed here. The email renderer also consumes
+    // hero_image_url, which stays on Public page by deliberate exception —
+    // see the 2026-08-12 amendment in ADR 0003.
     fields: [
       'email_subject', 'email_body', 'terms_conditions', 'usage_info',
       'redemption_instructions',


### PR DESCRIPTION
Implements **urbanjungleirc/vouchers#91** — §7 of the crop map #86, settled in #82. This is the last piece of the map.

> Documentation and comments only. No behaviour changes, `SURFACES` is untouched, and no user-visible surface moves. Merging still publishes to `ujstaff.happyk.au`, as every merge here does.

## What was stale

ADR 0003 states the email renderer consumes *"exactly nine"* type columns, and derives the Email tab's membership from that count. True when it was accepted — the voucher email banner (#27) landed afterwards, and the renderer now takes **ten**: `email.js:96` reads `heroImageUrl`, `email.js:171` renders it as the banner.

## Why the field doesn't move

#82 tested the premise and it didn't survive contact with the code. The Email tab **does** have a live preview; `previewVoucherType()` passes `hero_image_url` from the draft (`index.js:799`); and `applyImage()` → `refreshPreview()` → the dirty re-render in `setTypeTab()` means picking an image on Public page shows the banner on Email already.

That collapses the accent-colour analogy that would justify a read-only mirror — brand colour is mirrored onto Public page precisely **because** that tab has no preview. Here a mirror would duplicate the preview sitting directly beneath it.

So `hero_image_url` stays homed on **Public page**, and the fix is documentation.

## Why an exception, not a corrected count

The count is load-bearing. Someone re-deriving the partition from the rule as written would find `hero_image_url` doesn't fit, move it off Public page, and undo a decision without knowing it was made. The amendment therefore *names* the exception where the rule lives.

It is **appended as a dated amendment** rather than edited into the Decision text — an ADR records what was decided when, and the original count was correct on the day it was written.

## Changes

| File | Change |
|---|---|
| `docs/adr/0003-…-organised-by-surface.md` | `## Amendment — 2026-08-12 (#82)` appended, verbatim |
| `vouchers/type-surfaces.js:34` | corrected comment, verbatim |
| `vouchers/test/type-surfaces.test.js` | third copy of the same stale claim — see below |

Both specified texts were verified **programmatically** against #82's resolution comment, normalised for markdown wrapping — an exact match, not an eyeball.

## Beyond the two specified texts — flag for veto

#91 names two texts. I changed a third thing, and it's worth your call:

`test/type-surfaces.test.js:71` carried the same false claim — *"The email renderer in payments-worker consumes exactly these nine columns"* — attached to the very test asserting the count. That comment is read by exactly the person who would re-derive the partition, so leaving it would have half-defeated the ticket. The comment and the test name now say "the nine columns homed there" and point at the amendment.

The assertion itself is unchanged and still expects `9`, which stays correct: **nine columns are homed on the surface, ten are consumed by the renderer.** That distinction is the whole point of the amendment.

Say the word and I'll drop that hunk.

## Verification

- `npm test` in `vouchers/`: **217 passing, 13 files** — unchanged from `main`, as a docs-and-comments change should be.
- `SURFACES` data untouched (acceptance criterion 3).
- Both verbatim texts match #82 character for character.

Closes urbanjungleirc/vouchers#91 — and with it, urbanjungleirc/vouchers#86, whose §7 this was.
