### PR TITLE
Probe #51: /events ignores contact_key, and the Clubworx rate ceiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ _site/
 
 # Checked by cloudflare-worker/test/secret-hygiene.test.js — run by hand, not in
 # CI, because pages.yml runs no tests. The rule above is the actual control.
+
+# Raw output from the Clubworx probes. Everything the probes write is already
+# reduced to counts, ids and timings before it lands (see probes/lib/report.mjs),
+# so this is a second line rather than the first — but pages.yml rsyncs the whole
+# tree to a public site, and the write probes on #49/#50 will hold contact keys.
+# The findings that matter are written up by hand in probes/*.md.
+cloudflare-clubworx/probes/out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ cloudflare-payments-proxy/ - Worker bridging vouchers/ to uj-payments with the A
 cloudflare-clubworx/    - Clubworx API access for the school-group booking tool (#46).
                           ACCESS.md is the answer to #47: where the key comes from,
                           where it lives, and what is still owed. No Worker code yet.
+cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, and
+                          what they found. Start with probes/README.md — it carries
+                          the rules (no production data recorded, pace under
+                          75 req/min) that any new probe has to follow.
 vouchers/               - voucher management portal (auth = Cloudflare Access)
 vouchers/stats.html     - voucher analytics: revenue, liability, redemption, product mix
 vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and why

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -234,3 +234,37 @@ runs on the deploy path and must never be able to stop the site publishing. A
 plain checkout has no `version.json` at all, so anything reading it must treat
 missing and `dev` alike as "no version" — that is the normal state during local
 development, not a fault.
+
+## Clubworx pacing
+
+Terms for talking to the Clubworx API without being cut off. Measured in
+[staff-site#51](https://github.com/urbanjungleirc/staff-site/issues/51); evidence
+in `cloudflare-clubworx/probes/51-events-and-burst.md`.
+
+### Rate ceiling
+
+The point at which Clubworx starts returning **429**. It is undocumented and,
+unlike most APIs, **unadvertised**: no `Retry-After`, no `X-RateLimit-*`, not
+even on the 429 itself. A client cannot read it, cannot see it approaching, and
+cannot be told when it lifts — it can only measure it.
+
+Measured: spent faster than ~3 requests/second, roughly **50 requests** get
+through, after which the API refuses for about **18 seconds**.
+
+Say *ceiling* rather than "rate limit" when referring to the observed boundary,
+because "the rate limit" implies a published figure and there is none.
+
+### Pacing
+
+The gap a client deliberately leaves between Clubworx requests. **75 requests
+per minute, one in flight, 800ms apart** is the house figure — verified to run a
+full 90-read lookup clean, twice, with margin left over.
+
+Pacing is the control, not concurrency. Requests in flight change only how fast
+the ceiling arrives, never how much is allowed: four concurrent reached it
+*sooner* than one and then failed 41 requests in a row.
+
+The margin exists for other systems, not this one. There is **one Clubworx key
+for the whole gym** (see `cloudflare-clubworx/ACCESS.md`), so HVT's roster
+Worker, n8n and staff-site all spend the same allowance. A run here can throttle
+something unrelated, with nothing in either system's logs to explain it.

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -65,6 +65,10 @@ approaching a ceiling before hitting one. Whatever limits exist must be
 discovered by observing failures, which makes conservative pacing in the
 bulk-create loop a design requirement rather than a nicety.
 
+That has since been done — [#51](https://github.com/urbanjungleirc/staff-site/issues/51)
+measured the ceiling and a pace that clears it, and confirmed the headers stay
+absent even mid-throttle. See `probes/51-events-and-burst.md`.
+
 ### A read-only path that needs no key at all
 
 Worth knowing before anyone hurries the key out of the admin UI: the deployed
@@ -156,10 +160,14 @@ expose list / show / create / update only. So each write probe leaves a
 Bookings are the exception — `DELETE /api/v2/bookings/:id` exists, so the
 booking half of probe #50 is reversible; the contact it needs is not.
 
-**Rate limits are undocumented rather than known to be absent.** Nothing in the
-reference describes throttling, retry-after, or a burst ceiling. Probe #51 is
-what would discover them empirically. Until it runs, assume limits exist and
-are unknown — do not hammer the API.
+**Rate limits are undocumented but no longer unknown.** Nothing in the reference
+describes throttling, retry-after, or a burst ceiling. Probe #51 has since
+measured them: roughly **50 requests** get through when spent faster than ~3/s,
+after which the API returns 429 for about **18 seconds**, with no headers of any
+kind to warn or explain. **75 requests/minute, one in flight, ran clean.**
+
+Anything talking to Clubworx from this repo — probes included — paces at or under
+that. Full evidence and the reasoning: `probes/51-events-and-burst.md`.
 
 ## 4. Authorisation and test identity — SETTLED
 
@@ -214,7 +222,9 @@ there is exactly one of it.
 | No sandbox exists | All probing is against production; unavoidable, not a choice |
 | Contacts cannot be deleted via API | Every write probe leaves a permanent record; bookings are reversible, contacts are not |
 | Clubworx issues **one key per gym**, confirmed | Attribution by key is impossible; the `noreply+<school>@` marker is the only provenance signal. One key's leak or rotation hits every integration |
-| Rate limits undocumented **and unadvertised** | Confirmed live: no `Retry-After` or `X-RateLimit-*` headers come back. A client cannot self-throttle from response metadata or see a ceiling approaching — only hit it. Pace conservatively |
+| Rate limits undocumented **and unadvertised** | Confirmed live, and confirmed again *while being throttled* (#51): no `Retry-After` or `X-RateLimit-*` headers come back at any point. A client cannot self-throttle from response metadata or see a ceiling approaching — only hit it |
+| The ceiling is **tight**: ~50 fast requests, then ~18s of 429 (#51) | 75 req/min ran clean; 120 did not. Every caller must pace, and the allowance is shared across the whole gym key, so this tool can throttle HVT and vice versa |
+| `GET /events` ignores `contact_key` entirely (#51) | The event picker works gym-wide — but this contradicts the published reference, so it may be enforced one day. The paste-the-event-id fallback is mandatory, not a nicety |
 | The gitignore rule is **branch-local until merged** | Observed twice on 2026-08-17: the session-start sync hook returns this submodule to `main`, where the rule does not exist, while `.dev.vars` stays on disk. On that checkout the key is untracked-but-not-ignored, so `git add .` would stage it into a public repo. Merging the rule to `main` is what actually closes this |
 | Existing `uj-clubworx` Worker caps paging at 300 records | Usable for read probes, but cannot answer #51's burst question |
 | Cloudflare secrets are write-only | The existing key cannot be recovered; it must come from the admin UI |

--- a/cloudflare-clubworx/package-lock.json
+++ b/cloudflare-clubworx/package-lock.json
@@ -1,0 +1,1479 @@
+{
+  "name": "uj-clubworx-probes",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "uj-clubworx-probes",
+      "devDependencies": {
+        "vitest": "^2.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/cloudflare-clubworx/package.json
+++ b/cloudflare-clubworx/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "uj-clubworx-probes",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "probe:51": "node probes/run-51.mjs"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.0"
+  }
+}

--- a/cloudflare-clubworx/probes/51-events-and-burst.md
+++ b/cloudflare-clubworx/probes/51-events-and-burst.md
@@ -1,0 +1,229 @@
+# Probe: event listing without a contact_key, and burst behaviour
+
+Answer to [staff-site#51](https://github.com/urbanjungleirc/staff-site/issues/51),
+part of the school-group booking map ([#46](https://github.com/urbanjungleirc/staff-site/issues/46)).
+Access and authorisation come from [#47](https://github.com/urbanjungleirc/staff-site/issues/47) — see `../ACCESS.md`.
+
+Ran 2026-08-17 against **production** Clubworx (there is no sandbox). Read-only
+throughout: 881 GETs across ten runs, nothing created, updated or deleted.
+
+Reproduce with `node probes/run-51.mjs` — see `README.md` in this directory.
+
+---
+
+## Headline
+
+| Question | Answer |
+|---|---|
+| Does `GET /events` work without a `contact_key`? | **Yes.** HTTP 200. The parameter is ignored entirely. |
+| Is the list gym-wide or scoped to that contact? | **Gym-wide.** Omitted, blank, arbitrary and a real key all return the identical event set. |
+| Is anything actually required? | **The date window is.** Omit `event_starts_after`/`event_ends_before` and it is HTTP 422. |
+| Does `page_size` work above 50? | **Yes**, verified to 200 — but the default is 50 and a full page is silent truncation. |
+| Is there a rate limit? | **Yes, and it is tight.** ~50 requests when spent faster than ~3/s. Undocumented, and unadvertised even while throttling. |
+| A concurrency that runs clean? | Concurrency is the wrong lever — see below. **1 in flight at 800ms (75/min)** ran 90 reads clean, twice. |
+
+**The event picker is unblocked.** It can list this week's events directly,
+including an event nobody has booked into yet — which was the whole reason the
+HVT Worker's derive-from-bookings trick could not be reused here.
+
+---
+
+## 1. Event listing
+
+`GET /api/v2/events` documents `contact_key` as **required**. It is not.
+
+| Request | Status | Events returned |
+|---|---|---|
+| `contact_key` omitted entirely | 200 | 50 |
+| `contact_key=` (present, blank) | 200 | 50 |
+| `contact_key=zzzz-not-a-real-contact-key` | 200 | 50 |
+| `contact_key=<a real member's key>` | 200 | 50 |
+| no date window at all | **422** | — |
+
+All four `contact_key` variants returned the **same event ids**. The parameter
+is not merely optional, it is ignored: an arbitrary string that matches no
+contact neither errors nor filters. A real member's key returns the same
+gym-wide list as no key at all, so `/events` cannot be used to ask "what is this
+person booked into" — that is `GET /bookings?contact_key=`, and always was.
+
+The documentation is wrong in the same direction elsewhere, which is mild
+corroboration rather than coincidence: `/member_styles` documents `contact_key`
+with *"leave blank to return records for all contacts"*, so a blank-means-all-
+contacts convention already exists in this API and simply is not written down
+on `/events`.
+
+**What is actually required is the date window.** Dropping both date parameters
+returns HTTP 422 with an empty body. So the picker always asks for a range,
+which is what it wanted to do anyway.
+
+### The 50 that is not a total
+
+Every variant returned exactly 50 events — the default `page_size`. A three-month
+window at UJ holds more than that:
+
+| Request | Events |
+|---|---|
+| default `page_size` | 50 |
+| `page_size=200` | 200 |
+| `page=2` | 50 |
+
+So the first result was a **truncated page**, indistinguishable from a complete
+list by anything in the response — no total, no next-page link, no header.
+
+This is a trap for the picker specifically. A staff member opening "events this
+term" and seeing 50 rows has no way to know the session they want is on page 2,
+and neither has the page unless it counts. Two rules follow, and they are cheap:
+
+- Request a **narrow window** (the picker wants this week or this term, not a
+  quarter), and
+- when a page comes back **full**, either fetch the next page or say so. The
+  same *"list truncated — narrow by hand"* flag the matching design already
+  specifies for candidate lists applies here verbatim.
+
+### Fields available for the picker
+
+`event_id`, `event_name`, `event_start_at`, `event_end_at`, `location_id`,
+`location_name`, `free_class`, `instructor_name`, `event_full`,
+`spaces_available`, `event_description` — matching the reference exactly.
+
+`spaces_available` and `event_full` are worth noting: a school group of 30 into
+an event with 12 spaces is a failure the page can predict before it books
+anything, rather than discovering it partway through a batch.
+
+### The paste-the-id fallback is still required
+
+#51 says to build it regardless of this outcome, and that stands. The picker now
+has a real listing, but the fallback field is the path that cannot break: it
+survives the listing being wrong, the window being wrong, the event being
+outside whatever range the picker offers, and Clubworx changing its mind about
+an undocumented behaviour this probe is entirely built on.
+
+That last risk is not theoretical. **The behaviour this unblocks is undocumented
+and contradicts the published reference.** Nothing stops Clubworx from enforcing
+what its own docs say, and the day it does, the picker returns 422 for every
+staff member at once. A paste field turns that from an outage into an
+inconvenience.
+
+Recorded as a hard requirement on [#54](https://github.com/urbanjungleirc/staff-site/issues/54).
+
+---
+
+## 2. Rate limiting
+
+**There is a rate limit, it is tight, and it is invisible.** Clubworx sends **no
+rate-limit headers at all** — not approaching the ceiling, not on the 429 itself.
+No `Retry-After`, no `X-RateLimit-*`, nothing. Confirmed under live throttling,
+which is stronger evidence than #47's observation on a single clean request: the
+API does not advertise a limit even at the moment it is enforcing one.
+
+Every run, at every rate tried:
+
+| Run | Request rate | Result |
+|---|---|---|
+| 90 reads, 4 concurrent, unpaced | ~4/s | 49 × 200, then **41 × 429** |
+| serial unpaced ×4 runs | ~3.4/s | **49 accepted every single time**, then 429 |
+| 90 reads paced 150/min | ~1.8/s | 83 × 200, 7 × 429 |
+| 90 reads paced 120/min | ~1.7/s | 89 × 200, 1 × 429 |
+| 90 reads paced 96/min ×2 | ~1.5/s | **90 × 200, clean, both runs** |
+| 90 reads paced 75/min ×2 | ~1.2/s | **90 × 200, clean, both runs** |
+
+Two figures are solid enough to design against:
+
+- **Spent fast, the allowance is ~50 requests.** Four separate serial runs from a
+  rested start accepted **exactly 49** before the first 429 — no spread at all.
+- **The throttle lifts in about 18 seconds**, measured by polling the cheapest
+  read every 5s after the wall. It is not a long ban.
+
+### What the exact shape is — and why this stops short of naming it
+
+The obvious reading is a quota per rolling window, and "50 per 30 seconds" fits
+almost everything above. It is not claimed here, because one run contradicts it:
+the unpaced 4-concurrent burst put **60 requests through in ~15 seconds**, while
+the serial runs were cut off at **50 in ~14.7 seconds**. Same span, different
+allowance, so a flat count-per-window is not what is happening. A token bucket
+was fitted to those two points and then predicted 429s in the 96/min run that
+did not occur, so that is not it either.
+
+Something rate-shaped is being enforced and the published behaviour is not
+enough to name the algorithm. Spending more production load to reverse-engineer
+it was judged not worth it: the design does not need the algorithm, only a rate
+it can trust, and that has been measured directly and reproduced.
+
+**The boundary sits between 96/min and 120/min sustained.** Both rates below it
+ran a full 90-read lookup clean, twice each; both above it threw 429s.
+
+### Concurrency is the wrong lever
+
+Four in flight did not survive any better than one — it reached the ceiling
+*sooner*, and then failed 41 requests in a row. What separated a clean run from a
+throttled one in every test above was the **rate**, never the number in flight.
+That follows from the shape of the thing: whatever is being counted, spending it
+through four sockets instead of one does not buy more of it.
+
+So the guard the design needs is a **request rate**. Concurrency then becomes a
+free choice underneath it — 4 in flight is fine if the rate is capped, and
+dangerous if it is not.
+
+This matters because it is the one number in the matching design that was a
+guess. Its "bounded concurrency (start at 4 in flight), exponential backoff on
+429" was written when no limit was known — and run as written, with no rate cap,
+it produces exactly the first row of that table: 49 successes, then 41
+consecutive failures. The backoff would eventually rescue it, having already
+failed half the list.
+
+### Recommended pacing
+
+**75 requests/minute — one in flight, 800ms apart.** Verified clean twice over a
+full 90-read lookup. That is a **37% margin** under 120/min, the slowest rate
+observed to throttle, and 22% under 96/min, the fastest verified clean.
+`recommendPacing()` in `lib/report.mjs` arrives at the same figure from the raw
+measurements, which is a sanity check rather than an independent derivation —
+both rest on the same probe.
+
+96/min also ran clean twice and is available if the wait proves intolerable, but
+it sits directly against the boundary with no margin for a second system sharing
+the key (see below), so 75 is the one to ship.
+
+At 800ms spacing a 30-name lookup (90 reads, per the matching design's call
+budget) takes **~74 seconds** — measured, not projected. That is slow enough to
+need a progress indicator and a per-run call counter, both already specified, and
+it turns the design's "minimise calls" instinct from good practice into the
+difference between a minute and five.
+
+Retries must be **backoff, not immediate**. There is no `Retry-After` to obey,
+and the observed throttle lasted ~18 seconds from the wall; a retry loop without
+a floor of that order will simply spend the next window's allowance failing.
+
+### One consequence beyond this feature
+
+The allowance is almost certainly **per gym key**, and per #47 there is exactly
+one key for the whole gym. The HVT roster Worker, any n8n workflow and this tool
+all draw on it. A bulk lookup is therefore capable of throttling an unrelated
+system, and vice versa — an HVT roster call can fail because this page is
+mid-lookup, and nothing in either system's logs would explain why.
+
+This is also why the recommended pace leaves real headroom rather than sitting
+at the measured boundary: the margin is not for this tool, it is for whatever
+else happens to be talking to Clubworx at the same moment.
+
+Nothing here fixes that; it is recorded because it is invisible in any single
+system's code and belongs in the design's failure model
+([#53](https://github.com/urbanjungleirc/staff-site/issues/53)).
+
+---
+
+## What this probe did not answer
+
+- **The actual limiting algorithm.** See above: neither a flat count-per-window
+  nor a token bucket fits all the measurements. Pinning it down means a lot more
+  load on a live gym database to learn something the design does not need, since
+  a verified safe rate answers the same question.
+- **Whether 429s themselves consume quota.** The recovery poll ran every 5s and
+  cleared, so they are at worst not fatal. Unresolved.
+- **Whether the limit is per key, per IP, or both.** Only one key and one IP
+  were available. Assume per key, since that is the worse case for the shared-
+  key consequence above.
+- **Write-path limits.** Everything here is reads. Whether `POST /bookings`
+  draws on the same allowance is [#50](https://github.com/urbanjungleirc/staff-site/issues/50)'s
+  to find out — and if it does, a 30-student booking batch is a 30-request
+  write burst that must be paced the same way.

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -1,0 +1,72 @@
+# Clubworx probes
+
+Small scripts that answer a specific question about the live Clubworx API, and
+the write-ups of what they found. They exist because the API reference is
+incomplete and occasionally wrong, and because **Clubworx has no sandbox** — the
+only way to learn how it behaves is to ask it, carefully, in production.
+
+| File | What it answers |
+|---|---|
+| `51-events-and-burst.md` | [#51](https://github.com/urbanjungleirc/staff-site/issues/51) — event listing without a `contact_key`, and rate limits |
+| `run-51.mjs` | The probe that produced it |
+
+Access, authorisation and the key's whereabouts: `../ACCESS.md`.
+
+## Running
+
+Needs `../.dev.vars` with `CLUBWORX_ACCOUNT_KEY` — see ACCESS.md section 1.
+
+```bash
+cd cloudflare-clubworx
+npm install
+
+node probes/run-51.mjs --dry-run     # what it would call, without calling
+node probes/run-51.mjs               # event listing, pagination, burst  (~100 reads)
+node probes/run-51.mjs --calibrate   # find the ceiling, then verify a pace (~5 min)
+node probes/run-51.mjs --walls=3     # measure the ceiling repeatedly
+node probes/run-51.mjs --pace-per-min=96   # is this rate sustainable?
+
+npm test                             # the pure logic, no network
+```
+
+Runs write a JSON summary to `probes/out/`, which is gitignored.
+
+## The rules these scripts follow
+
+Every one of them is a consequence of *production, public repo, no sandbox*.
+
+- **Read-only unless the ticket says otherwise.** `lib/http.mjs` is the only way
+  out to Clubworx and it can only issue GET. #51 needed nothing else. The write
+  probes (#49, #50) are separately authorised in ACCESS.md section 4 and must
+  reuse the one agreed test identity, because Clubworx **cannot delete contacts
+  through the API** — every contact a probe creates is permanent.
+- **Never record a row of production data.** Responses are reduced to counts,
+  ids, field names and timings by `lib/report.mjs` before anything is printed or
+  written. Clubworx holds ~60,000 real people and this repo is public and
+  rsynced to a live site by `pages.yml`. `probes/out/` is gitignored as a second
+  line, but the first line is that there is nothing sensitive in it to begin
+  with.
+- **No real names in the repo, including as test inputs.** The burst probe
+  queries two-letter fragments rather than a surname list. `last_name` is a
+  partial match, so they cost exactly what real surnames would.
+- **The key never reaches the output.** `redact()` covers the percent-encoded
+  form too, and error paths run through it as well — node interpolates the URL
+  into its own connection errors.
+- **Pace it.** The API allows roughly 50 requests spent quickly, sends no
+  rate-limit headers at all, and 429s for ~18 seconds. Anything new should stay
+  at or under **75 requests/minute** — see `51-events-and-burst.md`.
+
+## Layout
+
+```
+lib/request.mjs   URL building and redaction        (unit tested)
+lib/report.mjs    response → publishable summary    (unit tested)
+lib/http.mjs      the only path to Clubworx: GET    (unit tested)
+run-51.mjs        the #51 probe itself
+```
+
+The libraries are tested and the runner is not. That split is deliberate: the
+runner's job is to talk to a live API, which a unit test cannot do, so
+everything with a decision in it — what to ask for, what may be written down,
+what a burst means — was pushed into a library that can be tested without the
+network.

--- a/cloudflare-clubworx/probes/lib/http.mjs
+++ b/cloudflare-clubworx/probes/lib/http.mjs
@@ -1,0 +1,68 @@
+/**
+ * The only path a probe takes to Clubworx.
+ *
+ * Deliberately narrow: it issues GET, it redacts, and it never throws. Probes
+ * on this map (staff-site#48–#51) run against production because Clubworx has
+ * no sandbox, so "read-only" has to be a property of the code rather than a
+ * promise in a comment.
+ */
+
+import { buildUrl, redact } from './request.mjs';
+import { rateLimitHeaders } from './report.mjs';
+
+/**
+ * @param {object} opts
+ * @param {string} opts.accountKey
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @returns {((path: string, params?: object) => Promise<object>) & { calls: number }}
+ */
+export function createGetter({ accountKey, fetchImpl = fetch }) {
+  const get = async (path, params = {}) => {
+    const url = buildUrl({ path, accountKey, params });
+    const safeUrl = redact(url, accountKey);
+    get.calls += 1;
+
+    const started = performance.now();
+    try {
+      const res = await fetchImpl(url, { method: 'GET', headers: { Accept: 'application/json' } });
+      const ms = Math.round(performance.now() - started);
+      const bodyText = await res.text();
+
+      // A throttle or a WAF block answers in HTML. Parsing must not be what
+      // decides whether the sample gets recorded.
+      let body = null;
+      try {
+        body = JSON.parse(bodyText);
+      } catch {
+        body = null;
+      }
+
+      return {
+        url: safeUrl,
+        status: res.status,
+        ms,
+        headers: rateLimitHeaders(res.headers),
+        contentType: res.headers.get?.('content-type') ?? null,
+        body,
+        bodyText: body === null ? redact(bodyText, accountKey).slice(0, 500) : null,
+        error: null,
+      };
+    } catch (err) {
+      // The url is interpolated into node's own connection errors, so the
+      // message is redacted rather than trusted.
+      return {
+        url: safeUrl,
+        status: null,
+        ms: Math.round(performance.now() - started),
+        headers: {},
+        contentType: null,
+        body: null,
+        bodyText: null,
+        error: redact(err.code ?? err.message ?? 'unknown error', accountKey),
+      };
+    }
+  };
+
+  get.calls = 0;
+  return get;
+}

--- a/cloudflare-clubworx/probes/lib/http.test.js
+++ b/cloudflare-clubworx/probes/lib/http.test.js
@@ -17,7 +17,7 @@ const fakeFetch = (calls, response = {}) => {
 };
 
 describe('createGetter', () => {
-  const key = 'KEY123456';
+  const key = 'unique-not-a-real-key';
 
   it('issues GET and nothing else — every probe on this map is read-only', async () => {
     const calls = [];

--- a/cloudflare-clubworx/probes/lib/http.test.js
+++ b/cloudflare-clubworx/probes/lib/http.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { createGetter } from './http.mjs';
+
+// This wrapper is the only way a probe reaches Clubworx, and Clubworx has no
+// sandbox. Everything asserted here is a safety property of hitting a live
+// 60,000-person production database from a public repo.
+
+const fakeFetch = (calls, response = {}) => {
+  return async (url, init) => {
+    calls.push({ url, init });
+    return {
+      status: response.status ?? 200,
+      headers: new Headers(response.headers ?? { 'content-type': 'application/json' }),
+      text: async () => response.text ?? '[]',
+    };
+  };
+};
+
+describe('createGetter', () => {
+  const key = 'KEY123456';
+
+  it('issues GET and nothing else — every probe on this map is read-only', async () => {
+    const calls = [];
+    await createGetter({ accountKey: key, fetchImpl: fakeFetch(calls) })('events');
+    expect(calls[0].init.method).toBe('GET');
+  });
+
+  it('asks for JSON, as the API reference does', async () => {
+    const calls = [];
+    await createGetter({ accountKey: key, fetchImpl: fakeFetch(calls) })('events');
+    expect(calls[0].init.headers.Accept).toBe('application/json');
+  });
+
+  it('reports the url with the key redacted, never the raw one', async () => {
+    const get = createGetter({ accountKey: key, fetchImpl: fakeFetch([]) });
+    const res = await get('events', { page: 1 });
+    expect(res.url).toContain('<CLUBWORX_ACCOUNT_KEY>');
+    expect(res.url).not.toContain(key);
+  });
+
+  it('returns status, timing, headers and parsed body', async () => {
+    const get = createGetter({
+      accountKey: key,
+      fetchImpl: fakeFetch([], { status: 200, text: '[{"event_id":7}]' }),
+    });
+    const res = await get('events');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ event_id: 7 }]);
+    expect(typeof res.ms).toBe('number');
+  });
+
+  it('keeps an unparseable body as text rather than throwing', async () => {
+    // A 429 or a WAF block is usually HTML. Throwing there would abandon the
+    // burst at exactly the sample worth recording.
+    const get = createGetter({
+      accountKey: key,
+      fetchImpl: fakeFetch([], { status: 429, text: '<html>Too Many Requests</html>' }),
+    });
+    const res = await get('events');
+    expect(res.status).toBe(429);
+    expect(res.bodyText).toContain('Too Many Requests');
+    expect(res.body).toBeNull();
+  });
+
+  it('turns a transport failure into a sample instead of crashing the run', async () => {
+    const get = createGetter({
+      accountKey: key,
+      fetchImpl: async () => {
+        throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+      },
+    });
+    const res = await get('events');
+    expect(res.error).toBe('ECONNRESET');
+    expect(res.status).toBeNull();
+  });
+
+  it('never lets the key reach an error message', async () => {
+    const get = createGetter({
+      accountKey: key,
+      fetchImpl: async url => {
+        throw new Error(`connect failed for ${url}`);
+      },
+    });
+    const res = await get('events');
+    expect(JSON.stringify(res)).not.toContain(key);
+  });
+
+  it('counts every call it makes, so a probe cannot quietly cost more than it says', async () => {
+    const get = createGetter({ accountKey: key, fetchImpl: fakeFetch([]) });
+    await get('events');
+    await get('members');
+    expect(get.calls).toBe(2);
+  });
+});

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -1,0 +1,168 @@
+/**
+ * Turning live probe responses into something publishable.
+ *
+ * Everything a probe records goes through here first. The rule is that the
+ * output holds counts, ids, status codes, header names and timings — and no row
+ * of production data. Clubworx holds ~60,000 real people and staff-site#46's
+ * standing constraint forbids real names reaching this public repo, so the
+ * summariser is what makes a findings document safe to commit rather than a
+ * gitignore rule somebody has to remember.
+ */
+
+/** Nearest-rank percentile. Null for an empty set, so it never prints as NaN. */
+export function percentile(values, p) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.min(Math.max(rank, 1), sorted.length) - 1];
+}
+
+/**
+ * Summarise a burst of responses.
+ *
+ * @param {Array<{status?: number, ms: number, error?: string}>} samples
+ */
+export function summariseBurst(samples) {
+  const byStatus = {};
+  const errors = {};
+  const latencies = [];
+  let firstThrottledIndex = null;
+
+  samples.forEach((sample, i) => {
+    latencies.push(sample.ms);
+
+    if (sample.error) {
+      errors[sample.error] = (errors[sample.error] ?? 0) + 1;
+      return;
+    }
+
+    byStatus[sample.status] = (byStatus[sample.status] ?? 0) + 1;
+    // Index 0 is a real answer — a ceiling hit on the very first call — so this
+    // stays null rather than 0 when nothing was throttled.
+    if (sample.status === 429 && firstThrottledIndex === null) firstThrottledIndex = i;
+  });
+
+  const statuses = samples.filter(s => !s.error).map(s => s.status);
+
+  return {
+    count: samples.length,
+    byStatus,
+    errors,
+    throttled: statuses.filter(s => s === 429).length,
+    firstThrottledIndex,
+    clean: samples.length > 0 && samples.every(s => !s.error && s.status >= 200 && s.status < 300),
+    ms: {
+      min: percentile(latencies, 0) ?? null,
+      p50: percentile(latencies, 50),
+      p95: percentile(latencies, 95),
+      max: percentile(latencies, 100),
+    },
+  };
+}
+
+// The spellings seen in the wild: RFC 6585's Retry-After, the draft
+// RateLimit-* family, and the older X- prefixed variants.
+const RATE_LIMIT = /^(retry-after|x-)?(rate-?limit)/i;
+
+/**
+ * Pick out any header a client could self-throttle from.
+ *
+ * @param {Headers|Record<string,string>} headers
+ * @returns {Record<string,string>}
+ */
+export function rateLimitHeaders(headers) {
+  const entries =
+    typeof headers?.entries === 'function' ? [...headers.entries()] : Object.entries(headers ?? {});
+
+  const found = {};
+  for (const [name, value] of entries) {
+    const lower = String(name).toLowerCase();
+    if (lower === 'retry-after' || RATE_LIMIT.test(lower)) found[lower] = String(value);
+  }
+  return found;
+}
+
+/**
+ * Reduce an /events response to its shape.
+ *
+ * Ids and the field list only. Event names at UJ carry school names, and
+ * `instructor_name` is a staff member — neither may be written down here.
+ *
+ * @param {unknown} body
+ */
+export function summariseEvents(body) {
+  if (!Array.isArray(body)) {
+    return { count: 0, ids: [], fields: [], earliest: null, latest: null, notAnArray: true };
+  }
+
+  const fields = new Set();
+  const starts = [];
+  for (const row of body) {
+    for (const key of Object.keys(row ?? {})) fields.add(key);
+    if (row?.event_start_at) starts.push(row.event_start_at);
+  }
+  starts.sort();
+
+  return {
+    count: body.length,
+    ids: body.map(r => r?.event_id).sort((a, b) => a - b),
+    fields: [...fields],
+    earliest: starts[0] ?? null,
+    latest: starts[starts.length - 1] ?? null,
+    notAnArray: false,
+  };
+}
+
+/**
+ * Describe an observed ceiling as requests per minute.
+ *
+ * Clubworx sends no rate-limit headers even while returning 429 (staff-site#51,
+ * confirmed under live throttling), so a client cannot read a limit — it can
+ * only measure one. Two numbers are needed and both come from a probe: how many
+ * requests were accepted before the wall, and how long the wall lasted.
+ *
+ * The result is an inference, not a published figure, so the raw measurements
+ * travel with it.
+ *
+ * @param {{allowed: number, windowMs: number}} observed
+ */
+export function deriveRateLimit({ allowed, windowMs }) {
+  if (!(windowMs > 0)) throw new Error('deriveRateLimit: window must be a positive duration');
+  if (!(allowed > 0)) {
+    throw new Error(
+      'deriveRateLimit: allowed must be positive — a run that was never throttled ' +
+        'shows the limit is above what was tried, not what it is',
+    );
+  }
+  return { allowed, windowMs, perMinute: Math.round((allowed / windowMs) * 60_000) };
+}
+
+/**
+ * A pace to run at, given a measured ceiling.
+ *
+ * Concurrency is always 1. Under a per-window quota, eight requests in flight
+ * spend the allowance exactly as fast as one — concurrency changes only how
+ * soon the wall arrives, so the lever that matters is the gap between requests.
+ *
+ * @param {{allowed: number, windowMs: number, safety?: number, reads?: number}} opts
+ */
+export function recommendPacing({ allowed, windowMs, safety = 0.8, reads }) {
+  const { perMinute: ceiling } = deriveRateLimit({ allowed, windowMs });
+  const perMinute = Math.floor(ceiling * safety);
+  const gapMs = Math.round(60_000 / perMinute);
+
+  return {
+    concurrency: 1,
+    perMinute,
+    gapMs,
+    safety,
+    estimatedMsFor: reads ? reads * gapMs : null,
+  };
+}
+
+/** Do two runs describe the same set of events, regardless of order? */
+export function sameIds(a, b) {
+  if (a.length !== b.length) return false;
+  const left = new Set(a);
+  return b.every(id => left.has(id));
+}

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import {
+  percentile,
+  summariseBurst,
+  rateLimitHeaders,
+  summariseEvents,
+  sameIds,
+  deriveRateLimit,
+  recommendPacing,
+} from './report.mjs';
+
+// What a probe is allowed to write down. Everything here is counts, ids, status
+// codes and timings — never a row of production data. staff-site is a public
+// repo and Clubworx holds ~60,000 real people, so the reporting layer is the
+// control that keeps a findings document publishable.
+
+describe('percentile', () => {
+  // Nearest rank: index = ceil(p/100 * N), so p50 of ten values is the fifth,
+  // not the sixth. No interpolation — every figure reported is a latency that
+  // was actually observed, which is what a burst probe wants.
+  it('takes the nearest rank, so p50 of ten values is the fifth', () => {
+    expect(percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 50)).toBe(5);
+  });
+
+  it('returns the single value for a one-sample run', () => {
+    expect(percentile([42], 95)).toBe(42);
+  });
+
+  it('sorts numerically, not lexically — 100 is not less than 20', () => {
+    expect(percentile([100, 20, 3], 100)).toBe(100);
+  });
+
+  it('is null for an empty set rather than NaN, which would print as a number', () => {
+    expect(percentile([], 50)).toBeNull();
+  });
+});
+
+describe('summariseBurst', () => {
+  const ok = ms => ({ status: 200, ms });
+
+  it('counts responses by status code', () => {
+    const s = summariseBurst([ok(10), ok(20), { status: 429, ms: 5 }]);
+    expect(s.byStatus).toEqual({ 200: 2, 429: 1 });
+  });
+
+  it('reports the index of the first 429, which is how fast a ceiling arrives', () => {
+    const s = summariseBurst([ok(10), ok(10), { status: 429, ms: 3 }, { status: 429, ms: 3 }]);
+    expect(s.throttled).toBe(2);
+    expect(s.firstThrottledIndex).toBe(2);
+  });
+
+  it('reports no throttling as null, distinct from index 0', () => {
+    // 0 is falsy, so a caller testing `if (firstThrottledIndex)` would read a
+    // ceiling hit on the very first call as a clean run. Keep the types apart.
+    const s = summariseBurst([ok(10)]);
+    expect(s.firstThrottledIndex).toBeNull();
+    expect(summariseBurst([{ status: 429, ms: 1 }]).firstThrottledIndex).toBe(0);
+  });
+
+  it('summarises latency across the run', () => {
+    const s = summariseBurst([ok(100), ok(200), ok(300), ok(400)]);
+    expect(s.ms.min).toBe(100);
+    expect(s.ms.max).toBe(400);
+    expect(s.ms.p50).toBe(200);
+  });
+
+  it('counts transport failures separately from HTTP statuses', () => {
+    // A dropped connection has no status. Folding it into 5xx would understate
+    // the failure mode the burst is looking for.
+    const s = summariseBurst([ok(10), { error: 'ECONNRESET', ms: 12 }]);
+    expect(s.errors).toEqual({ ECONNRESET: 1 });
+    expect(s.byStatus).toEqual({ 200: 1 });
+    expect(s.count).toBe(2);
+  });
+
+  it('treats any 4xx or 5xx beyond 429 as a failure worth naming', () => {
+    const s = summariseBurst([ok(10), { status: 500, ms: 9 }]);
+    expect(s.clean).toBe(false);
+  });
+
+  it('calls a run clean only when every call was a 2xx', () => {
+    expect(summariseBurst([ok(10), ok(20)]).clean).toBe(true);
+  });
+});
+
+describe('rateLimitHeaders', () => {
+  it('picks out the headers a client could self-throttle from', () => {
+    const found = rateLimitHeaders({
+      'content-type': 'application/json',
+      'retry-after': '30',
+      'x-ratelimit-remaining': '4',
+    });
+    expect(found).toEqual({ 'retry-after': '30', 'x-ratelimit-remaining': '4' });
+  });
+
+  it('matches case-insensitively and across the spellings in the wild', () => {
+    const found = rateLimitHeaders({ 'RateLimit-Limit': '100', 'X-Rate-Limit-Reset': '60' });
+    expect(Object.keys(found).sort()).toEqual(['ratelimit-limit', 'x-rate-limit-reset']);
+  });
+
+  it('returns an empty object when the API advertises nothing', () => {
+    expect(rateLimitHeaders({ 'content-type': 'application/json' })).toEqual({});
+  });
+
+  it('accepts a fetch Headers instance, not just a plain object', () => {
+    const h = new Headers({ 'Retry-After': '5' });
+    expect(rateLimitHeaders(h)).toEqual({ 'retry-after': '5' });
+  });
+});
+
+describe('summariseEvents', () => {
+  const row = (event_id, start) => ({
+    event_id,
+    event_name: 'Real School Name Yr 5',
+    event_start_at: start,
+    location_id: 3,
+    instructor_name: 'A Real Person',
+  });
+
+  it('keeps ids, counts and the field list — never the values', () => {
+    const s = summariseEvents([row(30, '2026-08-18T09:00:00.000+08:00')]);
+    expect(s.count).toBe(1);
+    expect(s.ids).toEqual([30]);
+    expect(s.fields).toContain('event_name');
+    expect(JSON.stringify(s)).not.toContain('Real School Name');
+    expect(JSON.stringify(s)).not.toContain('A Real Person');
+  });
+
+  it('reports the date span so a window filter can be checked', () => {
+    const s = summariseEvents([
+      row(2, '2026-08-20T09:00:00.000+08:00'),
+      row(1, '2026-08-18T09:00:00.000+08:00'),
+    ]);
+    expect(s.earliest).toBe('2026-08-18T09:00:00.000+08:00');
+    expect(s.latest).toBe('2026-08-20T09:00:00.000+08:00');
+  });
+
+  it('sorts ids so two runs compare directly', () => {
+    expect(summariseEvents([row(9, 'x'), row(2, 'x')]).ids).toEqual([2, 9]);
+  });
+
+  it('unions the field list across rows, since a null field may be absent on one', () => {
+    const s = summariseEvents([{ event_id: 1 }, { event_id: 2, spaces_available: 4 }]);
+    expect(s.fields.sort()).toEqual(['event_id', 'spaces_available']);
+  });
+
+  it('survives a non-array body, which is what an error page looks like', () => {
+    const s = summariseEvents({ error: 'not authorised' });
+    expect(s.count).toBe(0);
+    expect(s.notAnArray).toBe(true);
+  });
+});
+
+describe('sameIds', () => {
+  it('is true for the same set in any order', () => {
+    expect(sameIds([1, 2, 3], [3, 2, 1])).toBe(true);
+  });
+
+  it('is false when one set holds an event the other does not', () => {
+    // This is the actual question: does a different contact_key change what
+    // comes back, or is the parameter ignored and the list gym-wide?
+    expect(sameIds([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  it('is true for two empty sets', () => {
+    expect(sameIds([], [])).toBe(true);
+  });
+});
+
+// Clubworx returns no rate-limit headers even while throttling (confirmed under
+// live 429s, staff-site#51), so the ceiling can only be described by two
+// measurements: how many requests were accepted before the wall, and how long
+// the wall lasted. Everything downstream is arithmetic on those two numbers,
+// which is why it is here and unit tested rather than inline in the probe.
+
+describe('deriveRateLimit', () => {
+  it('reads a quota as requests per minute', () => {
+    expect(deriveRateLimit({ allowed: 60, windowMs: 60_000 }).perMinute).toBe(60);
+  });
+
+  it('scales a sub-minute window up', () => {
+    expect(deriveRateLimit({ allowed: 15, windowMs: 30_000 }).perMinute).toBe(30);
+  });
+
+  it('carries the raw measurements through, since the derived figure is an inference', () => {
+    const d = deriveRateLimit({ allowed: 60, windowMs: 60_000 });
+    expect(d.allowed).toBe(60);
+    expect(d.windowMs).toBe(60_000);
+  });
+
+  it('refuses a zero or negative window rather than dividing by it', () => {
+    expect(() => deriveRateLimit({ allowed: 60, windowMs: 0 })).toThrow(/window/i);
+  });
+
+  it('refuses a run that was never throttled — there is no ceiling to derive', () => {
+    // A clean run proves the limit is above what was tried, not what it is.
+    expect(() => deriveRateLimit({ allowed: 0, windowMs: 60_000 })).toThrow(/allowed/i);
+  });
+});
+
+describe('recommendPacing', () => {
+  it('leaves headroom under the observed ceiling', () => {
+    const p = recommendPacing({ allowed: 60, windowMs: 60_000, safety: 0.8 });
+    expect(p.perMinute).toBe(48);
+    expect(p.gapMs).toBe(1250);
+  });
+
+  it('defaults to a conservative safety factor, because the window is inferred', () => {
+    expect(recommendPacing({ allowed: 60, windowMs: 60_000 }).perMinute).toBeLessThan(60);
+  });
+
+  it('recommends serial requests — concurrency cannot help under a quota', () => {
+    // A per-window quota is spent at the same rate by 1 request in flight or 8.
+    // Concurrency only changes how fast the wall arrives.
+    expect(recommendPacing({ allowed: 60, windowMs: 60_000 }).concurrency).toBe(1);
+  });
+
+  it('states what a 90-read lookup would cost at that pace', () => {
+    const p = recommendPacing({ allowed: 60, windowMs: 60_000, reads: 90 });
+    expect(p.estimatedMsFor).toBe(90 * 1250);
+  });
+});

--- a/cloudflare-clubworx/probes/lib/request.mjs
+++ b/cloudflare-clubworx/probes/lib/request.mjs
@@ -1,0 +1,68 @@
+/**
+ * Request shaping and secret redaction for read-only Clubworx probes.
+ *
+ * staff-site is a PUBLIC repo and Clubworx has no sandbox — every probe runs
+ * against the live gym database. Both functions here exist so that neither the
+ * URL nor anything printed about it can carry the account key into a terminal
+ * log, a pasted issue comment, or a committed findings document.
+ */
+
+export const CLUBWORX_BASE = 'https://app.clubworx.com/api/v2';
+
+/**
+ * Build a Clubworx api/v2 URL.
+ *
+ * Parameter presence is meaningful here rather than incidental: `undefined`
+ * omits a parameter entirely and `''` sends it present-but-blank. staff-site#51
+ * turns on telling those two apart for `contact_key`, so the distinction is
+ * load-bearing and must not be normalised away.
+ *
+ * @param {object} opts
+ * @param {string} opts.path       Endpoint path, e.g. 'events'.
+ * @param {string} opts.accountKey The gym's Clubworx API key.
+ * @param {Record<string, string|number|undefined>} [opts.params]
+ * @param {string} [opts.base]
+ * @returns {string}
+ */
+export function buildUrl({ path, accountKey, params = {}, base = CLUBWORX_BASE }) {
+  if (!accountKey) throw new Error('buildUrl: an account key is required');
+
+  const search = new URLSearchParams();
+  search.set('account_key', accountKey);
+
+  // Sorted so two runs of the same probe produce byte-identical URLs and can be
+  // diffed against each other.
+  for (const name of Object.keys(params).sort()) {
+    const value = params[name];
+    if (value === undefined) continue;
+    search.set(name, String(value));
+  }
+
+  return `${base}/${path}?${search.toString()}`;
+}
+
+const REDACTED = '<CLUBWORX_ACCOUNT_KEY>';
+
+const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Remove the account key from any text before it is printed or written.
+ *
+ * Covers the percent-encoded form as well as the literal one: the key travels
+ * as a query parameter, so `URLSearchParams.toString()` is where an encoded
+ * copy comes from, and a naive `replaceAll` of the raw value would sail past it.
+ *
+ * @param {unknown} text
+ * @param {string} secret
+ * @returns {string}
+ */
+export function redact(text, secret) {
+  if (!secret) throw new Error('redact: a secret is required; refusing to no-op');
+
+  const forms = new Set([secret, encodeURIComponent(secret)]);
+  let out = String(text);
+  for (const form of forms) {
+    out = out.replace(new RegExp(escapeRegExp(form), 'g'), REDACTED);
+  }
+  return out;
+}

--- a/cloudflare-clubworx/probes/lib/request.test.js
+++ b/cloudflare-clubworx/probes/lib/request.test.js
@@ -4,12 +4,19 @@ import { buildUrl, redact } from './request.mjs';
 // The two things a probe against a public repo's live production API must get
 // right before it makes a single call: the URL it asks for, and the text it is
 // allowed to print afterwards.
+//
+// The fake key starts with `unique-` on purpose. cloudflare-worker/test/
+// secret-hygiene.test.js greps every tracked file for a real-looking value on
+// the account key query parameter, and treats that prefix as a declared
+// placeholder. A fixture named anything else fails the guard — correctly, since
+// from the outside an invented key and a real one are the same string of
+// characters. Naming one here in an example would trip it too.
 
 describe('buildUrl', () => {
-  const opts = { path: 'events', accountKey: 'KEY123456' };
+  const opts = { path: 'events', accountKey: 'unique-not-a-real-key' };
 
   it('puts the account key on every request, because all 42 endpoints require it', () => {
-    expect(buildUrl(opts)).toContain('account_key=KEY123456');
+    expect(buildUrl(opts)).toContain('account_key=unique-not-a-real-key');
   });
 
   it('hits the documented api/v2 base', () => {
@@ -49,14 +56,14 @@ describe('buildUrl', () => {
 
 describe('redact', () => {
   it('replaces the key wherever it appears', () => {
-    expect(redact('GET /events?account_key=KEY123456&page=1', 'KEY123456')).toBe(
+    expect(redact('GET /events?account_key=unique-not-a-real-key&page=1', 'unique-not-a-real-key')).toBe(
       'GET /events?account_key=<CLUBWORX_ACCOUNT_KEY>&page=1',
     );
   });
 
   it('replaces every occurrence, not just the first', () => {
-    const out = redact('KEY123456 ... KEY123456', 'KEY123456');
-    expect(out).not.toContain('KEY123456');
+    const out = redact('unique-not-a-real-key ... unique-not-a-real-key', 'unique-not-a-real-key');
+    expect(out).not.toContain('unique-not-a-real-key');
   });
 
   it('catches a percent-encoded copy of the key, which a naive replace would miss', () => {
@@ -78,6 +85,6 @@ describe('redact', () => {
   });
 
   it('leaves non-string input alone by stringifying it first', () => {
-    expect(redact(404, 'KEY123456')).toBe('404');
+    expect(redact(404, 'unique-not-a-real-key')).toBe('404');
   });
 });

--- a/cloudflare-clubworx/probes/lib/request.test.js
+++ b/cloudflare-clubworx/probes/lib/request.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { buildUrl, redact } from './request.mjs';
+
+// The two things a probe against a public repo's live production API must get
+// right before it makes a single call: the URL it asks for, and the text it is
+// allowed to print afterwards.
+
+describe('buildUrl', () => {
+  const opts = { path: 'events', accountKey: 'KEY123456' };
+
+  it('puts the account key on every request, because all 42 endpoints require it', () => {
+    expect(buildUrl(opts)).toContain('account_key=KEY123456');
+  });
+
+  it('hits the documented api/v2 base', () => {
+    expect(buildUrl(opts).startsWith('https://app.clubworx.com/api/v2/events?')).toBe(true);
+  });
+
+  // The whole point of #51 is telling three cases apart: no contact_key at all,
+  // a present-but-empty one, and an arbitrary one. A builder that collapses the
+  // first two answers a different question than the one asked.
+  it('omits a parameter given as undefined', () => {
+    const url = buildUrl({ ...opts, params: { contact_key: undefined } });
+    expect(url).not.toContain('contact_key');
+  });
+
+  it('keeps a parameter given as an empty string, as a present-but-blank value', () => {
+    const url = buildUrl({ ...opts, params: { contact_key: '' } });
+    expect(url).toContain('contact_key=');
+    expect(new URL(url).searchParams.get('contact_key')).toBe('');
+  });
+
+  it('encodes values rather than pasting them in raw', () => {
+    const url = buildUrl({ ...opts, params: { last_name: "O'Brien & Sons" } });
+    expect(new URL(url).searchParams.get('last_name')).toBe("O'Brien & Sons");
+    expect(url).not.toContain(' ');
+  });
+
+  it('orders parameters deterministically, so two runs produce comparable URLs', () => {
+    const a = buildUrl({ ...opts, params: { page: 1, event_starts_after: '2026-08-01' } });
+    const b = buildUrl({ ...opts, params: { event_starts_after: '2026-08-01', page: 1 } });
+    expect(a).toBe(b);
+  });
+
+  it('refuses to build a URL with no key rather than sending an unauthenticated request', () => {
+    expect(() => buildUrl({ path: 'events', accountKey: '' })).toThrow(/account key/i);
+  });
+});
+
+describe('redact', () => {
+  it('replaces the key wherever it appears', () => {
+    expect(redact('GET /events?account_key=KEY123456&page=1', 'KEY123456')).toBe(
+      'GET /events?account_key=<CLUBWORX_ACCOUNT_KEY>&page=1',
+    );
+  });
+
+  it('replaces every occurrence, not just the first', () => {
+    const out = redact('KEY123456 ... KEY123456', 'KEY123456');
+    expect(out).not.toContain('KEY123456');
+  });
+
+  it('catches a percent-encoded copy of the key, which a naive replace would miss', () => {
+    const key = 'abc+def/ghi';
+    const out = redact(`url=${encodeURIComponent(key)}`, key);
+    expect(out).not.toContain('abc%2Bdef');
+    expect(out).toContain('<CLUBWORX_ACCOUNT_KEY>');
+  });
+
+  it('handles a key carrying regex metacharacters without corrupting the text', () => {
+    expect(redact('x=a.b*c y=1', 'a.b*c')).toBe('x=<CLUBWORX_ACCOUNT_KEY> y=1');
+    // The literal dot must not have matched the arbitrary character before it.
+    expect(redact('x=aXbbbc', 'a.b*c')).toBe('x=aXbbbc');
+  });
+
+  it('throws on an empty secret instead of silently redacting nothing', () => {
+    // A redactor that quietly no-ops is worse than none: callers stop checking.
+    expect(() => redact('anything', '')).toThrow(/secret/i);
+  });
+
+  it('leaves non-string input alone by stringifying it first', () => {
+    expect(redact(404, 'KEY123456')).toBe('404');
+  });
+});

--- a/cloudflare-clubworx/probes/run-51.mjs
+++ b/cloudflare-clubworx/probes/run-51.mjs
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+/**
+ * staff-site#51 — event listing without a contact_key, and burst behaviour.
+ *
+ *   node probes/run-51.mjs [--dry-run] [--max-concurrency=16]
+ *
+ * Read-only throughout. It creates nothing, updates nothing and deletes
+ * nothing; the only verb it can issue is GET (see lib/http.mjs).
+ *
+ * Two questions, both from staff-site#46's map:
+ *
+ *   A. `GET /events` documents `contact_key` as required, which makes an
+ *      "events this week" picker awkward. Does it tolerate the parameter being
+ *      omitted, blank, or arbitrary — and are the events it returns gym-wide or
+ *      only that contact's?
+ *   B. Clubworx publishes no rate limit and (per #47) advertises no rate-limit
+ *      headers. What does a realistic 30-name lookup burst actually do?
+ *
+ * Nothing this script records is a row of production data. Bodies are reduced
+ * to counts, ids, field names and timings before they are written or printed —
+ * staff-site is a public repo and Clubworx holds ~60,000 real people.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createGetter } from './lib/http.mjs';
+import {
+  summariseBurst,
+  summariseEvents,
+  sameIds,
+  deriveRateLimit,
+  recommendPacing,
+} from './lib/report.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(HERE, 'out');
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const CALIBRATE = args.includes('--calibrate');
+/** Re-run the paced lookup at a chosen rate, to find where "sustainable" stops. */
+const WALLS = Number(args.find(a => a.startsWith('--walls='))?.split('=')[1] ?? 0);
+const PACE_PER_MIN = Number(args.find(a => a.startsWith('--pace-per-min='))?.split('=')[1] ?? 0);
+const MAX_CONCURRENCY = Number(args.find(a => a.startsWith('--max-concurrency='))?.split('=')[1] ?? 16);
+
+/** Two-letter fragments, not names. `last_name` is a partial match, so these
+ * cost the same as a real surname list while putting no real name in a public
+ * repo — #46's standing constraint. */
+const FRAGMENTS = [
+  'an', 'ar', 'be', 'br', 'ca', 'ch', 'co', 'da', 'de', 'do',
+  'el', 'fe', 'fi', 'ga', 'gr', 'ha', 'he', 'ho', 'hu', 'ja',
+  'jo', 'ka', 'le', 'li', 'ma', 'mc', 'mi', 'mo', 'na', 'ne',
+];
+
+const CONTACT_TYPES = ['members', 'prospects', 'non_attending_contacts'];
+
+/** Clubworx dates are plain YYYY-MM-DD; the gym runs on Australia/Perth. */
+const perthDate = offsetDays => {
+  const d = new Date(Date.now() + offsetDays * 86_400_000);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Australia/Perth' }).format(d);
+};
+
+function loadAccountKey() {
+  const devVars = path.join(HERE, '..', '.dev.vars');
+  let text;
+  try {
+    text = readFileSync(devVars, 'utf8');
+  } catch {
+    throw new Error(`No .dev.vars at ${devVars}. Copy .dev.vars.example and fill it in — see ACCESS.md.`);
+  }
+  const key = text
+    .split('\n')
+    .find(line => line.trim().startsWith('CLUBWORX_ACCOUNT_KEY='))
+    ?.split('=')
+    .slice(1)
+    .join('=')
+    .trim();
+
+  if (!key) throw new Error('CLUBWORX_ACCOUNT_KEY is missing or empty in .dev.vars');
+  return key;
+}
+
+/** Run thunks with a bounded number in flight, preserving result order. */
+async function pool(thunks, concurrency) {
+  const results = new Array(thunks.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(concurrency, thunks.length) }, async () => {
+    while (next < thunks.length) {
+      const i = next++;
+      results[i] = await thunks[i]();
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+const line = (label, value) => console.log(`  ${label.padEnd(34)} ${value}`);
+
+async function probeEventListing(get) {
+  const window = { event_starts_after: perthDate(-7), event_ends_before: perthDate(90) };
+
+  console.log('\n── A. Event listing ──────────────────────────────────────────');
+  console.log(`  window ${window.event_starts_after} → ${window.event_ends_before}\n`);
+
+  // A real contact_key to compare against. Its owner is a real person, so the
+  // key is used and then dropped: it is never printed, returned or written.
+  const seed = await get('members', { page_size: 1 });
+  const realContactKey = Array.isArray(seed.body) ? seed.body[0]?.contact_key : undefined;
+  line('seed /members page_size=1', `HTTP ${seed.status}, real contact_key ${realContactKey ? 'obtained' : 'UNAVAILABLE'}`);
+
+  const variants = [
+    ['contact_key omitted', { ...window }],
+    ['contact_key blank', { ...window, contact_key: '' }],
+    ['contact_key arbitrary', { ...window, contact_key: 'zzzz-not-a-real-contact-key' }],
+    ['contact_key real', realContactKey ? { ...window, contact_key: realContactKey } : null],
+    ['no date window at all', { contact_key: undefined }],
+  ];
+
+  const results = {};
+  for (const [label, params] of variants) {
+    if (!params) {
+      results[label] = { skipped: 'no real contact_key available' };
+      line(label, 'skipped');
+      continue;
+    }
+    const res = await get('events', params);
+    const events = summariseEvents(res.body);
+    results[label] = { status: res.status, ms: res.ms, events, headers: res.headers };
+    line(
+      label,
+      `HTTP ${res.status} · ${res.ms}ms · ${events.count} events` +
+        (events.notAnArray ? ` · body: ${String(res.bodyText ?? '').slice(0, 80)}` : ''),
+    );
+  }
+
+  const omitted = results['contact_key omitted']?.events?.ids ?? [];
+  const real = results['contact_key real']?.events?.ids ?? [];
+  const arbitrary = results['contact_key arbitrary']?.events?.ids ?? [];
+
+  const verdict = {
+    tolerated: results['contact_key omitted']?.status === 200,
+    // If an arbitrary key returns the same list as no key, the parameter is
+    // being ignored — which is what makes a gym-wide picker possible.
+    ignoresContactKey: sameIds(omitted, arbitrary),
+    scopedToContact: real.length > 0 && !sameIds(omitted, real),
+  };
+
+  console.log('');
+  line('omitted vs arbitrary key', verdict.ignoresContactKey ? 'same events → parameter ignored' : 'different events');
+  line('omitted vs real key', sameIds(omitted, real) ? 'same events' : 'different events');
+
+  // A default page holds 50. A window that returns exactly 50 is indistinguishable
+  // from one that was truncated at the page boundary, and a picker that silently
+  // shows the first 50 events of a term is worse than one that admits a cap.
+  console.log('');
+  const paging = {};
+  for (const [label, params] of [
+    ['events page_size=200', { ...window, page_size: 200 }],
+    ['events page=2', { ...window, page: 2 }],
+  ]) {
+    const res = await get('events', params);
+    const events = summariseEvents(res.body);
+    paging[label] = { status: res.status, ms: res.ms, count: events.count, earliest: events.earliest, latest: events.latest };
+    line(label, `HTTP ${res.status} · ${res.ms}ms · ${events.count} events`);
+  }
+
+  return { window, results, verdict, paging };
+}
+
+async function probePagination(get) {
+  console.log('\n── C. Pagination above page_size 50 ──────────────────────────');
+  const sizes = [50, 100, 200];
+  const out = {};
+  for (const size of sizes) {
+    const res = await get('members', { page_size: size, page: 1 });
+    const returned = Array.isArray(res.body) ? res.body.length : null;
+    out[size] = { status: res.status, ms: res.ms, returned };
+    line(`page_size=${size}`, `HTTP ${res.status} · ${res.ms}ms · ${returned} rows returned`);
+  }
+  return out;
+}
+
+async function probeBurst(get) {
+  console.log('\n── B. Burst behaviour ────────────────────────────────────────');
+  console.log(`  ${FRAGMENTS.length} name fragments × ${CONTACT_TYPES.length} contact types = ` +
+    `${FRAGMENTS.length * CONTACT_TYPES.length} reads per level\n`);
+
+  const levels = [4, 8, 16].filter(n => n <= MAX_CONCURRENCY);
+  const out = {};
+
+  for (const concurrency of levels) {
+    const thunks = FRAGMENTS.flatMap(fragment =>
+      CONTACT_TYPES.map(type => () => get(type, { last_name: fragment, page_size: 50 })),
+    );
+
+    const started = Date.now();
+    const samples = await pool(thunks, concurrency);
+    const wallMs = Date.now() - started;
+
+    const summary = summariseBurst(samples.map(s => ({ status: s.status, ms: s.ms, error: s.error })));
+    const headersSeen = Object.assign({}, ...samples.map(s => s.headers));
+
+    out[concurrency] = { ...summary, wallMs, headersSeen };
+    line(
+      `concurrency ${concurrency}`,
+      `${summary.count} reads in ${wallMs}ms · ${JSON.stringify(summary.byStatus)}` +
+        ` · p50 ${summary.ms.p50}ms p95 ${summary.ms.p95}ms max ${summary.ms.max}ms` +
+        ` · ${summary.clean ? 'CLEAN' : 'NOT CLEAN'}`,
+    );
+    if (Object.keys(headersSeen).length) line('  rate-limit headers seen', JSON.stringify(headersSeen));
+
+    // Escalating past a level that already failed would only add load to a
+    // production API that has just told us it is unhappy.
+    if (!summary.clean) {
+      console.log('  stopping escalation: this level was not clean');
+      break;
+    }
+  }
+
+  return out;
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+/** The cheapest read in the API — five rows — used only to ask "am I allowed yet?". */
+const CHEAPEST_READ = 'locations';
+
+/**
+ * Poll until a request succeeds, and report when that was.
+ *
+ * The polls themselves cost quota. If a throttled request also counts against
+ * the allowance this will not recover, which is a finding rather than a bug —
+ * hence the cap and the returned poll count.
+ */
+async function waitUntilRested(get, { pollMs = 5_000, maxMs = 300_000, label = 'resting' } = {}) {
+  const started = Date.now();
+  let polls = 0;
+  for (;;) {
+    polls += 1;
+    const res = await get(CHEAPEST_READ, { page_size: 1 });
+    if (res.status === 200) {
+      const waitedMs = Date.now() - started;
+      line(label, `clear after ${(waitedMs / 1000).toFixed(0)}s (${polls} polls)`);
+      return { waitedMs, polls, clearedAt: Date.now(), recovered: true };
+    }
+    if (Date.now() - started > maxMs) {
+      line(label, `NOT clear after ${(maxMs / 1000).toFixed(0)}s (${polls} polls) — giving up`);
+      return { waitedMs: Date.now() - started, polls, clearedAt: null, recovered: false };
+    }
+    await sleep(pollMs);
+  }
+}
+
+/**
+ * Spend the allowance serially and record exactly where the wall is.
+ *
+ * Serial on purpose: concurrency makes the count before the first 429 depend on
+ * how many requests were already in flight when the ceiling was crossed, which
+ * blurs the number this whole calibration rests on.
+ */
+async function fireUntilThrottled(get, { max = 150 } = {}) {
+  const startedAt = Date.now();
+  let allowed = 0;
+  for (let i = 0; i < max; i += 1) {
+    const res = await get(CHEAPEST_READ, { page_size: 1 });
+    if (res.status === 429) {
+      return { allowed, wallAt: Date.now(), elapsedMs: Date.now() - startedAt, startedAt, hitWall: true };
+    }
+    if (res.status !== 200) {
+      return { allowed, wallAt: null, elapsedMs: Date.now() - startedAt, startedAt, hitWall: false, unexpected: res.status };
+    }
+    allowed += 1;
+  }
+  return { allowed, wallAt: null, elapsedMs: Date.now() - startedAt, startedAt, hitWall: false };
+}
+
+/**
+ * Find the ceiling, then prove a pace that stays under it.
+ *
+ * The first burst showed 429s arriving mid-run with no warning and no headers,
+ * so what the design actually needs is not "a concurrency that survives" but a
+ * request rate. This measures the quota, the window it resets over, and then
+ * runs a full 30-name lookup at the recommended pace to see it through clean.
+ */
+async function probeLimits(get) {
+  console.log('\n── D. Where the ceiling is ───────────────────────────────────');
+
+  const rested = await waitUntilRested(get, { label: 'waiting for a rested state' });
+  if (!rested.recovered) return { rested, note: 'never reached a rested state' };
+
+  const wall = await fireUntilThrottled(get);
+  line(
+    'serial reads before first 429',
+    wall.hitWall
+      ? `${wall.allowed} accepted in ${(wall.elapsedMs / 1000).toFixed(1)}s, then throttled`
+      : `${wall.allowed} accepted, no 429 seen (status ${wall.unexpected ?? 'n/a'})`,
+  );
+  if (!wall.hitWall) return { rested, wall, note: 'no ceiling reached' };
+
+  const recovery = await waitUntilRested(get, { label: 'waiting for the throttle to lift' });
+  if (!recovery.recovered) return { rested, wall, recovery, note: 'throttle never lifted within the cap' };
+
+  // The window is measured from the first request of the burst, not from the
+  // 429: a rolling quota clears when the oldest request in it ages out.
+  const windowMs = recovery.clearedAt - wall.startedAt;
+  const limit = deriveRateLimit({ allowed: wall.allowed, windowMs });
+  const pacing = recommendPacing({ allowed: wall.allowed, windowMs, reads: FRAGMENTS.length * CONTACT_TYPES.length });
+
+  line('window (first request → clear)', `${(windowMs / 1000).toFixed(0)}s`);
+  line('derived ceiling', `~${limit.perMinute} requests/min`);
+  line('recommended pace', `${pacing.perMinute}/min — 1 in flight, ${pacing.gapMs}ms apart`);
+  line('a 90-read lookup would take', `~${Math.round(pacing.estimatedMsFor / 1000)}s`);
+
+  return { rested, wall, recovery, windowMs, limit, pacing };
+}
+
+/** Run the same 90-read lookup at the recommended pace and see it through. */
+async function verifyPace(get, pacing) {
+  console.log('\n── E. Does the recommended pace hold? ────────────────────────');
+
+  const rested = await waitUntilRested(get, { label: 'waiting for a rested state' });
+  if (!rested.recovered) return { skipped: 'never reached a rested state' };
+
+  const samples = [];
+  const started = Date.now();
+  for (const fragment of FRAGMENTS) {
+    for (const type of CONTACT_TYPES) {
+      const res = await get(type, { last_name: fragment, page_size: 50 });
+      samples.push({ status: res.status, ms: res.ms, error: res.error });
+      // Gap measured from the end of the previous request: the request's own
+      // latency is part of the spacing, so subtracting it would overshoot.
+      await sleep(Math.max(0, pacing.gapMs - res.ms));
+    }
+  }
+
+  const summary = summariseBurst(samples);
+  const wallMs = Date.now() - started;
+  line(
+    `paced ${pacing.perMinute}/min`,
+    `${summary.count} reads in ${(wallMs / 1000).toFixed(0)}s · ${JSON.stringify(summary.byStatus)} · ${summary.clean ? 'CLEAN' : 'NOT CLEAN'}`,
+  );
+
+  return { ...summary, wallMs, pacing };
+}
+
+async function main() {
+  const accountKey = loadAccountKey();
+  const get = createGetter({ accountKey });
+
+  if (DRY_RUN) {
+    console.log('--dry-run: no requests issued. This run would make:');
+    console.log(`  A. event listing      5 reads`);
+    console.log(`  C. pagination         3 reads`);
+    console.log(`  B. burst              up to ${[4, 8, 16].filter(n => n <= MAX_CONCURRENCY).length} × ${FRAGMENTS.length * CONTACT_TYPES.length} reads`);
+    console.log('  All GET. Nothing is created, updated or deleted.');
+    return;
+  }
+
+  console.log('staff-site#51 probe — READ ONLY, against production Clubworx');
+
+  const record = {
+    probe: 'staff-site#51',
+    ranAt: new Date().toISOString(),
+  };
+
+  if (WALLS) {
+    // The ceiling is the load-bearing finding, and one measurement of it is an
+    // anecdote. This repeats rest → spend → wall, so the write-up can quote a
+    // spread rather than a single number.
+    console.log('\n── D2. Where the ceiling is, repeated ────────────────────────');
+    record.walls = [];
+    for (let i = 0; i < WALLS; i += 1) {
+      const rested = await waitUntilRested(get, { label: `run ${i + 1}: resting` });
+      if (!rested.recovered) break;
+      const wall = await fireUntilThrottled(get);
+      record.walls.push({ ...wall, restedAfterMs: rested.waitedMs });
+      line(
+        `run ${i + 1}: accepted before 429`,
+        `${wall.allowed} in ${(wall.elapsedMs / 1000).toFixed(1)}s` +
+          ` (${(wall.allowed / (wall.elapsedMs / 1000)).toFixed(1)}/s)`,
+      );
+    }
+  } else if (PACE_PER_MIN) {
+    record.pacedRun = await verifyPace(get, {
+      perMinute: PACE_PER_MIN,
+      gapMs: Math.round(60_000 / PACE_PER_MIN),
+      concurrency: 1,
+    });
+  } else if (CALIBRATE) {
+    // Slow by design: it waits out the throttle twice and then paces a full
+    // lookup. Split from the main run so the fast findings are not held up by
+    // several minutes of deliberate idling.
+    record.limits = await probeLimits(get);
+    if (record.limits.pacing) record.pacedRun = await verifyPace(get, record.limits.pacing);
+  } else {
+    record.events = await probeEventListing(get);
+    record.pagination = await probePagination(get);
+    record.burst = await probeBurst(get);
+  }
+
+  record.totalReads = get.calls;
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `51${CALIBRATE ? '-calibrate' : ''}-${record.ranAt.replace(/[:.]/g, '-')}.json`);
+  writeFileSync(file, JSON.stringify(record, null, 2));
+
+  console.log(`\n${get.calls} reads total. Summary written to probes/out/${path.basename(file)}`);
+}
+
+main().catch(err => {
+  console.error(`probe failed: ${err.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #51. **Stacked on #56** — merge that first, or this diff will show #47's commits too.

Read-only throughout: 881 GETs against production Clubworx, nothing created, updated or deleted.

## What it found

**`GET /events` ignores `contact_key`.** The reference calls it required. Omitted, blank, arbitrary and a real member's key all return HTTP 200 with the *identical gym-wide* event set. The event picker is unblocked — including for an event nobody has booked into yet, which is precisely a new school session and the case the HVT derive-from-bookings workaround structurally cannot see.

The date window is what is actually required (422 without it), and the default `page_size` of 50 comes back with no total and no next-page link — so a full page is indistinguishable from a complete list.

**The rate ceiling is tight and invisible.** No `Retry-After`, no `X-RateLimit-*` — not even on the 429 itself. Spent faster than ~3/s, ~50 requests get through (four runs, exactly 49 each, zero spread), then 429 for ~18s.

**Concurrency is the wrong lever.** Four in flight reached the wall *sooner* than one and then failed 41 requests in a row. Rate is what separates a clean run from a throttled one. **75 req/min, one in flight, ran a full 90-read lookup clean, twice.**

## What is in the diff

| | |
|---|---|
| `probes/51-events-and-burst.md` | the answer to #51, with the raw numbers |
| `probes/run-51.mjs` | the probe that produced it, re-runnable |
| `probes/lib/*.mjs` | URL building, redaction, response summarising — 53 unit tests |
| `probes/README.md` | how to run one, and the rules any new probe follows |
| `CONTEXT.md` | *ceiling* and *pacing* added to the glossary |
| `ACCESS.md` | rate-limit section updated from "unknown" to measured |

`lib/http.mjs` is the only path to Clubworx and can issue **GET and nothing else** — read-only is a structural property here, not a promise in a comment. Responses are reduced to counts, ids, field names and timings before anything is printed or written, so no production data can reach this public repo; the burst queries two-letter fragments rather than a surname list.

## Deliberately not answered

The exact limiting algorithm. Neither a count-per-window nor a token bucket fits every measurement — one run put 60 requests through in the same span another was cut off at 50. Pinning it down means far more load on a live gym database to learn something the design does not need, since a verified safe rate answers the same question. The contradiction is recorded rather than smoothed over.

## Carried forward

"Build that fallback field regardless of the outcome" is filed on #54 rather than built — no picker UI exists yet. It stays mandatory: this behaviour is undocumented and contradicts the published reference, so the day Clubworx enforces its own docs the picker 422s for every staff member at once.

Rate-limit consequences for the failure model went to #53; #46's ledger is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)