### PR TITLE
Provision Clubworx API access (#47) and close a .dev.vars leak path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ node_modules/
 
 # Staging directory built by .github/workflows/pages.yml
 _site/
+
+# Worker secrets, at any depth. This repo is PUBLIC, and a key that reaches a
+# commit here is world-readable and permanent in history. cloudflare-worker/
+# had its own rule, but a per-directory rule only protects directories that
+# already exist — the next Worker directory starts unprotected, which is
+# exactly how a key gets committed. Guarded by
+# cloudflare-worker/test/secret-hygiene.test.js.
+.dev.vars

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,16 @@ _site/
 # commit here is world-readable and permanent in history. cloudflare-worker/
 # had its own rule, but a per-directory rule only protects directories that
 # already exist — the next Worker directory starts unprotected, which is
-# exactly how a key gets committed. Guarded by
-# cloudflare-worker/test/secret-hygiene.test.js.
+# exactly how a key gets committed.
+#
+# Wrangler reads .dev.vars and .dev.vars.<environment>, and .env is the habit
+# people arrive with, so all of them are covered — matching only the bare name
+# would certify a gap it does not close. The .example template is the one file
+# here meant to be committed.
 .dev.vars
+.dev.vars.*
+!.dev.vars.example
+.env
+
+# Checked by cloudflare-worker/test/secret-hygiene.test.js — run by hand, not in
+# CI, because pages.yml runs no tests. The rule above is the actual control.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,9 @@ index.html              - hub homepage; renders cards/groups from tools.json
 tools.json              - source of truth for hub entries
 roster.html             - daily staff roster, pulled from Deputy via Cloudflare Worker
 cloudflare-worker/      - Worker for roster API and tools.json editor API
+cloudflare-clubworx/    - Clubworx API access for the school-group booking tool (#46).
+                          ACCESS.md is the answer to #47: where the key comes from,
+                          where it lives, and what is still owed. No Worker code yet.
 hvt/                    - High-volume Training tool copy
 slideshow/              - Google Drive TV slideshow tool
 sls_tv.html             - Summer Lead Series TV display

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ tools.json              - source of truth for hub entries
 roster.html             - daily staff roster, pulled from Deputy via Cloudflare Worker
 cloudflare-worker/      - Worker for roster API and tools.json editor API
 cloudflare-payments-proxy/ - Worker bridging vouchers/ to uj-payments with the Access JWT
+cloudflare-clubworx/    - Clubworx API access for the school-group booking tool (#46).
+                          ACCESS.md is the answer to #47: where the key comes from,
+                          where it lives, and what is still owed. No Worker code yet.
 vouchers/               - voucher management portal (auth = Cloudflare Access)
 vouchers/stats.html     - voucher analytics: revenue, liability, redemption, product mix
 vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and why

--- a/cloudflare-clubworx/.dev.vars.example
+++ b/cloudflare-clubworx/.dev.vars.example
@@ -10,8 +10,8 @@
 
 # The gym's Clubworx API key. Clubworx admin UI -> Settings -> API.
 # Sent as the account_key query parameter on every api/v2 request.
+#
+# This is the only variable staff-site#47 settles. The Worker's own auth is a
+# separate decision — the #46 map calls for it to be Access-gated — so nothing
+# is pre-declared for it here. Add what that ticket decides, when it decides it.
 CLUBWORX_ACCOUNT_KEY=
-
-# Shared secret the staff-portal page sends as X-Staff-Secret when running
-# against a local `wrangler dev`. Generate with: openssl rand -hex 24
-STAFF_SHARED_SECRET=

--- a/cloudflare-clubworx/.dev.vars.example
+++ b/cloudflare-clubworx/.dev.vars.example
@@ -1,0 +1,17 @@
+# Template for cloudflare-clubworx/.dev.vars — copy, then fill in locally.
+#
+#   cp .dev.vars.example .dev.vars
+#
+# .dev.vars is gitignored repo-wide (see the root .gitignore). This file, the
+# .example, is committed and must never carry a real value.
+#
+# staff-site is a PUBLIC repo. In production these are Wrangler secrets
+# (`npx wrangler secret put <NAME>`), never [vars] in wrangler.toml.
+
+# The gym's Clubworx API key. Clubworx admin UI -> Settings -> API.
+# Sent as the account_key query parameter on every api/v2 request.
+CLUBWORX_ACCOUNT_KEY=
+
+# Shared secret the staff-portal page sends as X-Staff-Secret when running
+# against a local `wrangler dev`. Generate with: openssl rand -hex 24
+STAFF_SHARED_SECRET=

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -1,0 +1,140 @@
+# Clubworx API access for development
+
+Answer to [staff-site#47](https://github.com/urbanjungleirc/staff-site/issues/47),
+part of the school-group booking map ([#46](https://github.com/urbanjungleirc/staff-site/issues/46)).
+Later tickets on that map (#48–#51) depend on all four sections below.
+
+Status: **sections 2 and 3 settled; sections 1 and 4 need Jiri.** No live probe
+may run until section 4 is signed off.
+
+---
+
+## 1. Source of the key — ACTION REQUIRED
+
+**Where it comes from:** the Clubworx admin UI, **Settings → API**. (Same route
+already recorded for the HVT integration in `hvt/docs/CLUBWORX_IMPORT.md`.)
+
+**Why it cannot be recovered from what we already have.** The existing
+`uj-clubworx` Worker (in the `hvt` repo) holds the key as a Cloudflare secret,
+and Cloudflare does not read secrets back out. The local
+`uj/hvt-scoring-app/.env` was checked and holds only
+`VITE_CLUBWORX_WORKER_URL` and `VITE_CLUBWORX_STAFF_SECRET` — the address of
+that Worker and the shared secret used to call it, not the Clubworx key itself.
+The key is genuinely absent from this machine.
+
+**Reuse or issue a separate key?** The ticket asks for this to be decided so
+this tool's traffic is attributable. The API reference describes `account_key`
+as *"Your gym's unique API key"* — singular, one per gym — on all 30+ endpoints.
+That wording suggests per-integration keys are **not offered**, in which case
+attribution by key is impossible and the question is moot. This has not been
+confirmed against the admin UI, which is the only place that can answer it.
+
+> **To confirm while fetching the key:** does Settings → API let you issue a
+> second, separate key, or is there exactly one gym key? If there is only one,
+> attribution must come from somewhere else — the `noreply+<school>@` email
+> marker this map already adopted is the natural fallback, since it is per-record
+> rather than per-request.
+
+### A read-only path that needs no key at all
+
+Worth knowing before anyone hurries the key out of the admin UI: the deployed
+`uj-clubworx` Worker already proxies Clubworx reads, authenticated by the
+`X-Staff-Secret` we *do* hold locally. It exposes `/v1/events`, `/v1/roster`
+and `/v1/lookup`.
+
+That covers part of the **read** side of probe [#51](https://github.com/urbanjungleirc/staff-site/issues/51)
+(event listing) without this project ever holding the raw key. It does **not**
+cover the write probes — that Worker exposes no create path — so
+[#49](https://github.com/urbanjungleirc/staff-site/issues/49) (plus-addressed
+duplicate emails) and [#50](https://github.com/urbanjungleirc/staff-site/issues/50)
+(booking a membership-less prospect) still need the key.
+
+Two caveats if that shortcut is used: its paging is capped at
+`MAX_PAGES = 3 × PAGE_SIZE = 100`, i.e. **300 records**, after which it sets a
+`capped` flag rather than continuing — so it cannot answer #51's burst-behaviour
+question. And its upstream timeout is 10s.
+
+## 2. Location for probing — SETTLED
+
+`cloudflare-clubworx/.dev.vars`, gitignored. Copy `.dev.vars.example` in this
+directory and fill it in.
+
+**staff-site is a public repo** (`urbanjungleirc/staff-site`, confirmed
+`"visibility": "PUBLIC"`). A key that reaches a commit here is world-readable
+and permanent in history. Three things now hold that closed:
+
+- `.dev.vars` is ignored **repo-wide** from the root `.gitignore`. Previously
+  only `cloudflare-worker/` ignored it, via its own file — which protected that
+  one directory and nothing else. A `.dev.vars` in this new directory would
+  have been committable. That gap was real and is now closed.
+- `cloudflare-worker/test/secret-hygiene.test.js` asserts it: `.dev.vars` is
+  ignored in every Worker directory *including ones not yet created*, no
+  `.dev.vars` is tracked anywhere, and no committed file carries a literal
+  `account_key=` value. Both failure modes were verified by planting a fake key
+  and a tracked `.dev.vars` and watching the suite go red.
+- In production the key is a **Wrangler secret** (`npx wrangler secret put
+  CLUBWORX_ACCOUNT_KEY`), never `[vars]` in `wrangler.toml`, which is committed.
+
+The key must also never reach the page. The browser talks to this Worker; only
+the Worker talks to Clubworx.
+
+## 3. Environment — SETTLED: production only
+
+**There is no Clubworx sandbox.** The 2,365-line API reference at
+`uj/automations/ClubworxAPI_docs.md` contains no occurrence of *sandbox*,
+*staging*, *test mode*, *demo account*, *rate limit*, *throttle* or *429*. A
+public search surfaced no sandbox environment either.
+
+So, plainly: **every probe on this map runs against live production data**, the
+same ~60,000-profile database staff use daily. There is no safe rehearsal
+environment, and no way to ask for one.
+
+This compounds a constraint already recorded on #46: **Clubworx contacts cannot
+be deleted through the API.** Prospects, members and non-attending contacts
+expose list / show / create / update only. So each write probe leaves a
+**permanent** contact in production, removable only by hand in the Clubworx UI.
+Bookings are the exception — `DELETE /api/v2/bookings/:id` exists, so the
+booking half of probe #50 is reversible; the contact it needs is not.
+
+**Rate limits are undocumented rather than known to be absent.** Nothing in the
+reference describes throttling, retry-after, or a burst ceiling. Probe #51 is
+what would discover them empirically. Until it runs, assume limits exist and
+are unknown — do not hammer the API.
+
+## 4. Authorisation and test identity — ACTION REQUIRED
+
+Not yet given. Explicitly needed before any write probe runs, because the two
+write probes create permanent production records:
+
+- **#49** — create contacts on plus-addressed variants of `noreply@` to see
+  whether Clubworx treats them as duplicates.
+- **#50** — create a prospect with no membership, then attempt to book it.
+
+**Requested:**
+
+1. Confirmation that write probes against **production** Clubworx are
+   authorised, given no sandbox exists and created contacts are permanent.
+2. The single fake test identity all probes reuse, so the blast radius is one
+   known record rather than a scatter. Proposed, pending approval:
+   - name: `Ztest Wayfinder`
+   - DOB: `1900-01-01`
+   - email: `noreply+wayfindertest@urbanjungleirc.com`
+   - Chosen so it sorts to the end of an alphabetical list, is obviously not a
+     student, and carries the same `noreply+` marker convention this map
+     already adopted for schools. **No real student name, DOB or school may be
+     used** — #46's standing constraint, and this repo is public.
+
+Record the answers here and on #47 when given.
+
+---
+
+## Caveats discovered while answering
+
+| Caveat | Consequence |
+|---|---|
+| No sandbox exists | All probing is against production; unavoidable, not a choice |
+| Contacts cannot be deleted via API | Every write probe leaves a permanent record; bookings are reversible, contacts are not |
+| `account_key` is documented as one key per gym | Per-integration attribution may be impossible; confirm in admin UI |
+| Rate limits undocumented | Unknown, not absent. Probe #51 discovers them; assume they exist meanwhile |
+| Existing `uj-clubworx` Worker caps paging at 300 records | Usable for read probes, but cannot answer #51's burst question |
+| Cloudflare secrets are write-only | The existing key cannot be recovered; it must come from the admin UI |

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -4,8 +4,9 @@ Answer to [staff-site#47](https://github.com/urbanjungleirc/staff-site/issues/47
 part of the school-group booking map ([#46](https://github.com/urbanjungleirc/staff-site/issues/46)).
 Later tickets on that map (#48–#51) depend on all four sections below.
 
-Status: **sections 1, 2 and 3 settled; section 4 needs Jiri.** No live probe may
-run until section 4 is signed off.
+Status: **all four sections settled, 2026-08-17.** #47 is answered and closed.
+Write probes on #49 and #50 are authorised against production, under the test
+identity in section 4.
 
 ---
 
@@ -52,6 +53,17 @@ cp .dev.vars.example .dev.vars
 
 `.dev.vars` is gitignored, so it stays on the machine and never appears on
 GitHub — see section 2.
+
+**Verified working, 2026-08-17.** The key was placed and exercised with a single
+read-only `GET /locations`: **HTTP 200**, 5 location rows, ~1.1s. Access is
+provisioned, not merely configured.
+
+That request also answered something #51 wants: **Clubworx advertises no
+rate-limit headers** — no `Retry-After`, no `X-RateLimit-*`, nothing. So a
+client cannot self-throttle from response metadata and cannot learn it is
+approaching a ceiling before hitting one. Whatever limits exist must be
+discovered by observing failures, which makes conservative pacing in the
+bulk-create loop a design requirement rather than a nicety.
 
 ### A read-only path that needs no key at all
 
@@ -103,6 +115,16 @@ and permanent in history. Three things now hold that closed:
 - In production the key is a **Wrangler secret** (`npx wrangler secret put
   CLUBWORX_ACCOUNT_KEY`), never `[vars]` in `wrangler.toml`, which is committed.
 
+> ⚠️ **The rule only protects the branch it is on.** This was hit twice on
+> 2026-08-17: the session-start sync hook returns this submodule to `main`,
+> which does not carry the rule, while a real `.dev.vars` sits on disk. On that
+> checkout git reports `?? cloudflare-clubworx/` — untracked but *not ignored* —
+> so a `git add .` or an `-A` commit would stage the key into a public repo.
+>
+> Merging this `.gitignore` change to `main` is what actually closes the hole.
+> Until then, check `git check-ignore cloudflare-clubworx/.dev.vars` returns a
+> match before staging anything in this repo.
+
 The key must also never reach the page. The browser talks to this Worker; only
 the Worker talks to Clubworx.
 
@@ -139,30 +161,49 @@ reference describes throttling, retry-after, or a burst ceiling. Probe #51 is
 what would discover them empirically. Until it runs, assume limits exist and
 are unknown — do not hammer the API.
 
-## 4. Authorisation and test identity — ACTION REQUIRED
+## 4. Authorisation and test identity — SETTLED
 
-Not yet given. Explicitly needed before any write probe runs, because the two
-write probes create permanent production records:
+**Authorised by Jiri, 2026-08-17.** Write probes may run against **production**
+Clubworx — the only environment there is. This covers:
 
 - **#49** — create contacts on plus-addressed variants of `noreply@` to see
   whether Clubworx treats them as duplicates.
 - **#50** — create a prospect with no membership, then attempt to book it.
 
-**Requested:**
+### The agreed test identity
 
-1. Confirmation that write probes against **production** Clubworx are
-   authorised, given no sandbox exists and created contacts are permanent.
-2. The single fake test identity all probes reuse, so the blast radius is one
-   known record rather than a scatter. Proposed, pending approval:
-   - name: `Ztest Wayfinder`
-   - DOB: `1900-01-01`
-   - email: `noreply+wayfindertest@urbanjungleirc.com`
-   - Chosen so it sorts to the end of an alphabetical list, is obviously not a
-     student, and carries the same `noreply+` marker convention this map
-     already adopted for schools. **No real student name, DOB or school may be
-     used** — #46's standing constraint, and this repo is public.
+Every write probe on this map reuses **one** identity, so the blast radius is a
+single known record rather than a scatter of orphans nobody can find later:
 
-Record the answers here and on #47 when given.
+| Field | Value |
+|---|---|
+| First name | `Ztest` |
+| Last name | `Wayfinder` |
+| DOB | `1900-01-01` |
+| Email | `noreply+wayfindertest@urbanjungleirc.com` |
+
+Chosen so it sorts to the end of an alphabetical list, is unmistakably not a
+student, and carries the `noreply+` marker convention this map already adopted.
+**No real student name, DOB or school may be used** — #46's standing constraint,
+and this repo is public.
+
+### What authorisation does and does not cover
+
+- It covers **creating** the records the probes need, under that identity, in
+  production.
+- It does **not** make them disposable. Contacts cannot be deleted through the
+  API, so every probe contact is permanent and removable only by hand in the
+  Clubworx UI. Reuse the one identity; do not improvise new ones per run.
+- Bookings *are* reversible (`DELETE /api/v2/bookings/:id`), so #50 should clean
+  up the booking it creates even though it cannot clean up the contact.
+- Probes are **#49 and #50's** work. #47 provisions access and stops there; it
+  ran only a read-only `GET /locations` to prove the key authenticates.
+
+### Before the first write probe
+
+Search first. If `Ztest Wayfinder` already exists from an earlier run, reuse it
+rather than creating a second — the identity is only a blast-radius control if
+there is exactly one of it.
 
 ---
 
@@ -173,7 +214,8 @@ Record the answers here and on #47 when given.
 | No sandbox exists | All probing is against production; unavoidable, not a choice |
 | Contacts cannot be deleted via API | Every write probe leaves a permanent record; bookings are reversible, contacts are not |
 | Clubworx issues **one key per gym**, confirmed | Attribution by key is impossible; the `noreply+<school>@` marker is the only provenance signal. One key's leak or rotation hits every integration |
-| Rate limits undocumented | Unknown, not absent. Probe #51 discovers them; assume they exist meanwhile |
+| Rate limits undocumented **and unadvertised** | Confirmed live: no `Retry-After` or `X-RateLimit-*` headers come back. A client cannot self-throttle from response metadata or see a ceiling approaching — only hit it. Pace conservatively |
+| The gitignore rule is **branch-local until merged** | Observed twice on 2026-08-17: the session-start sync hook returns this submodule to `main`, where the rule does not exist, while `.dev.vars` stays on disk. On that checkout the key is untracked-but-not-ignored, so `git add .` would stage it into a public repo. Merging the rule to `main` is what actually closes this |
 | Existing `uj-clubworx` Worker caps paging at 300 records | Usable for read probes, but cannot answer #51's burst question |
 | Cloudflare secrets are write-only | The existing key cannot be recovered; it must come from the admin UI |
 | This repo runs no tests in CI | The secret-hygiene guard is advisory until that changes — see below |

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -24,8 +24,9 @@ The key is genuinely absent from this machine.
 
 **Reuse or issue a separate key?** The ticket asks for this to be decided so
 this tool's traffic is attributable. The API reference describes `account_key`
-as *"Your gym's unique API key"* — singular, one per gym — on all 30+ endpoints.
-That wording suggests per-integration keys are **not offered**, in which case
+as *"Your gym's unique API key"* — singular, one per gym — on all **42**
+endpoints that take it, and never mentions issuing, revoking or regenerating a
+key. That wording suggests per-integration keys are **not offered**, in which case
 attribution by key is impossible and the question is moot. This has not been
 confirmed against the admin UI, which is the only place that can answer it.
 
@@ -38,9 +39,10 @@ confirmed against the admin UI, which is the only place that can answer it.
 ### A read-only path that needs no key at all
 
 Worth knowing before anyone hurries the key out of the admin UI: the deployed
-`uj-clubworx` Worker already proxies Clubworx reads, authenticated by the
-`X-Staff-Secret` we *do* hold locally. It exposes `/v1/events`, `/v1/roster`
-and `/v1/lookup`.
+`uj-clubworx` Worker already proxies a small number of Clubworx **read**
+endpoints, and the shared secret needed to call it *is* held locally. Its
+routes and auth model are documented in the `hvt` repo alongside its source —
+not restated here, since this file is public.
 
 That covers part of the **read** side of probe [#51](https://github.com/urbanjungleirc/staff-site/issues/51)
 (event listing) without this project ever holding the raw key. It does **not**
@@ -49,10 +51,10 @@ cover the write probes — that Worker exposes no create path — so
 duplicate emails) and [#50](https://github.com/urbanjungleirc/staff-site/issues/50)
 (booking a membership-less prospect) still need the key.
 
-Two caveats if that shortcut is used: its paging is capped at
-`MAX_PAGES = 3 × PAGE_SIZE = 100`, i.e. **300 records**, after which it sets a
-`capped` flag rather than continuing — so it cannot answer #51's burst-behaviour
-question. And its upstream timeout is 10s.
+One caveat if that shortcut is used: it stops paging after a few hundred records
+and flags the result as capped rather than continuing, so it cannot answer #51's
+burst-behaviour question. Read its source for the exact limits before relying on
+them.
 
 ## 2. Location for probing — SETTLED
 
@@ -63,20 +65,39 @@ directory and fill it in.
 `"visibility": "PUBLIC"`). A key that reaches a commit here is world-readable
 and permanent in history. Three things now hold that closed:
 
-- `.dev.vars` is ignored **repo-wide** from the root `.gitignore`. Previously
-  only `cloudflare-worker/` ignored it, via its own file — which protected that
-  one directory and nothing else. A `.dev.vars` in this new directory would
-  have been committable. That gap was real and is now closed.
-- `cloudflare-worker/test/secret-hygiene.test.js` asserts it: `.dev.vars` is
-  ignored in every Worker directory *including ones not yet created*, no
-  `.dev.vars` is tracked anywhere, and no committed file carries a literal
-  `account_key=` value. Both failure modes were verified by planting a fake key
-  and a tracked `.dev.vars` and watching the suite go red.
+- Secret files are ignored **repo-wide** from the root `.gitignore` —
+  `.dev.vars`, `.dev.vars.<environment>` (Wrangler's own convention) and `.env`,
+  with `.dev.vars.example` excepted so the template stays committable.
+  Previously only `cloudflare-worker/` ignored `.dev.vars`, via its own file,
+  which protected that one directory and nothing else: a `.dev.vars` in this new
+  directory would have been committable. That gap was real and is now closed.
+  **This rule is the actual control.**
+- `cloudflare-worker/test/secret-hygiene.test.js` checks it: every secret
+  filename is ignored in every Worker directory *including ones not yet
+  created*, none is tracked anywhere, and no committed file carries a literal
+  `account_key=` value. Each was verified able to fail, by planting a fake key
+  and a tracked `.dev.vars` and watching the suite go red — one of them first
+  passed for the wrong reason and was repaired.
+
+  **It is a check, not a gate.** `pages.yml` is this repo's only workflow and it
+  runs no tests, so nothing executes this guard automatically; it fires only
+  when someone runs vitest by hand. Wiring it into CI is the open recommendation
+  at the end of this file.
 - In production the key is a **Wrangler secret** (`npx wrangler secret put
   CLUBWORX_ACCOUNT_KEY`), never `[vars]` in `wrangler.toml`, which is committed.
 
 The key must also never reach the page. The browser talks to this Worker; only
 the Worker talks to Clubworx.
+
+One thing that surprises people about this repo: **`.github/workflows/pages.yml`
+rsyncs the whole tree into the published site**, excluding only `.git`,
+`node_modules` and `_site`. So this directory is itself served — `ACCESS.md` and
+`.dev.vars.example` are reachable under `ujstaff.happyk.au/cloudflare-clubworx/`,
+and are on GitHub publicly regardless. That is safe *because* the rsync runs
+against a CI checkout, which only ever contains tracked files: a gitignored
+`.dev.vars` does not exist in CI and cannot be published. It is the same posture
+`cloudflare-worker/` has had all along — but it is the reason the gitignore rule
+is the load-bearing control here, not a tidiness preference.
 
 ## 3. Environment — SETTLED: production only
 
@@ -138,3 +159,18 @@ Record the answers here and on #47 when given.
 | Rate limits undocumented | Unknown, not absent. Probe #51 discovers them; assume they exist meanwhile |
 | Existing `uj-clubworx` Worker caps paging at 300 records | Usable for read probes, but cannot answer #51's burst question |
 | Cloudflare secrets are write-only | The existing key cannot be recovered; it must come from the admin UI |
+| This repo runs no tests in CI | The secret-hygiene guard is advisory until that changes — see below |
+
+## Open recommendation: run the guard in CI
+
+`.github/workflows/pages.yml` is the only workflow here, and it runs no tests —
+checkout, version, stage, check, deploy. So the secret-hygiene guard protects
+nothing on its own; it only reports when a human runs it.
+
+Given `main` **is** production and merging is deploying, the cheap fix is a
+separate workflow on push and pull request that runs just this file. Deliberately
+*not* a step inside `pages.yml`: a failing test there would freeze the site on
+its previous build, turning a hygiene check into an outage.
+
+Not done here because it changes CI on a public, auto-deploying repo, which is
+Jiri's call rather than a detail of #47.

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -4,37 +4,54 @@ Answer to [staff-site#47](https://github.com/urbanjungleirc/staff-site/issues/47
 part of the school-group booking map ([#46](https://github.com/urbanjungleirc/staff-site/issues/46)).
 Later tickets on that map (#48–#51) depend on all four sections below.
 
-Status: **sections 2 and 3 settled; sections 1 and 4 need Jiri.** No live probe
-may run until section 4 is signed off.
+Status: **sections 1, 2 and 3 settled; section 4 needs Jiri.** No live probe may
+run until section 4 is signed off.
 
 ---
 
-## 1. Source of the key — ACTION REQUIRED
+## 1. Source of the key — SETTLED: reuse, because there is only one
 
-**Where it comes from:** the Clubworx admin UI, **Settings → API**. (Same route
-already recorded for the HVT integration in `hvt/docs/CLUBWORX_IMPORT.md`.)
+**Clubworx issues exactly one key per gym.** Confirmed by Jiri, 2026-08-17. A
+separate key for this integration is **not available**, so the ticket's
+reuse-or-issue question is closed by the product: the existing gym key is
+reused, and there is no choice in it.
 
-**Why it cannot be recovered from what we already have.** The existing
-`uj-clubworx` Worker (in the `hvt` repo) holds the key as a Cloudflare secret,
-and Cloudflare does not read secrets back out. The local
-`uj/hvt-scoring-app/.env` was checked and holds only
-`VITE_CLUBWORX_WORKER_URL` and `VITE_CLUBWORX_STAFF_SECRET` — the address of
-that Worker and the shared secret used to call it, not the Clubworx key itself.
-The key is genuinely absent from this machine.
+The API reference already pointed this way — it calls `account_key` *"Your gym's
+unique API key"* on all **42** endpoints that take it, and never mentions
+issuing, revoking or regenerating one — but the admin UI is what settles it.
 
-**Reuse or issue a separate key?** The ticket asks for this to be decided so
-this tool's traffic is attributable. The API reference describes `account_key`
-as *"Your gym's unique API key"* — singular, one per gym — on all **42**
-endpoints that take it, and never mentions issuing, revoking or regenerating a
-key. That wording suggests per-integration keys are **not offered**, in which case
-attribution by key is impossible and the question is moot. This has not been
-confirmed against the admin UI, which is the only place that can answer it.
+**Consequence: per-integration attribution by key is impossible.** Every caller
+— this tool, the HVT roster Worker, any n8n workflow — presents the same key, so
+Clubworx cannot tell them apart, and nothing in an audit trail there will say
+which system created a record. Two things follow, and both matter later:
 
-> **To confirm while fetching the key:** does Settings → API let you issue a
-> second, separate key, or is there exactly one gym key? If there is only one,
-> attribution must come from somewhere else — the `noreply+<school>@` email
-> marker this map already adopted is the natural fallback, since it is per-record
-> rather than per-request.
+- **Attribution has to live in the data, not the request.** The
+  `noreply+<school>@urbanjungleirc.com` marker this map already adopted is what
+  identifies a record as this tool's work. That decision was made for dedup and
+  search; it is now also the *only* provenance signal, which raises its stakes.
+- **Blast radius is shared.** A key rotated for one integration breaks all of
+  them at once, and a key leaked from any one of them exposes the whole gym
+  database. That is an argument for the gitignore rule in section 2 being
+  load-bearing rather than tidy.
+
+**Where the key is.** Jiri holds it — it is already in use by another project.
+It is *not* recoverable from this machine or from Cloudflare: the `uj-clubworx`
+Worker holds it as a Cloudflare secret, and secrets do not read back out. The
+local `uj/hvt-scoring-app/.env` holds only `VITE_CLUBWORX_WORKER_URL` and
+`VITE_CLUBWORX_STAFF_SECRET` — the Worker's address and the secret used to call
+it, not the Clubworx key. If a fresh copy is ever needed: Clubworx admin UI,
+**Settings → API**.
+
+To place it for local probing:
+
+```bash
+cd cloudflare-clubworx
+cp .dev.vars.example .dev.vars
+# then paste the key after CLUBWORX_ACCOUNT_KEY=
+```
+
+`.dev.vars` is gitignored, so it stays on the machine and never appears on
+GitHub — see section 2.
 
 ### A read-only path that needs no key at all
 
@@ -155,7 +172,7 @@ Record the answers here and on #47 when given.
 |---|---|
 | No sandbox exists | All probing is against production; unavoidable, not a choice |
 | Contacts cannot be deleted via API | Every write probe leaves a permanent record; bookings are reversible, contacts are not |
-| `account_key` is documented as one key per gym | Per-integration attribution may be impossible; confirm in admin UI |
+| Clubworx issues **one key per gym**, confirmed | Attribution by key is impossible; the `noreply+<school>@` marker is the only provenance signal. One key's leak or rotation hits every integration |
 | Rate limits undocumented | Unknown, not absent. Probe #51 discovers them; assume they exist meanwhile |
 | Existing `uj-clubworx` Worker caps paging at 300 records | Usable for read probes, but cannot answer #51's burst question |
 | Cloudflare secrets are write-only | The existing key cannot be recovered; it must come from the admin UI |

--- a/cloudflare-worker/.gitignore
+++ b/cloudflare-worker/.gitignore
@@ -1,4 +1,6 @@
-.dev.vars
+# .dev.vars and friends are ignored repo-wide from the root .gitignore, which
+# also covers Worker directories that do not exist yet. Kept out of here so
+# there is one place to look, not two that can disagree.
 node_modules/
 .wrangler/
 package-lock.json

--- a/cloudflare-worker/test/secret-hygiene.test.js
+++ b/cloudflare-worker/test/secret-hygiene.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Repo-wide secret hygiene, not Worker behaviour — it lives in this harness
+// because it is the only vitest setup in the repo, and `npm test` here is the
+// one command CI already runs.
+//
+// staff-site is a PUBLIC repo (urbanjungleirc/staff-site). A Worker secret that
+// reaches a commit here is world-readable and, once pushed, permanently in
+// history. Each Worker directory carrying its own .gitignore is not enough:
+// the next Worker directory starts without one, which is exactly how a key
+// gets committed. These tests assert the repo-level rule instead.
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const git = (...args) => execFileSync('git', args, { cwd: REPO, encoding: 'utf8' });
+
+/**
+ * git grep exits 1 for "no matches" and 2+ for a real failure (bad regex, not a
+ * repo). Collapsing those makes a broken search look like a clean repo, so only
+ * status 1 is treated as an empty result and anything else rethrows.
+ */
+const gitGrep = (pattern) => {
+  try {
+    return git('grep', '-InE', pattern, '--', '.').split('\n').filter(Boolean);
+  } catch (err) {
+    if (err.status === 1) return [];
+    throw err;
+  }
+};
+
+/** git check-ignore exits 1 when the path is NOT ignored, which is not a throw we want. */
+const isIgnored = (relPath) => {
+  try {
+    git('check-ignore', '-q', relPath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('secret hygiene in a public repo', () => {
+  it('ignores .dev.vars in every Worker directory, including ones not yet created', () => {
+    const dirs = [
+      'cloudflare-worker',
+      'cloudflare-payments-proxy',
+      'cloudflare-clubworx',
+      // A directory nobody has thought of yet. The rule has to cover it too,
+      // or this test only ever documents the past.
+      'cloudflare-some-future-worker',
+    ];
+
+    const notIgnored = dirs.filter((d) => !isIgnored(`${d}/.dev.vars`));
+
+    expect(notIgnored).toEqual([]);
+  });
+
+  it('ignores a bare .dev.vars at the repo root', () => {
+    expect(isIgnored('.dev.vars')).toBe(true);
+  });
+
+  it('tracks no .dev.vars file anywhere in the repo', () => {
+    const tracked = git('ls-files').split('\n').filter((f) => path.basename(f) === '.dev.vars');
+
+    expect(tracked).toEqual([]);
+  });
+
+  it('tracks no file holding a literal clubworx account_key value', () => {
+    // The Worker builds its upstream URL as account_key=<secret>. A committed
+    // file with a non-placeholder value on that parameter is a leaked key.
+    //
+    // git grep -E is POSIX ERE and has no lookahead, so the placeholders are
+    // filtered here rather than in the pattern. Doing it in the pattern made
+    // git exit 2 on an invalid regex, which a bare catch then read as "clean" —
+    // a test that could not fail.
+    const PLACEHOLDER = /^(your-unique-digital-key|unique-|<|\$|\{)/;
+
+    const hits = gitGrep('account_key=[A-Za-z0-9_-]{8,}')
+      .filter((line) => {
+        const value = line.match(/account_key=([A-Za-z0-9_-]{8,})/)?.[1] ?? '';
+        return !PLACEHOLDER.test(value);
+      })
+      // The API reference is a documentation file of example URLs, not config.
+      .filter((line) => !line.startsWith('docs/'));
+
+    expect(hits).toEqual([]);
+  });
+});

--- a/cloudflare-worker/test/secret-hygiene.test.js
+++ b/cloudflare-worker/test/secret-hygiene.test.js
@@ -3,15 +3,23 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-// Repo-wide secret hygiene, not Worker behaviour — it lives in this harness
-// because it is the only vitest setup in the repo, and `npm test` here is the
-// one command CI already runs.
+// Repo-wide secret hygiene, not this Worker's behaviour.
 //
 // staff-site is a PUBLIC repo (urbanjungleirc/staff-site). A Worker secret that
 // reaches a commit here is world-readable and, once pushed, permanently in
 // history. Each Worker directory carrying its own .gitignore is not enough:
 // the next Worker directory starts without one, which is exactly how a key
 // gets committed. These tests assert the repo-level rule instead.
+//
+// Two caveats about where this sits, both deliberate and both worth knowing:
+//
+//   - It is in cloudflare-worker/ for want of a repo-level harness. There are
+//     three vitest packages here (cloudflare-worker, cloudflare-payments-proxy,
+//     vouchers) and no root one, so any home is somebody's subdirectory.
+//   - Nothing runs it automatically. pages.yml — the repo's only workflow —
+//     runs no tests at all, so this guard only fires when someone runs vitest
+//     by hand. It documents and checks the rule; it does not enforce it in CI.
+//     Wiring it into CI is staff-site#47's open recommendation.
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -22,7 +30,7 @@ const git = (...args) => execFileSync('git', args, { cwd: REPO, encoding: 'utf8'
  * repo). Collapsing those makes a broken search look like a clean repo, so only
  * status 1 is treated as an empty result and anything else rethrows.
  */
-const gitGrep = (pattern) => {
+const gitGrep = pattern => {
   try {
     return git('grep', '-InE', pattern, '--', '.').split('\n').filter(Boolean);
   } catch (err) {
@@ -32,7 +40,7 @@ const gitGrep = (pattern) => {
 };
 
 /** git check-ignore exits 1 when the path is NOT ignored, which is not a throw we want. */
-const isIgnored = (relPath) => {
+const isIgnored = relPath => {
   try {
     git('check-ignore', '-q', relPath);
     return true;
@@ -41,28 +49,47 @@ const isIgnored = (relPath) => {
   }
 };
 
+/** Every Worker directory present today, so a rename cannot silently skip one. */
+const workerDirs = () =>
+  git('ls-files')
+    .split('\n')
+    .map(f => f.split('/')[0])
+    .filter(d => d.startsWith('cloudflare-'));
+
+// Wrangler reads .dev.vars and .dev.vars.<environment>; .env is the habit people
+// arrive with. All three would carry the same key, so all three must be covered.
+const SECRET_FILENAMES = ['.dev.vars', '.dev.vars.production', '.dev.vars.local', '.env'];
+
 describe('secret hygiene in a public repo', () => {
-  it('ignores .dev.vars in every Worker directory, including ones not yet created', () => {
+  it('ignores every secret filename in every Worker directory, including ones not yet created', () => {
     const dirs = [
-      'cloudflare-worker',
-      'cloudflare-payments-proxy',
-      'cloudflare-clubworx',
-      // A directory nobody has thought of yet. The rule has to cover it too,
-      // or this test only ever documents the past.
-      'cloudflare-some-future-worker',
+      ...new Set([
+        ...workerDirs(),
+        // A directory nobody has thought of yet. The rule has to cover it too,
+        // or this test only ever documents the past.
+        'cloudflare-some-future-worker',
+      ]),
     ];
 
-    const notIgnored = dirs.filter((d) => !isIgnored(`${d}/.dev.vars`));
+    const gaps = dirs.flatMap(d =>
+      SECRET_FILENAMES.filter(name => !isIgnored(`${d}/${name}`)).map(name => `${d}/${name}`),
+    );
 
-    expect(notIgnored).toEqual([]);
+    expect(gaps).toEqual([]);
   });
 
-  it('ignores a bare .dev.vars at the repo root', () => {
-    expect(isIgnored('.dev.vars')).toBe(true);
+  it('ignores every secret filename at the repo root', () => {
+    expect(SECRET_FILENAMES.filter(name => !isIgnored(name))).toEqual([]);
   });
 
-  it('tracks no .dev.vars file anywhere in the repo', () => {
-    const tracked = git('ls-files').split('\n').filter((f) => path.basename(f) === '.dev.vars');
+  it('keeps .dev.vars.example committable, or the template is unusable', () => {
+    expect(isIgnored('cloudflare-clubworx/.dev.vars.example')).toBe(false);
+  });
+
+  it('tracks no secret file anywhere in the repo', () => {
+    const tracked = git('ls-files')
+      .split('\n')
+      .filter(f => SECRET_FILENAMES.includes(path.basename(f)));
 
     expect(tracked).toEqual([]);
   });
@@ -75,15 +102,17 @@ describe('secret hygiene in a public repo', () => {
     // filtered here rather than in the pattern. Doing it in the pattern made
     // git exit 2 on an invalid regex, which a bare catch then read as "clean" —
     // a test that could not fail.
+    //
+    // Nothing is excused by path. An earlier version skipped docs/, reasoning
+    // that the API reference is example URLs — but that reference lives in
+    // uj/automations/, a different repo, so the exemption covered nothing real
+    // while blinding the check to exactly where someone pastes a curl example.
     const PLACEHOLDER = /^(your-unique-digital-key|unique-|<|\$|\{)/;
 
-    const hits = gitGrep('account_key=[A-Za-z0-9_-]{8,}')
-      .filter((line) => {
-        const value = line.match(/account_key=([A-Za-z0-9_-]{8,})/)?.[1] ?? '';
-        return !PLACEHOLDER.test(value);
-      })
-      // The API reference is a documentation file of example URLs, not config.
-      .filter((line) => !line.startsWith('docs/'));
+    const hits = gitGrep('account_key=[A-Za-z0-9_-]{8,}').filter(line => {
+      const value = line.match(/account_key=([A-Za-z0-9_-]{8,})/)?.[1] ?? '';
+      return !PLACEHOLDER.test(value);
+    });
 
     expect(hits).toEqual([]);
   });


### PR DESCRIPTION
Closes #47. Part of the school-group booking map #46.

## Why this should merge sooner rather than later

**The `.gitignore` rule in this branch is the only thing protecting a real Clubworx API key that is now on disk**, and it only protects the branch it is on.

Observed twice on 2026-08-17: the session-start sync hook returns this submodule to `main`, which does not carry the rule, while `cloudflare-clubworx/.dev.vars` stays on disk. On that checkout git reports `?? cloudflare-clubworx/` — untracked but **not ignored** — so a `git add .` or `commit -A` would stage a live key into this **public** repo.

Merging is what closes that. Until then: `git check-ignore cloudflare-clubworx/.dev.vars` before staging anything here.

> ⚠️ **Merging this deploys**, per the repo's rule that `main` is production. The site content is unchanged — this adds a gitignore rule, a test, two docs and a directory. No page, worker or `tools.json` behaviour is touched.

## What is here

**The answer to #47**, in `cloudflare-clubworx/ACCESS.md`:

- **One key per gym** — Clubworx offers no second key, so attribution by key is impossible. `noreply+<school>@` becomes the only provenance signal this system will have, which raises its stakes for the review-table ticket.
- **No sandbox** — 2,365 lines of API reference mention none, and no public source describes one. All probing hits the live ~60k-profile database, where contacts are permanent.
- **Key location** — gitignored `cloudflare-clubworx/.dev.vars`, template beside it. **Verified working**: read-only `GET /locations` → HTTP 200, 5 rows.
- **Write probes authorised** under one test identity, `Ztest Wayfinder` / `1900-01-01` / `noreply+wayfindertest@urbanjungleirc.com`.

**A leak path found and closed.** Only `cloudflare-worker/` ignored `.dev.vars`, via its own file — so a key in any *new* Worker directory was committable. The rule now sits at the root, covers directories that do not exist yet, and covers `.dev.vars.<environment>` (Wrangler's own convention) and `.env` too.

`cloudflare-worker/test/secret-hygiene.test.js` checks it. Each assertion was verified able to fail by planting a fake key and a tracked `.dev.vars`. One initially passed for the wrong reason — `git grep -E` has no lookahead, so it rejected the pattern and the `catch` read that as a clean repo; it now separates "no match" from "command failed".

**Free finding for #51:** Clubworx sends no `Retry-After` and no `X-RateLimit-*` headers. Limits are unadvertised, not just undocumented — clients cannot self-throttle from response metadata.

## Known limitation, stated plainly

**Nothing runs the guard automatically.** `pages.yml` is this repo's only workflow and runs no tests, so the check fires only when someone runs vitest by hand. Wiring it in is recommended in ACCESS.md as a *separate* workflow — inside `pages.yml` a failing test would freeze the site rather than block a commit. Not done here because it changes CI on a public auto-deploying repo.

## Verification

- `cloudflare-worker`: **81/81 pass**, `node --check` clean.
- `vouchers`: 216/217 — the one failure (`computeVersion` "outside a git repository") is pre-existing and reproduces on a clean tree with this work stashed.
- Remote branch confirmed to contain no `.dev.vars` or `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
