### PR TITLE
feat(clubworx): answer #49 — plus-addressing works, and email is not unique

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -268,3 +268,36 @@ The margin exists for other systems, not this one. There is **one Clubworx key
 for the whole gym** (see `cloudflare-clubworx/ACCESS.md`), so HVT's roster
 Worker, n8n and staff-site all spend the same allowance. A run here can throttle
 something unrelated, with nothing in either system's logs to explain it.
+
+## Clubworx school marking
+
+### School marker
+
+The plus-addressed email a school-created contact carries —
+`noreply+<school>@urbanjungleirc.com`. It is the **only** provenance signal this
+system has: Clubworx issues one API key per gym, so a contact cannot be
+attributed to the tool that made it, and the address is the substitute.
+
+Verified against writes in #49, not inferred: Clubworx accepts the `+`, stores
+the tag unchanged, partial-matches `noreply%2B` to find every marked contact, and
+returns exactly one school's contacts for a full tag. See
+`cloudflare-clubworx/probes/49-plus-addressed-duplicates.md`.
+
+### Shared email
+
+Two or more contacts holding the same address. **Clubworx permits it** — email is
+not unique per contact — which is what makes the marker workable at all, because
+siblings arrive on one parent's address and a whole school shares one
+`noreply+<school>@`.
+
+It also means an email can never identify a person here. Identity is surname plus
+date of birth (#46); the address identifies a *school*.
+
+### Contact status endpoints
+
+`/prospects`, `/members` and `/non_attending_contacts` are three disjoint views
+by status, not three indexes over one table. A contact created as a prospect
+appears in `/prospects` **only**, and moves when their status changes.
+
+So a lookup searches all three and merges. Which one holds a given student is a
+fact about their membership today, not about how they were created.

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -207,11 +207,36 @@ and this repo is public.
 - Probes are **#49 and #50's** work. #47 provisions access and stops there; it
   ran only a read-only `GET /locations` to prove the key authenticates.
 
+### Amendment, 2026-08-17: three contacts, not one — SPENT
+
+**Authorised by Jiri, 2026-08-17**, when #49 ran. One identity could not answer
+the ticket: question 2 asks whether *many* contacts may share an email, and
+question 3 asks whether a tag **isolates** a school — an exclusion needs a second
+tag to exclude. The set is declared in `probes/lib/identity.mjs` and is the whole
+blast radius.
+
+These three now exist in production and are **permanent**:
+
+| | Name | Email | `contact_key` |
+|---|---|---|---|
+| A | `Ztest Wayfinder` | `noreply+wayfindertest@urbanjungleirc.com` | `e35218ef-4e96-4928-a05f-1c14f56e574f` |
+| B | `Ztest Wayfindertwo` | `noreply+wayfindertest@urbanjungleirc.com` | `298dab8a-22b5-41f1-87b9-3936172f8ee1` |
+| C | `Ztest Wayfinderthree` | `noreply+wayfindertestb@urbanjungleirc.com` | `b39b1560-e76d-45bc-9f67-d19a1fbcb873` |
+
+**This authorisation is spent.** It covered #49's three contacts, not a standing
+allowance. **#50 must reuse them** — they are already the membership-less
+prospects that ticket needs. A fourth contact is a new decision.
+
+Findings: `probes/49-plus-addressed-duplicates.md`.
+
 ### Before the first write probe
 
 Search first. If `Ztest Wayfinder` already exists from an earlier run, reuse it
 rather than creating a second — the identity is only a blast-radius control if
 there is exactly one of it.
+
+`run-49.mjs` does this in code (`planContacts`), and a second run of it was
+verified to make zero writes. Any new write probe must do the same.
 
 ---
 

--- a/cloudflare-clubworx/package.json
+++ b/cloudflare-clubworx/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "probe:51": "node probes/run-51.mjs"
+    "probe:51": "node probes/run-51.mjs",
+    "probe:49": "node probes/run-49.mjs"
   },
   "devDependencies": {
     "vitest": "^2.1.0"

--- a/cloudflare-clubworx/probes/49-plus-addressed-duplicates.md
+++ b/cloudflare-clubworx/probes/49-plus-addressed-duplicates.md
@@ -1,0 +1,136 @@
+# Plus-addressed duplicate emails on `noreply@` — the answer to #49
+
+Probed against production Clubworx on **2026-08-17**. Three contacts created,
+all permanent; the cleanup list is at the bottom.
+
+**The school-marking scheme survives.** Every assumption #46 took on inference
+from reads held up against a write. Plus-addressing is accepted, email is not
+unique per contact, and a full tag isolates its own contacts cleanly.
+
+One thing did *not* get answered, and it is not the one that was expected — see
+[What is still unproven](#what-is-still-unproven).
+
+## The four questions
+
+### 1. Does `POST /api/v2/prospects` accept a plus-addressed `noreply@`? — **Yes**
+
+`noreply+wayfindertest@urbanjungleirc.com` was accepted with no validation
+complaint about the `+`. The address came back on the created record unchanged:
+Clubworx does not normalise the tag away, which is what makes it usable as a
+provenance marker at all.
+
+**It answers `200`, not `201`.** A client that treats "created" as `201` will
+read every successful write as a failure. Check `2xx`, not the exact code.
+
+### 2. Can many contacts share one email? — **Yes**
+
+Contact B was created with **byte-identical** email to contact A and a different
+surname. It was accepted, and given its own `contact_key`:
+
+| | Surname | Email | `contact_key` |
+|---|---|---|---|
+| A | `Wayfinder` | `noreply+wayfindertest@…` | `e35218ef…e574f` |
+| B | `Wayfindertwo` | `noreply+wayfindertest@…` | `298dab8a…8f2e1` |
+
+Email is **not** unique per contact. This is the finding the parked design
+depended on and had only inferred — siblings sharing a parent's address are a
+real case, and it now has a write behind it rather than an assumption.
+
+The fallback #49 named — a dedicated prospect status, which loses the
+which-school record — is **not needed**.
+
+### 3. Does the marker find its contacts, and only its contacts? — **Yes, both**
+
+On `/prospects`, with three contacts across two tags:
+
+| Query | Returned | Verdict |
+|---|---|---|
+| `email=noreply%2B` (partial) | 3 of 3 | partial match works |
+| `email=noreply+wayfindertest@…` | exactly A and B | isolated |
+| `email=noreply+wayfindertestb@…` | exactly C | isolated |
+
+No cross-tag leakage in either direction, and nothing missing. `email` is a
+prefix/partial match, so `noreply%2B` acts as "every school-created contact" and
+a full address acts as "this school only". Both halves the design needs.
+
+### 4. Does the same hold on `/members` and `/non_attending_contacts`? — **Not applicable, and that is the finding**
+
+Every query against both returned **HTTP 200 with zero rows** — including the
+bare `noreply%2B` partial.
+
+This is not the email filter failing. A contact created through
+`POST /prospects` exists **only** as a prospect: the three endpoints are
+disjoint views by contact status, not three indexes over one table. Nothing was
+there to find.
+
+**Consequence for #46's dedup pass:** searching `/prospects` alone is not
+enough, and neither is picking one endpoint by guesswork. Which endpoint holds a
+given student depends on their *current status* — a student who later takes a
+membership moves out of `/prospects` — so a lookup has to search all three and
+merge. That was already the plan; it is now a requirement with a reason.
+
+## What is still unproven
+
+**The email filter's behaviour on `/members` and `/non_attending_contacts` was
+never exercised.** Those endpoints returned zero rows because they held none of
+the probe's contacts, so the filter was never given a matching row to return.
+"Zero results" is consistent with a working filter *and* with one that ignores
+the `email` parameter entirely.
+
+This matters because #46's dedup pass relies on that filter on all three
+endpoints. Proving it needs a contact that is actually a member — which this
+probe cannot create, and which #50 may be able to arrange. Recorded as a gap
+rather than smoothed into the "yes" above.
+
+Also untested: pagination. Three contacts is far inside the default
+`page_size` of 50, so nothing here says how a school with 63 students on one
+`noreply+` tag pages — and #48 found a real list of exactly that size. The
+`page_size` cap from #51 applies, but the interaction with an email filter is
+unmeasured.
+
+## Fields a contact comes back with
+
+Schema only, no values:
+
+```
+first_name  last_name  email  phone  status  dob  address
+contact_key  last_attended  source  created_on  created
+```
+
+`source` and `status` are both present, which is worth noting for #52: they are
+alternative provenance carriers if the `noreply+` marker ever has to be dropped.
+
+## How it was run
+
+```bash
+node probes/run-49.mjs --dry-run   # the plan, zero requests
+node probes/run-49.mjs             # read-only: search, then the isolation reads
+node probes/run-49.mjs --write     # the only mode that creates anything
+```
+
+18 requests for the full write run, paced at one per 800ms (~75/min) per #51.
+The probe **searches first** and reuses what it finds, so re-running it costs
+nothing permanent — verified: a second run reported `still to create: none` and
+made 0 writes.
+
+Two controls sit in front of every write, in `lib/write.mjs` and
+`lib/identity.mjs`: writing is off unless explicitly enabled, and every contact
+must pass an identity guard before the network is touched. A write under
+anything resembling a real name is refused rather than reported afterwards —
+which matters, because it cannot be undone.
+
+## ⚠️ Cleanup — delete these by hand
+
+Clubworx cannot delete contacts through the API (ACCESS.md §4). These three are
+permanent until someone removes them in the Clubworx UI. They sort to the end of
+an alphabetical list under `Ztest`.
+
+| | Name | Email | `contact_key` |
+|---|---|---|---|
+| A | `Ztest Wayfinder` | `noreply+wayfindertest@urbanjungleirc.com` | `e35218ef-4e96-4928-a05f-1c14f56e574f` |
+| B | `Ztest Wayfindertwo` | `noreply+wayfindertest@urbanjungleirc.com` | `298dab8a-22b5-41f1-87b9-3936172f8ee1` |
+| C | `Ztest Wayfinderthree` | `noreply+wayfindertestb@urbanjungleirc.com` | `b39b1560-e76d-45bc-9f67-d19a1fbcb873` |
+
+**#50 should reuse these rather than create its own.** They are already the
+membership-less prospects that ticket needs, and every extra contact is another
+row somebody has to delete by hand.

--- a/cloudflare-clubworx/probes/49-plus-addressed-duplicates.md
+++ b/cloudflare-clubworx/probes/49-plus-addressed-duplicates.md
@@ -15,9 +15,15 @@ One thing did *not* get answered, and it is not the one that was expected — se
 ### 1. Does `POST /api/v2/prospects` accept a plus-addressed `noreply@`? — **Yes**
 
 `noreply+wayfindertest@urbanjungleirc.com` was accepted with no validation
-complaint about the `+`. The address came back on the created record unchanged:
-Clubworx does not normalise the tag away, which is what makes it usable as a
-provenance marker at all.
+complaint about the `+`.
+
+Clubworx also does not normalise the tag away, which is what makes it usable as
+a provenance marker at all — but the evidence for that is the **exact-match
+search**, not the create response. A later `GET ?email=noreply+wayfindertest@…`
+returned precisely the two contacts written on that address, which it could not
+do if the stored value differed from the one sent. The create response was never
+inspected for its `email` field; the probe now records it (`emailEcho`) so a
+future run has the direct measurement rather than this inference.
 
 **It answers `200`, not `201`.** A client that treats "created" as `201` will
 read every successful write as a failure. Check `2xx`, not the exact code.
@@ -81,6 +87,12 @@ This matters because #46's dedup pass relies on that filter on all three
 endpoints. Proving it needs a contact that is actually a member — which this
 probe cannot create, and which #50 may be able to arrange. Recorded as a gap
 rather than smoothed into the "yes" above.
+
+**So #49 closes on three and a half of its four questions.** Questions 1–3 are
+answered against writes. Question 4 is answered only in the sense that the
+endpoints were shown to be disjoint by status; the email filter on two of them
+remains unexercised. Whether that is enough to close the ticket is the issue
+owner's call, not the probe's.
 
 Also untested: pagination. Three contacts is far inside the default
 `page_size` of 50, so nothing here says how a school with 63 students on one

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -8,7 +8,9 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | File | What it answers |
 |---|---|
 | `51-events-and-burst.md` | [#51](https://github.com/urbanjungleirc/staff-site/issues/51) — event listing without a `contact_key`, and rate limits |
-| `run-51.mjs` | The probe that produced it |
+| `run-51.mjs` | The probe that produced it — read-only |
+| `49-plus-addressed-duplicates.md` | [#49](https://github.com/urbanjungleirc/staff-site/issues/49) — plus-addressed `noreply@`, duplicate emails, and whether a tag isolates a school |
+| `run-49.mjs` | The probe that produced it — **writes** |
 
 Access, authorisation and the key's whereabouts: `../ACCESS.md`.
 
@@ -26,8 +28,16 @@ node probes/run-51.mjs --calibrate   # find the ceiling, then verify a pace (~5 
 node probes/run-51.mjs --walls=3     # measure the ceiling repeatedly
 node probes/run-51.mjs --pace-per-min=96   # is this rate sustainable?
 
+node probes/run-49.mjs --dry-run     # the plan and every request, zero network
+node probes/run-49.mjs               # read-only: search, then the isolation reads
+node probes/run-49.mjs --write       # ⚠️ creates up to 3 PERMANENT contacts
+
 npm test                             # the pure logic, no network
 ```
+
+`--dev-vars=<path>` points either probe at a key outside the package — a git
+worktree, for instance, where `.dev.vars` is gitignored and so does not follow
+the checkout.
 
 Runs write a JSON summary to `probes/out/`, which is gitignored.
 
@@ -35,11 +45,22 @@ Runs write a JSON summary to `probes/out/`, which is gitignored.
 
 Every one of them is a consequence of *production, public repo, no sandbox*.
 
-- **Read-only unless the ticket says otherwise.** `lib/http.mjs` is the only way
-  out to Clubworx and it can only issue GET. #51 needed nothing else. The write
-  probes (#49, #50) are separately authorised in ACCESS.md section 4 and must
-  reuse the one agreed test identity, because Clubworx **cannot delete contacts
-  through the API** — every contact a probe creates is permanent.
+- **Read-only unless the ticket says otherwise.** There are two ways out to
+  Clubworx and they are separate files on purpose. `lib/http.mjs` issues GET and
+  nothing else, so a probe that imports only it *cannot* write — that is a
+  property of the script, not a claim about it. Creating anything means reaching
+  for `lib/write.mjs` deliberately.
+- **Two controls in front of every write**, because Clubworx **cannot delete
+  contacts through the API** and there is no sandbox. `createPoster` is inert
+  unless `live` is explicitly true, so a forgotten flag costs nothing; and every
+  contact must pass `lib/identity.mjs`'s guard *before* the network is touched,
+  so a write under anything resembling a real name is refused rather than
+  reported afterwards. Write probes are authorised in ACCESS.md section 4, and
+  the identity set there is the whole blast radius.
+- **A write probe must search first and reuse what it finds.** Re-running one
+  should cost nothing permanent. `planContacts` is what makes that true, and it
+  matches on surname *and* email — a stranger who happens to share the probe
+  address is not the probe's record.
 - **Never record a row of production data.** Responses are reduced to counts,
   ids, field names and timings by `lib/report.mjs` before anything is printed or
   written. Clubworx holds ~60,000 real people and this repo is public and
@@ -61,8 +82,13 @@ Every one of them is a consequence of *production, public repo, no sandbox*.
 ```
 lib/request.mjs   URL building and redaction        (unit tested)
 lib/report.mjs    response → publishable summary    (unit tested)
-lib/http.mjs      the only path to Clubworx: GET    (unit tested)
-run-51.mjs        the #51 probe itself
+lib/key.mjs       where the live key comes from     (unit tested)
+lib/http.mjs      the read path to Clubworx: GET    (unit tested)
+lib/write.mjs     the write path: POST, guarded     (unit tested)
+lib/identity.mjs  who a write may be, and what to   (unit tested)
+                  create given what already exists
+run-51.mjs        the #51 probe itself — read-only
+run-49.mjs        the #49 probe itself — writes
 ```
 
 The libraries are tested and the runner is not. That split is deliberate: the

--- a/cloudflare-clubworx/probes/lib/identity.mjs
+++ b/cloudflare-clubworx/probes/lib/identity.mjs
@@ -1,0 +1,191 @@
+/**
+ * Who a write probe is allowed to be, and what it is allowed to create.
+ *
+ * Clubworx has no sandbox and **cannot delete a contact through the API**
+ * (ACCESS.md section 4). Every contact a probe writes is permanent, lives
+ * beside ~60,000 real people, and can only be removed by hand in the Clubworx
+ * UI. So the identity is not a fixture detail — it is the blast radius, and
+ * `assertProbeIdentity` is the control that keeps it that size.
+ *
+ * The set below is deliberately the *smallest* one that can answer
+ * staff-site#49. Adding to it is a decision to leave more permanent records in
+ * a production database, not a refactor.
+ */
+
+/** The identity ACCESS.md section 4 agreed, 2026-08-17. */
+export const TEST_IDENTITY = {
+  first_name: 'Ztest',
+  last_name: 'Wayfinder',
+  dob: '1900-01-01',
+  email: 'noreply+wayfindertest@urbanjungleirc.com',
+};
+
+const SECOND_TAG_EMAIL = 'noreply+wayfindertestb@urbanjungleirc.com';
+
+/**
+ * The three contacts #49 needs, and why each one exists.
+ *
+ * ACCESS.md section 4 authorised *one* identity. #49 cannot be answered with
+ * one: question 2 asks whether many contacts may share an email, and question 3
+ * asks whether a tag *isolates* a school — an exclusion needs something to
+ * exclude. Three contacts, authorised 2026-08-17, is the minimum that answers
+ * all four questions. Every one of them is permanent.
+ */
+export const PROBE_CONTACTS = [
+  {
+    label: 'A',
+    ...TEST_IDENTITY,
+    why: 'baseline — does POST accept a plus-addressed noreply@ at all? (Q1)',
+  },
+  {
+    label: 'B',
+    first_name: 'Ztest',
+    last_name: 'Wayfindertwo',
+    dob: '1900-01-01',
+    email: TEST_IDENTITY.email,
+    why: 'same email as A, different surname — the sibling case (Q2)',
+  },
+  {
+    label: 'C',
+    first_name: 'Ztest',
+    last_name: 'Wayfinderthree',
+    dob: '1900-01-01',
+    email: SECOND_TAG_EMAIL,
+    why: 'a second plus-tag, so the isolation query has something to exclude (Q3)',
+  },
+];
+
+/** The probe email shape. Anything outside it is refused, not normalised. */
+const PROBE_EMAIL = /^noreply\+wayfindertest[a-z]*@urbanjungleirc\.com$/;
+const PROBE_DOB = '1900-01-01';
+
+/**
+ * Refuse to write anything that is not the agreed test identity.
+ *
+ * This sits in front of the only POST path (`lib/write.mjs`), so "a probe
+ * cannot create a contact that looks like a real person" is a property of the
+ * code rather than a promise in a comment — the same reason `lib/http.mjs` can
+ * only issue GET. It matters more here than there: a mistaken read costs
+ * nothing, and a mistaken write cannot be undone.
+ *
+ * @param {{first_name?: string, last_name?: string, dob?: string, email?: string}} contact
+ */
+export function assertProbeIdentity(contact) {
+  const { first_name, last_name, dob, email } = contact ?? {};
+
+  if (first_name !== 'Ztest') {
+    throw new Error(
+      `refusing to write a contact whose first name is not Ztest (got ${JSON.stringify(first_name)}) — ` +
+        'contacts created here are permanent',
+    );
+  }
+  if (typeof last_name !== 'string' || !last_name.startsWith('Wayfinder')) {
+    throw new Error(
+      `refusing to write a contact outside the Wayfinder family (got ${JSON.stringify(last_name)})`,
+    );
+  }
+  if (dob !== PROBE_DOB) {
+    throw new Error(`refusing to write a contact with a plausible dob (got ${JSON.stringify(dob)})`);
+  }
+  if (typeof email !== 'string' || !PROBE_EMAIL.test(email)) {
+    throw new Error(
+      `refusing to write a contact whose email is not a noreply+ probe address (got ${JSON.stringify(email)})`,
+    );
+  }
+
+  return contact;
+}
+
+/**
+ * Read the tag out of a plus-addressed email.
+ *
+ * @param {string} email
+ * @returns {string|null}
+ */
+export function plusTag(email) {
+  const match = /^[^+@]+\+([^@]+)@/.exec(String(email ?? ''));
+  return match ? match[1] : null;
+}
+
+/**
+ * Is this row one the probe wrote?
+ *
+ * Deliberately weaker than `assertProbeIdentity`, and the difference is
+ * load-bearing. A *write* must satisfy all four fields — that is the blast
+ * radius control. A *read* is matched on name and email only, because a list
+ * response is not guaranteed to carry a date of birth, and a recogniser that
+ * demanded one would fail to see the probe's own contacts and create three more
+ * permanent records on every run. The failure modes are asymmetric: being too
+ * strict here is what leaves litter behind.
+ *
+ * @param {{first_name?: string, last_name?: string, email?: string}} row
+ */
+export function isProbeRow(row) {
+  const { first_name, last_name, email } = row ?? {};
+  return (
+    first_name === 'Ztest' &&
+    typeof last_name === 'string' &&
+    last_name.startsWith('Wayfinder') &&
+    typeof email === 'string' &&
+    PROBE_EMAIL.test(email)
+  );
+}
+
+/**
+ * Keep only the rows this probe could have written, and only three fields of them.
+ *
+ * The search that feeds `planContacts` is a partial email match against a
+ * 60,000-person production database, so it returns strangers. Dropping them here
+ * — before anything is planned, printed or written to `probes/out/` — is what
+ * keeps the promise `summariseContacts` makes on the reporting path. A row is
+ * kept only if it passes the same identity guard a write would.
+ *
+ * @param {unknown} body
+ * @returns {Array<{contact_key: string, email: string, last_name: string}>}
+ */
+export function pickProbeRows(body) {
+  if (!Array.isArray(body)) return [];
+
+  return body
+    .filter(isProbeRow)
+    .map(row => ({
+      contact_key: row.contact_key,
+      email: row.email,
+      last_name: row.last_name,
+    }));
+}
+
+/**
+ * Decide what still needs creating, given what a search already found.
+ *
+ * ACCESS.md: *"Search first. If `Ztest Wayfinder` already exists from an
+ * earlier run, reuse it rather than creating a second — the identity is only a
+ * blast-radius control if there is exactly one of it."* A second run of this
+ * probe must therefore cost nothing permanent.
+ *
+ * Matching is on **email and surname together**. Email alone would see B as
+ * already present the moment A exists — they share an address on purpose — and
+ * question 2 would silently never be asked.
+ *
+ * @param {object} opts
+ * @param {Array<object>} opts.wanted   Contacts from PROBE_CONTACTS.
+ * @param {Array<{contact_key: string, email?: string, last_name?: string}>} opts.existing
+ * @returns {{create: Array<object>, reuse: Array<object>}}
+ */
+export function planContacts({ wanted, existing = [] }) {
+  const create = [];
+  const reuse = [];
+
+  for (const contact of wanted) {
+    const found = existing.find(
+      row => row?.email === contact.email && row?.last_name === contact.last_name,
+    );
+    if (found) {
+      reuse.push({ ...contact, contact_key: found.contact_key });
+    } else {
+      create.push(contact);
+    }
+  }
+
+  return { create, reuse };
+}

--- a/cloudflare-clubworx/probes/lib/identity.test.js
+++ b/cloudflare-clubworx/probes/lib/identity.test.js
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TEST_IDENTITY,
+  PROBE_CONTACTS,
+  assertProbeIdentity,
+  planContacts,
+  pickProbeRows,
+  plusTag,
+} from './identity.mjs';
+
+// Clubworx cannot delete a contact through the API, so every contact a probe
+// creates is permanent and removable only by hand. That single fact is what
+// each assertion here is protecting: the set must be the smallest one that
+// answers staff-site#49, and nothing outside it may ever be written.
+
+describe('PROBE_CONTACTS', () => {
+  it('is the three contacts authorised for #49, and no more', () => {
+    // ACCESS.md section 4 authorised one identity; #49 needs three, agreed
+    // 2026-08-17. Any growth beyond that is a decision, not a refactor.
+    expect(PROBE_CONTACTS).toHaveLength(3);
+  });
+
+  it('marks every contact as unmistakably not a student', () => {
+    for (const contact of PROBE_CONTACTS) {
+      expect(contact.first_name).toBe('Ztest');
+      expect(contact.last_name.startsWith('Wayfinder')).toBe(true);
+      expect(contact.dob).toBe('1900-01-01');
+    }
+  });
+
+  it('has two contacts sharing one email — the case #49 question 2 asks about', () => {
+    // Siblings share a parent's address, so "many contacts, one email" is the
+    // real scenario. It cannot be answered with a single contact.
+    const byEmail = {};
+    for (const c of PROBE_CONTACTS) byEmail[c.email] = (byEmail[c.email] ?? 0) + 1;
+    expect(Object.values(byEmail).sort()).toEqual([1, 2]);
+  });
+
+  it('has a second plus-tag, so the isolation query has something to exclude', () => {
+    // #49 question 3 asks whether email=noreply+stmarys isolates one school. A
+    // single tag can only show a match, never an exclusion.
+    const tags = new Set(PROBE_CONTACTS.map(c => plusTag(c.email)));
+    expect(tags.size).toBe(2);
+  });
+
+  it('starts from the identity ACCESS.md agreed', () => {
+    expect(PROBE_CONTACTS[0]).toMatchObject({
+      first_name: TEST_IDENTITY.first_name,
+      last_name: TEST_IDENTITY.last_name,
+      email: TEST_IDENTITY.email,
+      dob: TEST_IDENTITY.dob,
+    });
+  });
+});
+
+describe('assertProbeIdentity', () => {
+  it('accepts every contact the probe is authorised to create', () => {
+    for (const contact of PROBE_CONTACTS) {
+      expect(() => assertProbeIdentity(contact)).not.toThrow();
+    }
+  });
+
+  it('refuses a real-looking name', () => {
+    // The blast-radius control. A contact written under a real name is
+    // permanent, in a 60,000-person production database, and indistinguishable
+    // from a genuine record afterwards.
+    expect(() => assertProbeIdentity({ ...PROBE_CONTACTS[0], first_name: 'Katie' })).toThrow(
+      /Ztest/,
+    );
+  });
+
+  it('refuses a surname outside the Wayfinder family', () => {
+    expect(() => assertProbeIdentity({ ...PROBE_CONTACTS[0], last_name: 'Fernsby' })).toThrow(
+      /Wayfinder/,
+    );
+  });
+
+  it('refuses an email that is not a noreply+ probe address', () => {
+    expect(() =>
+      assertProbeIdentity({ ...PROBE_CONTACTS[0], email: 'parent@example.com' }),
+    ).toThrow(/noreply\+/);
+  });
+
+  it('refuses a plausible date of birth', () => {
+    // 1900-01-01 is the marker. A real DOB would make the record look like a
+    // student even to someone reading it in the Clubworx UI.
+    expect(() => assertProbeIdentity({ ...PROBE_CONTACTS[0], dob: '2010-07-06' })).toThrow(/dob/i);
+  });
+
+  it('refuses a contact missing a field entirely', () => {
+    expect(() => assertProbeIdentity({ first_name: 'Ztest' })).toThrow();
+  });
+});
+
+describe('planContacts', () => {
+  const wanted = PROBE_CONTACTS;
+
+  it('creates all three when the gym holds none of them', () => {
+    const plan = planContacts({ wanted, existing: [] });
+    expect(plan.create).toHaveLength(3);
+    expect(plan.reuse).toHaveLength(0);
+  });
+
+  it('reuses an existing probe contact rather than creating a second', () => {
+    // ACCESS.md: "the identity is only a blast-radius control if there is
+    // exactly one of it". A re-run must cost nothing permanent.
+    const existing = [{ contact_key: 'key-a', email: wanted[0].email, last_name: wanted[0].last_name }];
+    const plan = planContacts({ wanted, existing });
+
+    expect(plan.reuse).toHaveLength(1);
+    expect(plan.reuse[0].contact_key).toBe('key-a');
+    expect(plan.create.map(c => c.label)).toEqual(['B', 'C']);
+  });
+
+  it('creates nothing on a second full run', () => {
+    const existing = wanted.map((c, i) => ({
+      contact_key: `key-${i}`,
+      email: c.email,
+      last_name: c.last_name,
+    }));
+    expect(planContacts({ wanted, existing }).create).toHaveLength(0);
+  });
+
+  it('tells A and B apart by surname, though they share an email', () => {
+    // Matching on email alone would see B as already present the moment A
+    // exists, and question 2 would never be asked.
+    const existing = [{ contact_key: 'key-a', email: wanted[0].email, last_name: wanted[0].last_name }];
+    const plan = planContacts({ wanted, existing });
+    expect(plan.create.some(c => c.email === wanted[0].email)).toBe(true);
+  });
+
+  it('ignores a stranger who happens to share the probe email', () => {
+    // A partial-match search returns anything, including rows this probe did
+    // not write. Treating one as "already created" would skip a write and
+    // silently answer question 2 with someone else's record.
+    const existing = [{ contact_key: 'key-x', email: wanted[0].email, last_name: 'Nguyen' }];
+    expect(planContacts({ wanted, existing }).create).toHaveLength(3);
+  });
+});
+
+describe('pickProbeRows', () => {
+  // The search that feeds planContacts is a partial email match, so it returns
+  // strangers. This is where they are dropped — before their email and surname
+  // reach a plan, a log line, or probes/out/. summariseContacts protects the
+  // reporting path; this protects the planning path.
+  const probeRow = {
+    contact_key: 'ck-a',
+    first_name: 'Ztest',
+    last_name: 'Wayfinder',
+    email: TEST_IDENTITY.email,
+  };
+  const strangerRow = {
+    contact_key: 'ck-real',
+    first_name: 'Katie',
+    last_name: 'Fernsby',
+    email: 'parent@example.com',
+  };
+
+  it('keeps rows this probe could have written', () => {
+    expect(pickProbeRows([probeRow, strangerRow])).toHaveLength(1);
+    expect(pickProbeRows([probeRow, strangerRow])[0].contact_key).toBe('ck-a');
+  });
+
+  it('carries nothing about a stranger into the result', () => {
+    const json = JSON.stringify(pickProbeRows([probeRow, strangerRow]));
+    expect(json).not.toContain('Fernsby');
+    expect(json).not.toContain('parent@example.com');
+    expect(json).not.toContain('ck-real');
+  });
+
+  it('keeps only the three fields planning needs', () => {
+    // Not a general row copy. Whatever else Clubworx returns about a contact
+    // stays out of probes/out/ by construction.
+    expect(Object.keys(pickProbeRows([probeRow])[0]).sort()).toEqual([
+      'contact_key',
+      'email',
+      'last_name',
+    ]);
+  });
+
+  it('drops a row that matches the probe email but not a probe name', () => {
+    // Someone else using noreply+wayfindertest@ is not this probe's record, and
+    // reusing it would answer question 2 with a stranger's contact.
+    expect(pickProbeRows([{ ...strangerRow, email: TEST_IDENTITY.email }])).toHaveLength(0);
+  });
+
+  it('recognises an existing contact even when the search omits its dob', () => {
+    // Recognition is looser than writing on purpose. A list response is not
+    // guaranteed to carry a date of birth, and a recogniser that demanded one
+    // would miss the probe's own contacts and create three MORE permanent
+    // records on every run. Too strict here is the expensive direction.
+    expect(probeRow.dob).toBeUndefined();
+    expect(pickProbeRows([probeRow])).toHaveLength(1);
+  });
+
+  it('still refuses to write a contact without a dob', () => {
+    // The other half of that asymmetry: the write guard stays strict.
+    expect(() => assertProbeIdentity(probeRow)).toThrow(/dob/i);
+  });
+
+  it('survives a response that is not a list', () => {
+    expect(pickProbeRows(null)).toEqual([]);
+    expect(pickProbeRows({ error: 'nope' })).toEqual([]);
+  });
+});
+
+describe('plusTag', () => {
+  it('reads the tag out of a plus-addressed email', () => {
+    expect(plusTag('noreply+stmarys@urbanjungleirc.com')).toBe('stmarys');
+  });
+
+  it('returns null when there is no tag', () => {
+    expect(plusTag('noreply@urbanjungleirc.com')).toBeNull();
+  });
+});

--- a/cloudflare-clubworx/probes/lib/key.mjs
+++ b/cloudflare-clubworx/probes/lib/key.mjs
@@ -1,0 +1,44 @@
+/**
+ * Where a probe gets the live Clubworx account key.
+ *
+ * One copy for every probe. This function also writes the message someone sees
+ * when the key is missing, and a second copy of that message is a copy that
+ * eventually stops matching ACCESS.md.
+ *
+ * The key never appears in anything thrown from here: a failure message is the
+ * text most likely to end up pasted into a terminal log, an issue comment, or
+ * this public repo.
+ */
+
+import { readFileSync } from 'node:fs';
+
+const VAR = 'CLUBWORX_ACCOUNT_KEY';
+
+/**
+ * @param {string} devVarsPath Path to a `.dev.vars` file.
+ * @returns {string}
+ */
+export function loadAccountKey(devVarsPath) {
+  let text;
+  try {
+    text = readFileSync(devVarsPath, 'utf8');
+  } catch {
+    throw new Error(
+      `No .dev.vars at ${devVarsPath}. Copy .dev.vars.example and fill it in — see ACCESS.md.`,
+    );
+  }
+
+  const key = text
+    .split('\n')
+    .find(line => line.trim().startsWith(`${VAR}=`))
+    // Split on every '=' and rejoin all but the first: a base64 key ends in
+    // padding, and keeping only [1] would truncate the credential into a 401
+    // that looks like a permissions problem.
+    ?.split('=')
+    .slice(1)
+    .join('=')
+    .trim();
+
+  if (!key) throw new Error(`${VAR} is missing or empty in .dev.vars`);
+  return key;
+}

--- a/cloudflare-clubworx/probes/lib/key.test.js
+++ b/cloudflare-clubworx/probes/lib/key.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { loadAccountKey } from './key.mjs';
+
+// Where the live Clubworx key comes from. One copy, because this function also
+// produces the message that tells someone how to fix a missing key — two copies
+// drift, and the one that drifts is the one nobody reads.
+
+const withDevVars = contents => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'uj-clubworx-'));
+  const file = path.join(dir, '.dev.vars');
+  writeFileSync(file, contents);
+  return file;
+};
+
+describe('loadAccountKey', () => {
+  it('reads the key out of a .dev.vars file', () => {
+    expect(loadAccountKey(withDevVars('CLUBWORX_ACCOUNT_KEY=abc123\n'))).toBe('abc123');
+  });
+
+  it('ignores the other lines around it', () => {
+    const file = withDevVars('# a comment\nOTHER=1\nCLUBWORX_ACCOUNT_KEY=abc123\nMORE=2\n');
+    expect(loadAccountKey(file)).toBe('abc123');
+  });
+
+  it('keeps a key that contains "="', () => {
+    // Base64-ish keys end in padding. Splitting on the first = and taking [1]
+    // would silently truncate the credential and produce a 401 nobody can explain.
+    expect(loadAccountKey(withDevVars('CLUBWORX_ACCOUNT_KEY=abc==\n'))).toBe('abc==');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(loadAccountKey(withDevVars('  CLUBWORX_ACCOUNT_KEY=abc123  \n'))).toBe('abc123');
+  });
+
+  it('does not read a commented-out key', () => {
+    expect(() => loadAccountKey(withDevVars('# CLUBWORX_ACCOUNT_KEY=abc123\n'))).toThrow();
+  });
+
+  it('explains how to fix a missing file, naming the template and ACCESS.md', () => {
+    const missing = path.join(mkdtempSync(path.join(tmpdir(), 'uj-clubworx-')), '.dev.vars');
+    expect(() => loadAccountKey(missing)).toThrow(/\.dev\.vars\.example/);
+    expect(() => loadAccountKey(missing)).toThrow(/ACCESS\.md/);
+  });
+
+  it('rejects a present-but-empty key rather than sending a blank one', () => {
+    expect(() => loadAccountKey(withDevVars('CLUBWORX_ACCOUNT_KEY=\n'))).toThrow(/missing or empty/);
+  });
+
+  it('never puts the key in the error message', () => {
+    // The failure path is the one that gets pasted into a terminal, an issue
+    // comment, or a public repo.
+    const file = withDevVars('CLUBWORX_ACCOUNT_KEY=\n');
+    try {
+      loadAccountKey(file);
+    } catch (err) {
+      expect(err.message).not.toContain('CLUBWORX_ACCOUNT_KEY=');
+    }
+  });
+});

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -199,6 +199,68 @@ export function summariseContacts(body, ourKeys = []) {
 }
 
 /**
+ * What a write response means — did a contact come into existence?
+ *
+ * Two questions that are not the same one: whether a record now exists, and
+ * whether the server told us why not. Clubworx cannot delete contacts through
+ * the API, so anything that *might* have landed has to be treated as though it
+ * did — the cleanup list is the only record anyone gets, and a contact missing
+ * from it is a permanent row nobody knows the key of.
+ *
+ * A lost response is therefore `mayExist: true`, and only a 4xx is a rejection.
+ *
+ * @param {{status?: number|null, error?: string|null, refused?: string|null}} sample
+ */
+export function classifyWrite({ status, error, refused } = {}) {
+  if (refused) return { outcome: 'refused', mayExist: false, conclusive: false };
+  if (error) return { outcome: 'failed', mayExist: true, conclusive: false };
+
+  // Clubworx answers 200 on create, not 201, so the whole 2xx range counts.
+  if (status >= 200 && status < 300) return { outcome: 'created', mayExist: true, conclusive: true };
+  if (status >= 400 && status < 500) return { outcome: 'rejected', mayExist: false, conclusive: true };
+
+  return { outcome: 'failed', mayExist: true, conclusive: false };
+}
+
+/**
+ * Does #49's answer collapse the school-marking scheme?
+ *
+ * The ticket: *"If plus-addressing is rejected, or email turns out to be
+ * unique-constrained, the marking decision ... **collapses** ... Say so
+ * explicitly rather than inventing a workaround."*
+ *
+ * Only a **conclusive rejection** means that. A timeout or a 500 means run it
+ * again — reporting either as a collapse would invent exactly the conclusion
+ * the ticket asked to be stated only when true, and would send someone to
+ * re-decide a design over a dropped packet.
+ *
+ * @param {{plus: object|null, duplicate: object|null}} outcomes Results of classifyWrite.
+ */
+export function schemeCollapses({ plus, duplicate }) {
+  if (plus?.outcome === 'rejected') {
+    return {
+      collapsed: true,
+      inconclusive: false,
+      reason: 'plus-addressing was rejected — the noreply+<school> marker cannot be written',
+    };
+  }
+  if (duplicate?.outcome === 'rejected') {
+    return {
+      collapsed: true,
+      inconclusive: false,
+      reason: 'email is unique per contact — siblings and whole schools cannot share an address',
+    };
+  }
+
+  const attempted = [plus, duplicate].filter(Boolean);
+  return {
+    collapsed: false,
+    inconclusive: attempted.length > 0 && attempted.some(o => !o.conclusive),
+    reason: null,
+  };
+}
+
+/**
  * Did a plus-tag search isolate the contacts carrying that tag?
  *
  * This is the question staff-site#46's school-marking scheme rests on. It has

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -166,3 +166,73 @@ export function sameIds(a, b) {
   const left = new Set(a);
   return b.every(id => left.has(id));
 }
+
+/**
+ * Reduce a contact list to its shape, naming only contacts this probe created.
+ *
+ * staff-site#49 searches on a *partial* email (`email=noreply%2B`), so whatever
+ * else in the gym happens to match comes back with it — real members, with real
+ * names and real addresses. The count is the finding; the rows are not. Only
+ * `contact_key`s already known to the caller survive, because those are the ones
+ * the probe wrote and is about to hand back as a cleanup list.
+ *
+ * @param {unknown} body
+ * @param {string[]} [ourKeys] Contact keys this probe created or reused.
+ */
+export function summariseContacts(body, ourKeys = []) {
+  if (!Array.isArray(body)) {
+    return { count: 0, fields: [], ours: [], strangers: 0, notAnArray: true };
+  }
+
+  const known = new Set(ourKeys);
+  const fields = new Set();
+  const ours = [];
+  let strangers = 0;
+
+  for (const row of body) {
+    for (const key of Object.keys(row ?? {})) fields.add(key);
+    if (known.has(row?.contact_key)) ours.push(row.contact_key);
+    else strangers += 1;
+  }
+
+  return { count: body.length, fields: [...fields], ours: ours.sort(), strangers, notAnArray: false };
+}
+
+/**
+ * Did a plus-tag search isolate the contacts carrying that tag?
+ *
+ * This is the question staff-site#46's school-marking scheme rests on. It has
+ * two distinct failure modes and they are not interchangeable: a tag that
+ * *leaks* another school's contacts makes the marker useless for selecting, and
+ * a tag that *misses* its own makes it useless for finding. Both are reported
+ * rather than collapsed into one boolean, so the write-up can say which.
+ *
+ * `endpointHoldsOurs` separates "the marker does not work here" from "our
+ * contacts are not here to be found". A contact created as a prospect does not
+ * appear under `/members` at all, and scoring that as an isolation failure would
+ * report a working marker as a broken one.
+ *
+ * @param {{returned?: string[], expected?: string[], excluded?: string[], endpointHoldsOurs?: boolean}} opts
+ */
+export function describeIsolation({
+  returned = [],
+  expected = [],
+  excluded = [],
+  endpointHoldsOurs = true,
+}) {
+  const got = new Set(returned);
+  const missing = expected.filter(key => !got.has(key));
+  const crossTag = excluded.filter(key => got.has(key));
+
+  if (!endpointHoldsOurs) {
+    return { applicable: false, isolated: null, missing, crossTag, returnedCount: returned.length };
+  }
+
+  return {
+    applicable: true,
+    isolated: returned.length > 0 && missing.length === 0 && crossTag.length === 0,
+    missing,
+    crossTag,
+    returnedCount: returned.length,
+  };
+}

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -9,6 +9,8 @@ import {
   recommendPacing,
   summariseContacts,
   describeIsolation,
+  classifyWrite,
+  schemeCollapses,
 } from './report.mjs';
 
 // What a probe is allowed to write down. Everything here is counts, ids, status
@@ -265,6 +267,101 @@ describe('summariseContacts', () => {
     // "the request failed" are different answers to question 3.
     expect(summariseContacts({ error: 'nope' }, ours).notAnArray).toBe(true);
     expect(summariseContacts(null, ours).count).toBe(0);
+  });
+});
+
+describe('classifyWrite', () => {
+  // Two questions about a write that are not the same question: did a contact
+  // come into existence, and did the server tell us why not. Clubworx cannot
+  // delete contacts through the API, so "might exist" has to be treated as
+  // "exists" — the cleanup list is the only record anyone gets.
+
+  it('treats a 2xx as created', () => {
+    const v = classifyWrite({ status: 200 });
+    expect(v.outcome).toBe('created');
+    expect(v.mayExist).toBe(true);
+    expect(v.conclusive).toBe(true);
+  });
+
+  it('accepts any 2xx, not just 201', () => {
+    // Clubworx answers 200 on create. A client checking for 201 would read
+    // every successful write as a failure.
+    expect(classifyWrite({ status: 201 }).outcome).toBe('created');
+    expect(classifyWrite({ status: 200 }).outcome).toBe('created');
+  });
+
+  it('treats a 4xx as a conclusive rejection that created nothing', () => {
+    const v = classifyWrite({ status: 422 });
+    expect(v.outcome).toBe('rejected');
+    expect(v.mayExist).toBe(false);
+    expect(v.conclusive).toBe(true);
+  });
+
+  it('treats a transport failure as "may exist", never as a rejection', () => {
+    // The request may have been honoured and the response lost. This is the
+    // one case where a permanent contact exists and nobody has its key.
+    const v = classifyWrite({ status: null, error: 'ECONNRESET' });
+    expect(v.outcome).toBe('failed');
+    expect(v.mayExist).toBe(true);
+    expect(v.conclusive).toBe(false);
+  });
+
+  it('treats a 5xx as "may exist" too', () => {
+    const v = classifyWrite({ status: 500 });
+    expect(v.mayExist).toBe(true);
+    expect(v.conclusive).toBe(false);
+  });
+
+  it('treats a local identity refusal as nothing having been sent', () => {
+    const v = classifyWrite({ status: null, refused: 'not Ztest' });
+    expect(v.outcome).toBe('refused');
+    expect(v.mayExist).toBe(false);
+    expect(v.conclusive).toBe(false);
+  });
+});
+
+describe('schemeCollapses', () => {
+  // #49: "If plus-addressing is rejected, or email turns out to be
+  // unique-constrained, the marking decision COLLAPSES ... Say so explicitly
+  // rather than inventing a workaround." Only a conclusive rejection means
+  // that. A timeout means try again, and saying "collapsed" to a timeout
+  // invents the very conclusion the ticket asked to be stated only when true.
+  const rejected = { outcome: 'rejected', conclusive: true };
+  const failed = { outcome: 'failed', conclusive: false };
+  const created = { outcome: 'created', conclusive: true };
+
+  it('does not collapse when both writes were accepted', () => {
+    expect(schemeCollapses({ plus: created, duplicate: created }).collapsed).toBe(false);
+  });
+
+  it('collapses when the plus-addressed write was rejected', () => {
+    const v = schemeCollapses({ plus: rejected, duplicate: null });
+    expect(v.collapsed).toBe(true);
+    expect(v.reason).toMatch(/plus/i);
+  });
+
+  it('collapses when a duplicate email was rejected', () => {
+    const v = schemeCollapses({ plus: created, duplicate: rejected });
+    expect(v.collapsed).toBe(true);
+    expect(v.reason).toMatch(/unique/i);
+  });
+
+  it('does NOT collapse on a timeout or a server error', () => {
+    expect(schemeCollapses({ plus: created, duplicate: failed }).collapsed).toBe(false);
+    expect(schemeCollapses({ plus: failed, duplicate: null }).collapsed).toBe(false);
+  });
+
+  it('reports inconclusive rather than pretending a failure was an answer', () => {
+    const v = schemeCollapses({ plus: created, duplicate: failed });
+    expect(v.inconclusive).toBe(true);
+  });
+
+  it('is neither collapsed nor inconclusive when nothing was attempted', () => {
+    // A re-run creates nothing because the contacts already exist. That is not
+    // an inconclusive result, it is a run with no writes in it.
+    const v = schemeCollapses({ plus: null, duplicate: null });
+    expect(v.collapsed).toBe(false);
+    expect(v.inconclusive).toBe(false);
   });
 });
 

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -7,6 +7,8 @@ import {
   sameIds,
   deriveRateLimit,
   recommendPacing,
+  summariseContacts,
+  describeIsolation,
 } from './report.mjs';
 
 // What a probe is allowed to write down. Everything here is counts, ids, status
@@ -218,5 +220,105 @@ describe('recommendPacing', () => {
   it('states what a 90-read lookup would cost at that pace', () => {
     const p = recommendPacing({ allowed: 60, windowMs: 60_000, reads: 90 });
     expect(p.estimatedMsFor).toBe(90 * 1250);
+  });
+});
+
+describe('summariseContacts', () => {
+  // staff-site#49 searches on a partial email, so the responses it summarises
+  // contain whoever else happens to match — real people, in a public repo's
+  // probe output. Only counts, field names, and keys this probe already knows
+  // may survive this function.
+  const ours = ['ck-a', 'ck-b'];
+  const body = [
+    { contact_key: 'ck-a', first_name: 'Ztest', last_name: 'Wayfinder', email: 'noreply+wayfindertest@urbanjungleirc.com' },
+    { contact_key: 'ck-real', first_name: 'Katie', last_name: 'Fernsby', email: 'parent@example.com' },
+  ];
+
+  it('records no row of production data, whatever came back', () => {
+    const json = JSON.stringify(summariseContacts(body, ours));
+    expect(json).not.toContain('Katie');
+    expect(json).not.toContain('Fernsby');
+    expect(json).not.toContain('parent@example.com');
+    expect(json).not.toContain('ck-real');
+  });
+
+  it('counts everything returned, including rows it may not describe', () => {
+    // The count is the answer to "does a partial email match?", so it must
+    // include strangers even though their details cannot be written down.
+    expect(summariseContacts(body, ours).count).toBe(2);
+  });
+
+  it('names which of our own contacts came back', () => {
+    expect(summariseContacts(body, ours).ours).toEqual(['ck-a']);
+  });
+
+  it('counts the rest as strangers without identifying them', () => {
+    expect(summariseContacts(body, ours).strangers).toBe(1);
+  });
+
+  it('lists the field names, which are schema and not data', () => {
+    expect(summariseContacts(body, ours).fields).toContain('contact_key');
+  });
+
+  it('flags a body that is not a list rather than pretending it was empty', () => {
+    // A 422 or a throttle answers with an object or HTML. "0 contacts" and
+    // "the request failed" are different answers to question 3.
+    expect(summariseContacts({ error: 'nope' }, ours).notAnArray).toBe(true);
+    expect(summariseContacts(null, ours).count).toBe(0);
+  });
+});
+
+describe('describeIsolation', () => {
+  // Question 3: does email=noreply+<tag> isolate one school, or does it return
+  // every noreply+ contact? The whole school-marking scheme rests on this.
+  it('confirms isolation when a tag returns its own contacts and no others', () => {
+    const v = describeIsolation({ returned: ['ck-a', 'ck-b'], expected: ['ck-a', 'ck-b'], excluded: ['ck-c'] });
+    expect(v.isolated).toBe(true);
+    expect(v.missing).toEqual([]);
+    expect(v.crossTag).toEqual([]);
+  });
+
+  it('reports a tag that leaks contacts belonging to another tag', () => {
+    const v = describeIsolation({ returned: ['ck-a', 'ck-b', 'ck-c'], expected: ['ck-a', 'ck-b'], excluded: ['ck-c'] });
+    expect(v.isolated).toBe(false);
+    expect(v.crossTag).toEqual(['ck-c']);
+  });
+
+  it('reports a tag that fails to return its own contacts', () => {
+    // Just as fatal as leaking, and a different failure: the marker would not
+    // find the school it marked.
+    const v = describeIsolation({ returned: ['ck-a'], expected: ['ck-a', 'ck-b'], excluded: ['ck-c'] });
+    expect(v.isolated).toBe(false);
+    expect(v.missing).toEqual(['ck-b']);
+  });
+
+  it('is not isolated when nothing came back at all', () => {
+    const v = describeIsolation({ returned: [], expected: ['ck-a'], excluded: [] });
+    expect(v.isolated).toBe(false);
+  });
+
+  it('says "not applicable" when the endpoint holds none of our contacts', () => {
+    // A contact created as a prospect does not appear under /members at all.
+    // Reporting that as an isolation failure blames the search for the contact
+    // type being elsewhere — and #49's answer would read as a broken marker.
+    const v = describeIsolation({
+      returned: [],
+      expected: ['ck-a'],
+      excluded: [],
+      endpointHoldsOurs: false,
+    });
+    expect(v.applicable).toBe(false);
+    expect(v.isolated).toBeNull();
+  });
+
+  it('still judges isolation on an endpoint that does hold our contacts', () => {
+    const v = describeIsolation({
+      returned: ['ck-a'],
+      expected: ['ck-a'],
+      excluded: ['ck-c'],
+      endpointHoldsOurs: true,
+    });
+    expect(v.applicable).toBe(true);
+    expect(v.isolated).toBe(true);
   });
 });

--- a/cloudflare-clubworx/probes/lib/write.mjs
+++ b/cloudflare-clubworx/probes/lib/write.mjs
@@ -1,0 +1,135 @@
+/**
+ * The only path a probe takes to Clubworx that can create anything.
+ *
+ * Kept apart from `lib/http.mjs` on purpose. That module issues GET and nothing
+ * else, and the read-only probes (#51) import only it — so "this probe cannot
+ * write" stays a structural property of those scripts rather than a claim about
+ * them. Writing requires reaching for a different module, deliberately.
+ *
+ * Two controls sit in front of every request here, because Clubworx **cannot
+ * delete a contact through the API** (ACCESS.md section 4) and there is no
+ * sandbox:
+ *
+ *   1. `live` defaults to false. An import, or a forgotten flag, produces a
+ *      dry-run sample instead of a permanent record.
+ *   2. Every contact must pass `assertProbeIdentity`. A write under anything
+ *      resembling a real person is refused before the network is touched.
+ */
+
+import { buildUrl, redact } from './request.mjs';
+import { rateLimitHeaders } from './report.mjs';
+import { assertProbeIdentity } from './identity.mjs';
+
+/** Fields that exist for the write-up and the cleanup list, not for Clubworx. */
+const BOOKKEEPING = new Set(['label', 'why']);
+
+const payloadOf = contact =>
+  Object.fromEntries(Object.entries(contact).filter(([name]) => !BOOKKEEPING.has(name)));
+
+/**
+ * @param {object} opts
+ * @param {string} opts.accountKey
+ * @param {boolean} [opts.live]  Must be explicitly true before anything is created.
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @returns {((path: string, contact: object) => Promise<object>) & { writes: number }}
+ */
+export function createPoster({ accountKey, live = false, fetchImpl = fetch }) {
+  const post = async (path, contact) => {
+    const url = buildUrl({ path, accountKey });
+    const safeUrl = redact(url, accountKey);
+
+    // Before the live check, so a dry run also proves the guard rather than
+    // only proving the plumbing.
+    let payload;
+    try {
+      assertProbeIdentity(contact);
+      payload = payloadOf(contact);
+    } catch (err) {
+      return {
+        url: safeUrl,
+        status: null,
+        ms: 0,
+        headers: {},
+        contentType: null,
+        body: null,
+        bodyText: null,
+        error: null,
+        refused: err.message,
+        dryRun: !live,
+      };
+    }
+
+    if (!live) {
+      return {
+        url: safeUrl,
+        status: null,
+        ms: 0,
+        headers: {},
+        contentType: null,
+        body: null,
+        bodyText: null,
+        error: null,
+        refused: null,
+        dryRun: true,
+        wouldSend: payload,
+      };
+    }
+
+    post.writes += 1;
+    const started = performance.now();
+
+    try {
+      const res = await fetchImpl(url, {
+        method: 'POST',
+        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const ms = Math.round(performance.now() - started);
+      const bodyText = await res.text();
+
+      // A validation failure or a WAF block answers in HTML, and this is
+      // precisely the response worth recording — it is how question 1 and
+      // question 2 get answered. Parsing must not decide whether it survives.
+      let body = null;
+      try {
+        body = JSON.parse(bodyText);
+      } catch {
+        body = null;
+      }
+
+      return {
+        url: safeUrl,
+        status: res.status,
+        ms,
+        headers: rateLimitHeaders(res.headers),
+        contentType: res.headers.get?.('content-type') ?? null,
+        body,
+        bodyText: body === null ? redact(bodyText, accountKey).slice(0, 500) : null,
+        error: null,
+        refused: null,
+        dryRun: false,
+        sent: payload,
+      };
+    } catch (err) {
+      // The url is interpolated into node's own connection errors. A failed
+      // write may still have landed, so this sample is part of the cleanup
+      // list, not a reason to abandon the run.
+      return {
+        url: safeUrl,
+        status: null,
+        ms: Math.round(performance.now() - started),
+        headers: {},
+        contentType: null,
+        body: null,
+        bodyText: null,
+        error: redact(err.code ?? err.message ?? 'unknown error', accountKey),
+        refused: null,
+        dryRun: false,
+        sent: payload,
+      };
+    }
+  };
+
+  post.writes = 0;
+  return post;
+}

--- a/cloudflare-clubworx/probes/lib/write.test.js
+++ b/cloudflare-clubworx/probes/lib/write.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { createPoster } from './write.mjs';
+import { PROBE_CONTACTS } from './identity.mjs';
+
+// The only path out to Clubworx that can create anything. Clubworx cannot
+// delete a contact through the API, so a mistake made here is permanent in a
+// production database holding ~60,000 real people. Every assertion below is a
+// property that keeps an accidental or malformed write from happening at all,
+// rather than being noticed afterwards.
+
+const key = 'unique-not-a-real-key';
+const contact = PROBE_CONTACTS[0];
+
+const fakeFetch = (calls, response = {}) => async (url, init) => {
+  calls.push({ url, init });
+  return {
+    status: response.status ?? 201,
+    headers: new Headers(response.headers ?? { 'content-type': 'application/json' }),
+    text: async () => response.text ?? '{"contact_key":"ck-1"}',
+  };
+};
+
+describe('createPoster', () => {
+  it('does not touch the network unless writing is explicitly enabled', async () => {
+    // The default is inert. Importing this module, or forgetting a flag, must
+    // not be enough to create a permanent record.
+    const calls = [];
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch(calls) });
+
+    const res = await post('prospects', contact);
+
+    expect(calls).toHaveLength(0);
+    expect(res.dryRun).toBe(true);
+  });
+
+  it('reports what a dry run would have sent, so --dry-run is reviewable', async () => {
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch([]) });
+    const res = await post('prospects', contact);
+
+    expect(res.wouldSend).toMatchObject({ last_name: contact.last_name, email: contact.email });
+    expect(res.status).toBeNull();
+  });
+
+  it('issues POST when live', async () => {
+    const calls = [];
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch(calls), live: true });
+
+    await post('prospects', contact);
+
+    expect(calls[0].init.method).toBe('POST');
+  });
+
+  it('sends the contact as JSON', async () => {
+    const calls = [];
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch(calls), live: true });
+
+    await post('prospects', contact);
+
+    expect(calls[0].init.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(calls[0].init.body)).toMatchObject({
+      first_name: contact.first_name,
+      last_name: contact.last_name,
+      email: contact.email,
+      dob: contact.dob,
+    });
+  });
+
+  it('strips the probe’s own bookkeeping fields from what it sends', async () => {
+    // `label` and `why` exist for the write-up and the cleanup list. Posting
+    // them would put junk on a permanent record.
+    const calls = [];
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch(calls), live: true });
+
+    await post('prospects', contact);
+
+    const sent = JSON.parse(calls[0].init.body);
+    expect(sent.label).toBeUndefined();
+    expect(sent.why).toBeUndefined();
+  });
+
+  it('refuses a contact that is not the agreed test identity, before any request', async () => {
+    // The guard has to fire in front of the network. Refusing after the POST
+    // would be a report of a permanent record, not a control.
+    const calls = [];
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch(calls), live: true });
+
+    const res = await post('prospects', { ...contact, first_name: 'Katie' });
+
+    expect(calls).toHaveLength(0);
+    expect(res.refused).toMatch(/Ztest/);
+    expect(res.status).toBeNull();
+  });
+
+  it('refuses an unauthorised identity even in a dry run', async () => {
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch([]) });
+    const res = await post('prospects', { ...contact, email: 'parent@example.com' });
+    expect(res.refused).toMatch(/noreply\+/);
+  });
+
+  it('reports the url with the key redacted, never the raw one', async () => {
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch([]), live: true });
+    const res = await post('prospects', contact);
+
+    expect(res.url).toContain('<CLUBWORX_ACCOUNT_KEY>');
+    expect(res.url).not.toContain(key);
+  });
+
+  it('keeps an unparseable body as text rather than throwing', async () => {
+    const post = createPoster({
+      accountKey: key,
+      fetchImpl: fakeFetch([], { status: 422, text: '<html>Unprocessable</html>' }),
+      live: true,
+    });
+    const res = await post('prospects', contact);
+
+    expect(res.status).toBe(422);
+    expect(res.bodyText).toContain('Unprocessable');
+    expect(res.body).toBeNull();
+  });
+
+  it('turns a transport failure into a sample instead of crashing the run', async () => {
+    // A write that fails mid-probe must still leave a record of what was
+    // attempted — that record is the cleanup list.
+    const post = createPoster({
+      accountKey: key,
+      live: true,
+      fetchImpl: async () => {
+        throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+      },
+    });
+    const res = await post('prospects', contact);
+
+    expect(res.error).toBe('ECONNRESET');
+    expect(res.status).toBeNull();
+  });
+
+  it('never lets the key reach an error message', async () => {
+    const post = createPoster({
+      accountKey: key,
+      live: true,
+      fetchImpl: async url => {
+        throw new Error(`connect failed for ${url}`);
+      },
+    });
+    const res = await post('prospects', contact);
+
+    expect(JSON.stringify(res)).not.toContain(key);
+  });
+
+  it('counts the writes it actually made, so a probe cannot quietly create more than it says', async () => {
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch([]), live: true });
+
+    await post('prospects', contact);
+    await post('prospects', PROBE_CONTACTS[1]);
+    await post('prospects', { ...contact, first_name: 'Katie' }); // refused
+
+    expect(post.writes).toBe(2);
+  });
+
+  it('counts nothing when it is not live', async () => {
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch([]) });
+    await post('prospects', contact);
+    expect(post.writes).toBe(0);
+  });
+});

--- a/cloudflare-clubworx/probes/run-49.mjs
+++ b/cloudflare-clubworx/probes/run-49.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+/**
+ * staff-site#49 — plus-addressed duplicate emails on noreply@.
+ *
+ *   node probes/run-49.mjs --dry-run   # the plan and every request, zero network
+ *   node probes/run-49.mjs             # read-only: search, then the isolation reads
+ *   node probes/run-49.mjs --write     # creates up to 3 PERMANENT contacts
+ *   node probes/run-49.mjs --dev-vars=<path>
+ *
+ * ⚠️ `--write` is the only mode that creates anything, and what it creates
+ * cannot be undone. Clubworx has no sandbox and **cannot delete a contact
+ * through the API** (ACCESS.md section 4), so every contact this probe writes is
+ * permanent and removable only by hand in the Clubworx UI. The run ends by
+ * printing exactly what must be deleted.
+ *
+ * Four questions, all from staff-site#46's map. The school-marking scheme rests
+ * on every one of them, and all four were *inferred from reads* until now:
+ *
+ *   1. Does POST accept a plus-addressed `noreply+tag@`, or is the `+` rejected?
+ *   2. Can many contacts share one email — the sibling case — or is it unique?
+ *   3. Does `email=noreply%2B` partial-match, and does a full tag *isolate* one
+ *      school from another?
+ *   4. Does the same hold on /members and /non_attending_contacts, which the
+ *      dedup pass also searches?
+ *
+ * Nothing here records a row of production data. The searches partial-match a
+ * 60,000-person database, so responses are reduced by `summariseContacts` and
+ * candidate rows filtered by `pickProbeRows` before anything is printed.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createGetter } from './lib/http.mjs';
+import { createPoster } from './lib/write.mjs';
+import { loadAccountKey } from './lib/key.mjs';
+import { PROBE_CONTACTS, planContacts, pickProbeRows, plusTag } from './lib/identity.mjs';
+import { summariseContacts, describeIsolation } from './lib/report.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(HERE, 'out');
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const WRITE = args.includes('--write');
+const DEV_VARS =
+  args.find(a => a.startsWith('--dev-vars='))?.split('=').slice(1).join('=') ||
+  path.join(HERE, '..', '.dev.vars');
+
+/** The endpoints #46's dedup pass searches. Question 4 asks about all three. */
+const CONTACT_TYPES = ['prospects', 'members', 'non_attending_contacts'];
+
+/** The two plus-tags in play, derived rather than restated. */
+const TAG_EMAILS = [...new Set(PROBE_CONTACTS.map(c => c.email))];
+
+/** The bare prefix, for the partial-match question. URLSearchParams sends it as `noreply%2B`. */
+const PARTIAL_EMAIL = 'noreply+';
+
+/**
+ * 75 requests/minute, one in flight — the ceiling measured in #51. The allowance
+ * is shared across the whole gym key, so a probe that ignores it throttles HVT
+ * and the front desk too.
+ */
+const GAP_MS = 800;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const line = (label, value) => console.log(`  ${label.padEnd(38)} ${value}`);
+const rule = title => console.log(`\n── ${title} ${'─'.repeat(Math.max(0, 58 - title.length))}`);
+
+/** A contact_key out of a create response, wherever this API chose to put it. */
+const keyOf = body =>
+  body?.contact_key ?? body?.prospect?.contact_key ?? (Array.isArray(body) ? body[0]?.contact_key : null) ?? null;
+
+/**
+ * Find probe contacts an earlier run already created.
+ *
+ * ACCESS.md: *"Search first ... the identity is only a blast-radius control if
+ * there is exactly one of it."* Everything this returns has been through
+ * `pickProbeRows`, so a stranger who happens to match the email is counted and
+ * then dropped rather than mistaken for the probe's own record.
+ */
+async function searchExisting(get) {
+  rule('0. Search first — has an earlier run already created these?');
+
+  const found = [];
+  let strangers = 0;
+
+  for (const type of CONTACT_TYPES) {
+    for (const email of TAG_EMAILS) {
+      const res = await get(type, { email });
+      const rows = pickProbeRows(res.body);
+      // Scored against the rows just recognised, not an empty list — otherwise
+      // the probe's own contacts are reported as strangers on every re-run.
+      const summary = summariseContacts(
+        res.body,
+        rows.map(r => r.contact_key),
+      );
+      found.push(...rows);
+      strangers += summary.strangers;
+
+      line(
+        `${type} email=+${plusTag(email)}`,
+        `HTTP ${res.status} · ${summary.count} returned · ${rows.length} are ours`,
+      );
+      await sleep(GAP_MS);
+    }
+  }
+
+  // Deduplicate: the same contact can answer on more than one search.
+  const byKey = new Map(found.map(row => [row.contact_key, row]));
+  if (strangers) line('rows returned that are not ours', `${strangers} (counted, not recorded)`);
+
+  return [...byKey.values()];
+}
+
+/** Create what is missing. Every success here is permanent. */
+async function createContacts(post, toCreate) {
+  rule(`1–2. Creating ${toCreate.length} contact(s) — PERMANENT`);
+
+  const results = [];
+  for (const contact of toCreate) {
+    const res = await post('prospects', contact);
+    const contact_key = keyOf(res.body);
+
+    results.push({
+      label: contact.label,
+      why: contact.why,
+      first_name: contact.first_name,
+      last_name: contact.last_name,
+      email: contact.email,
+      status: res.status,
+      contact_key,
+      refused: res.refused ?? null,
+      error: res.error ?? null,
+      bodyText: res.bodyText ?? null,
+      created: res.status >= 200 && res.status < 300,
+    });
+
+    line(
+      `${contact.label} ${contact.last_name} <+${plusTag(contact.email)}>`,
+      res.refused
+        ? `REFUSED locally: ${res.refused}`
+        : `HTTP ${res.status ?? 'n/a'}${contact_key ? ` · contact_key ${contact_key}` : ''}` +
+          (res.error ? ` · ${res.error}` : '') +
+          (res.bodyText ? ` · ${res.bodyText.slice(0, 120)}` : ''),
+    );
+    await sleep(GAP_MS);
+  }
+
+  return results;
+}
+
+/**
+ * Questions 3 and 4: does the marker find its contacts, and only its contacts?
+ */
+async function probeSearchability(get, ourKeys, keysByEmail) {
+  const out = {};
+
+  for (const type of CONTACT_TYPES) {
+    rule(`3–4. ${type}`);
+
+    const partialRes = await get(type, { email: PARTIAL_EMAIL });
+    const partial = summariseContacts(partialRes.body, ourKeys);
+    line(
+      `email=${PARTIAL_EMAIL} (partial)`,
+      `HTTP ${partialRes.status} · ${partial.count} returned · ${partial.ours.length}/${ourKeys.length} of ours`,
+    );
+    await sleep(GAP_MS);
+
+    const tags = {};
+    for (const email of TAG_EMAILS) {
+      const res = await get(type, { email });
+      const summary = summariseContacts(res.body, ourKeys);
+      const expected = keysByEmail.get(email) ?? [];
+      const excluded = ourKeys.filter(k => !expected.includes(k));
+      const isolation = describeIsolation({
+        returned: summary.ours,
+        expected,
+        excluded,
+        // A prospect does not appear under /members. Judging isolation there
+        // would report a working marker as a broken one.
+        endpointHoldsOurs: partial.ours.length > 0,
+      });
+
+      tags[email] = { status: res.status, summary, isolation };
+      line(
+        `email=+${plusTag(email)} (exact)`,
+        `HTTP ${res.status} · ${summary.count} returned · ` +
+          (!isolation.applicable
+            ? 'n/a — this endpoint holds none of our contacts'
+            : isolation.isolated
+              ? 'ISOLATED'
+              : `NOT isolated (missing ${isolation.missing.length}, cross-tag ${isolation.crossTag.length})`),
+      );
+      await sleep(GAP_MS);
+    }
+
+    out[type] = {
+      partial: { status: partialRes.status, ...partial },
+      tags,
+      // The partial match is only useful if it finds every contact the probe
+      // created — that is what "find all school-created contacts" means.
+      partialFindsAll: ourKeys.length > 0 && partial.ours.length === ourKeys.length,
+    };
+  }
+
+  return out;
+}
+
+/** The list the ticket asks for: what a human must now delete by hand. */
+function printCleanupList(contacts) {
+  rule('Cleanup — delete these by hand in the Clubworx UI');
+
+  if (!contacts.length) {
+    console.log('  Nothing was created.');
+    return;
+  }
+
+  console.log('  Clubworx cannot delete contacts through the API (ACCESS.md §4).\n');
+  for (const c of contacts) {
+    console.log(
+      `  ${c.label}  ${c.first_name} ${c.last_name.padEnd(16)} ${c.email.padEnd(46)} ` +
+        `contact_key ${c.contact_key ?? 'UNKNOWN — check the UI'}${c.reused ? '  (from an earlier run)' : ''}`,
+    );
+  }
+}
+
+function printDryRun() {
+  console.log('--dry-run: no requests issued, nothing created.\n');
+  console.log(`This run would search ${CONTACT_TYPES.length} endpoints × ${TAG_EMAILS.length} emails ` +
+    `= ${CONTACT_TYPES.length * TAG_EMAILS.length} reads,`);
+  console.log(`then create up to ${PROBE_CONTACTS.length} PERMANENT contacts (only with --write):\n`);
+
+  for (const c of PROBE_CONTACTS) {
+    console.log(`  ${c.label}  ${c.first_name} ${c.last_name.padEnd(16)} ${c.email.padEnd(46)} ${c.why}`);
+  }
+
+  console.log(
+    `\nthen ${CONTACT_TYPES.length} × ${TAG_EMAILS.length + 1} reads to answer questions 3 and 4.`,
+  );
+  console.log(`Paced at one request per ${GAP_MS}ms (~${Math.round(60_000 / GAP_MS)}/min), per #51.`);
+}
+
+async function main() {
+  if (DRY_RUN) {
+    printDryRun();
+    return;
+  }
+
+  const accountKey = loadAccountKey(DEV_VARS);
+  const get = createGetter({ accountKey });
+  const post = createPoster({ accountKey, live: WRITE });
+
+  console.log(
+    WRITE
+      ? 'staff-site#49 probe — WRITES ENABLED, against production Clubworx'
+      : 'staff-site#49 probe — read-only. Pass --write to create the contacts.',
+  );
+
+  const record = { probe: 'staff-site#49', ranAt: new Date().toISOString(), write: WRITE };
+
+  const existing = await searchExisting(get);
+  const plan = planContacts({ wanted: PROBE_CONTACTS, existing });
+  record.plan = {
+    create: plan.create.map(c => c.label),
+    reuse: plan.reuse.map(c => ({ label: c.label, contact_key: c.contact_key })),
+  };
+  line('already present', plan.reuse.length ? plan.reuse.map(c => c.label).join(', ') : 'none');
+  line('still to create', plan.create.length ? plan.create.map(c => c.label).join(', ') : 'none');
+
+  let created = [];
+  if (plan.create.length && WRITE) {
+    created = await createContacts(post, plan.create);
+  } else if (plan.create.length) {
+    rule('1–2. Creating contacts — SKIPPED');
+    console.log('  Read-only run. Re-run with --write to create them.');
+  }
+  record.created = created;
+
+  // Both halves of what exists now: what this run wrote, and what an earlier one did.
+  const everything = [
+    ...created.filter(c => c.created).map(c => ({ ...c, reused: false })),
+    ...plan.reuse.map(c => ({
+      label: c.label,
+      first_name: c.first_name,
+      last_name: c.last_name,
+      email: c.email,
+      contact_key: c.contact_key,
+      reused: true,
+    })),
+  ];
+
+  const ourKeys = everything.map(c => c.contact_key).filter(Boolean);
+  const keysByEmail = new Map(
+    TAG_EMAILS.map(email => [email, everything.filter(c => c.email === email).map(c => c.contact_key).filter(Boolean)]),
+  );
+
+  if (ourKeys.length) {
+    record.searchability = await probeSearchability(get, ourKeys, keysByEmail);
+  } else {
+    rule('3–4. Searchability — SKIPPED');
+    console.log('  No probe contacts exist yet, so there is nothing to search for.');
+  }
+
+  // The verdicts #49 actually asked for, stated rather than left to be inferred.
+  const a = created.find(c => c.label === 'A');
+  const b = created.find(c => c.label === 'B');
+  record.verdicts = {
+    plusAccepted: a ? a.created : plan.reuse.some(c => c.label === 'A') ? 'previously' : null,
+    duplicateEmailAccepted: b ? b.created : plan.reuse.some(c => c.label === 'B') ? 'previously' : null,
+    partialMatchWorks: Object.values(record.searchability ?? {}).map(v => v.partialFindsAll),
+  };
+
+  rule('Verdicts');
+  line('Q1  POST accepts noreply+tag@', String(record.verdicts.plusAccepted));
+  line('Q2  many contacts share one email', String(record.verdicts.duplicateEmailAccepted));
+  if (record.verdicts.duplicateEmailAccepted === false) {
+    // #49: "Say so explicitly rather than inventing a workaround."
+    console.log(
+      '\n  ⚠️  Email appears to be unique per contact. The school-marking scheme\n' +
+        '      decided while charting #46 COLLAPSES and must be re-decided — the\n' +
+        '      fallback is a dedicated prospect status, which loses which-school.',
+    );
+  }
+
+  printCleanupList(everything);
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `49-${record.ranAt.replace(/[:.]/g, '-')}.json`);
+  writeFileSync(file, JSON.stringify(record, null, 2));
+
+  console.log(
+    `\n${get.calls} reads, ${post.writes} writes. Summary written to probes/out/${path.basename(file)}`,
+  );
+}
+
+main().catch(err => {
+  console.error(`probe failed: ${err.message}`);
+  process.exitCode = 1;
+});

--- a/cloudflare-clubworx/probes/run-49.mjs
+++ b/cloudflare-clubworx/probes/run-49.mjs
@@ -36,7 +36,12 @@ import { createGetter } from './lib/http.mjs';
 import { createPoster } from './lib/write.mjs';
 import { loadAccountKey } from './lib/key.mjs';
 import { PROBE_CONTACTS, planContacts, pickProbeRows, plusTag } from './lib/identity.mjs';
-import { summariseContacts, describeIsolation } from './lib/report.mjs';
+import {
+  summariseContacts,
+  describeIsolation,
+  classifyWrite,
+  schemeCollapses,
+} from './lib/report.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(HERE, 'out');
@@ -114,14 +119,22 @@ async function searchExisting(get) {
   return [...byKey.values()];
 }
 
-/** Create what is missing. Every success here is permanent. */
-async function createContacts(post, toCreate) {
-  rule(`1–2. Creating ${toCreate.length} contact(s) — PERMANENT`);
+/**
+ * Create what is missing. Every success here is permanent.
+ *
+ * Called on a read-only run too, where the poster is inert and reports what it
+ * *would* send. That is deliberate: the same guard and the same payload run in
+ * both modes, so a dry pass exercises the real path rather than a description
+ * of it.
+ */
+async function createContacts(post, toCreate, { live }) {
+  rule(live ? `1–2. Creating ${toCreate.length} contact(s) — PERMANENT` : '1–2. Would create');
 
   const results = [];
   for (const contact of toCreate) {
     const res = await post('prospects', contact);
     const contact_key = keyOf(res.body);
+    const classification = classifyWrite(res);
 
     results.push({
       label: contact.label,
@@ -134,18 +147,26 @@ async function createContacts(post, toCreate) {
       refused: res.refused ?? null,
       error: res.error ?? null,
       bodyText: res.bodyText ?? null,
-      created: res.status >= 200 && res.status < 300,
+      // What the server stored, when it echoes the record back. Question 1 asks
+      // whether Clubworx normalises the `+` away, and this is the direct
+      // evidence for it rather than an inference from a later search.
+      emailEcho: res.body?.email ?? null,
+      dryRun: res.dryRun ?? false,
+      ...classification,
     });
 
     line(
       `${contact.label} ${contact.last_name} <+${plusTag(contact.email)}>`,
       res.refused
         ? `REFUSED locally: ${res.refused}`
-        : `HTTP ${res.status ?? 'n/a'}${contact_key ? ` · contact_key ${contact_key}` : ''}` +
-          (res.error ? ` · ${res.error}` : '') +
-          (res.bodyText ? ` · ${res.bodyText.slice(0, 120)}` : ''),
+        : res.dryRun
+          ? `would POST ${JSON.stringify(res.wouldSend)}`
+          : `HTTP ${res.status ?? 'n/a'} ${classification.outcome}` +
+            (contact_key ? ` · contact_key ${contact_key}` : '') +
+            (res.error ? ` · ${res.error}` : '') +
+            (res.bodyText ? ` · ${res.bodyText.slice(0, 120)}` : ''),
     );
-    await sleep(GAP_MS);
+    if (live) await sleep(GAP_MS);
   }
 
   return results;
@@ -201,7 +222,11 @@ async function probeSearchability(get, ourKeys, keysByEmail) {
       tags,
       // The partial match is only useful if it finds every contact the probe
       // created — that is what "find all school-created contacts" means.
-      partialFindsAll: ourKeys.length > 0 && partial.ours.length === ourKeys.length,
+      //
+      // `null`, not `false`, when this endpoint holds none of ours: a contact
+      // created as a prospect is not under /members at all, and recording that
+      // as a failed search would contradict the finding it belongs to.
+      partialFindsAll: partial.ours.length === 0 ? null : partial.ours.length === ourKeys.length,
     };
   }
 
@@ -221,25 +246,54 @@ function printCleanupList(contacts) {
   for (const c of contacts) {
     console.log(
       `  ${c.label}  ${c.first_name} ${c.last_name.padEnd(16)} ${c.email.padEnd(46)} ` +
-        `contact_key ${c.contact_key ?? 'UNKNOWN — check the UI'}${c.reused ? '  (from an earlier run)' : ''}`,
+        `contact_key ${c.contact_key ?? 'UNKNOWN — search the UI for this email'}` +
+        (c.reused ? '  (from an earlier run)' : ''),
+    );
+  }
+
+  // A write whose response was lost may or may not have landed. Listing it as
+  // certain would be wrong; leaving it out would be worse.
+  const uncertain = contacts.filter(c => c.conclusive === false);
+  if (uncertain.length) {
+    console.log(
+      `\n  ⚠️  ${uncertain.length} of these did not confirm (${uncertain.map(c => c.label).join(', ')}).\n` +
+        '      The request may still have been honoured. Search the UI for the\n' +
+        '      email before assuming it is absent, and before re-running --write.',
     );
   }
 }
 
 function printDryRun() {
   console.log('--dry-run: no requests issued, nothing created.\n');
-  console.log(`This run would search ${CONTACT_TYPES.length} endpoints × ${TAG_EMAILS.length} emails ` +
-    `= ${CONTACT_TYPES.length * TAG_EMAILS.length} reads,`);
-  console.log(`then create up to ${PROBE_CONTACTS.length} PERMANENT contacts (only with --write):\n`);
 
+  // Every request, not a count of them. A dry run that only reports arithmetic
+  // cannot be reviewed before a write against a production database.
+  let n = 0;
+  const req = (verb, path, params) =>
+    console.log(`  ${String(++n).padStart(2)}. ${verb.padEnd(4)} /${path}${params ? `?${params}` : ''}`);
+
+  console.log('0. Search first — is any of this already here?');
+  for (const type of CONTACT_TYPES) for (const email of TAG_EMAILS) req('GET', type, `email=${email}`);
+
+  console.log(`\n1–2. Create, only with --write — ${PROBE_CONTACTS.length} PERMANENT contacts:`);
   for (const c of PROBE_CONTACTS) {
-    console.log(`  ${c.label}  ${c.first_name} ${c.last_name.padEnd(16)} ${c.email.padEnd(46)} ${c.why}`);
+    req('POST', 'prospects');
+    console.log(
+      `      ${c.label}  ${c.first_name} ${c.last_name.padEnd(16)} ${c.email.padEnd(46)}\n` +
+        `          dob ${c.dob} — ${c.why}`,
+    );
+  }
+
+  console.log('\n3–4. Searchability:');
+  for (const type of CONTACT_TYPES) {
+    req('GET', type, `email=${PARTIAL_EMAIL}`);
+    for (const email of TAG_EMAILS) req('GET', type, `email=${email}`);
   }
 
   console.log(
-    `\nthen ${CONTACT_TYPES.length} × ${TAG_EMAILS.length + 1} reads to answer questions 3 and 4.`,
+    `\n${n} requests, paced at one per ${GAP_MS}ms (~${Math.round(60_000 / GAP_MS)}/min), per #51.`,
   );
-  console.log(`Paced at one request per ${GAP_MS}ms (~${Math.round(60_000 / GAP_MS)}/min), per #51.`);
+  console.log('Contacts already present are reused, so a re-run creates nothing.');
 }
 
 async function main() {
@@ -270,17 +324,19 @@ async function main() {
   line('still to create', plan.create.length ? plan.create.map(c => c.label).join(', ') : 'none');
 
   let created = [];
-  if (plan.create.length && WRITE) {
-    created = await createContacts(post, plan.create);
-  } else if (plan.create.length) {
-    rule('1–2. Creating contacts — SKIPPED');
-    console.log('  Read-only run. Re-run with --write to create them.');
+  if (plan.create.length) {
+    created = await createContacts(post, plan.create, { live: WRITE });
+    if (!WRITE) console.log('\n  Read-only run — nothing was sent. Re-run with --write.');
   }
   record.created = created;
 
   // Both halves of what exists now: what this run wrote, and what an earlier one did.
+  //
+  // `mayExist`, not `outcome === 'created'`. A POST the server honoured but
+  // whose response was lost leaves a permanent contact with no key recorded
+  // anywhere — precisely the row that most needs to reach the cleanup list.
   const everything = [
-    ...created.filter(c => c.created).map(c => ({ ...c, reused: false })),
+    ...created.filter(c => c.mayExist).map(c => ({ ...c, reused: false })),
     ...plan.reuse.map(c => ({
       label: c.label,
       first_name: c.first_name,
@@ -304,23 +360,42 @@ async function main() {
   }
 
   // The verdicts #49 actually asked for, stated rather than left to be inferred.
-  const a = created.find(c => c.label === 'A');
-  const b = created.find(c => c.label === 'B');
+  const attempted = label => created.find(c => c.label === label && !c.dryRun) ?? null;
+  const previously = label => (plan.reuse.some(c => c.label === label) ? 'previously' : null);
+
+  const plus = attempted('A');
+  const duplicate = attempted('B');
+  const collapse = schemeCollapses({ plus, duplicate });
+
   record.verdicts = {
-    plusAccepted: a ? a.created : plan.reuse.some(c => c.label === 'A') ? 'previously' : null,
-    duplicateEmailAccepted: b ? b.created : plan.reuse.some(c => c.label === 'B') ? 'previously' : null,
-    partialMatchWorks: Object.values(record.searchability ?? {}).map(v => v.partialFindsAll),
+    plusAccepted: plus ? plus.outcome === 'created' : previously('A'),
+    duplicateEmailAccepted: duplicate ? duplicate.outcome === 'created' : previously('B'),
+    partialMatchWorks: Object.fromEntries(
+      Object.entries(record.searchability ?? {}).map(([type, v]) => [type, v.partialFindsAll]),
+    ),
+    collapse,
   };
 
   rule('Verdicts');
   line('Q1  POST accepts noreply+tag@', String(record.verdicts.plusAccepted));
   line('Q2  many contacts share one email', String(record.verdicts.duplicateEmailAccepted));
-  if (record.verdicts.duplicateEmailAccepted === false) {
-    // #49: "Say so explicitly rather than inventing a workaround."
+
+  if (collapse.collapsed) {
+    // #49: "Say so explicitly rather than inventing a workaround." Only on a
+    // conclusive rejection — see schemeCollapses.
     console.log(
-      '\n  ⚠️  Email appears to be unique per contact. The school-marking scheme\n' +
-        '      decided while charting #46 COLLAPSES and must be re-decided — the\n' +
-        '      fallback is a dedicated prospect status, which loses which-school.',
+      `\n  ⚠️  ${collapse.reason}.\n` +
+        '      The school-marking scheme decided while charting #46 COLLAPSES and\n' +
+        '      must be re-decided — the fallback is a dedicated prospect status,\n' +
+        '      which loses the which-school record.',
+    );
+  } else if (collapse.inconclusive) {
+    // A timeout is not an answer, and must not be reported as one.
+    console.log(
+      '\n  ⚠️  A write did not complete (timeout or server error). This says\n' +
+        '      nothing about plus-addressing or uniqueness — re-run before\n' +
+        '      concluding anything, and check the cleanup list: a lost response\n' +
+        '      may still have created a contact.',
     );
   }
 

--- a/cloudflare-clubworx/probes/run-51.mjs
+++ b/cloudflare-clubworx/probes/run-51.mjs
@@ -21,11 +21,12 @@
  * staff-site is a public repo and Clubworx holds ~60,000 real people.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { createGetter } from './lib/http.mjs';
+import { loadAccountKey } from './lib/key.mjs';
 import {
   summariseBurst,
   summariseEvents,
@@ -62,25 +63,7 @@ const perthDate = offsetDays => {
   return new Intl.DateTimeFormat('en-CA', { timeZone: 'Australia/Perth' }).format(d);
 };
 
-function loadAccountKey() {
-  const devVars = path.join(HERE, '..', '.dev.vars');
-  let text;
-  try {
-    text = readFileSync(devVars, 'utf8');
-  } catch {
-    throw new Error(`No .dev.vars at ${devVars}. Copy .dev.vars.example and fill it in — see ACCESS.md.`);
-  }
-  const key = text
-    .split('\n')
-    .find(line => line.trim().startsWith('CLUBWORX_ACCOUNT_KEY='))
-    ?.split('=')
-    .slice(1)
-    .join('=')
-    .trim();
-
-  if (!key) throw new Error('CLUBWORX_ACCOUNT_KEY is missing or empty in .dev.vars');
-  return key;
-}
+const DEV_VARS = path.join(HERE, '..', '.dev.vars');
 
 /** Run thunks with a bounded number in flight, preserving result order. */
 async function pool(thunks, concurrency) {
@@ -346,7 +329,7 @@ async function verifyPace(get, pacing) {
 }
 
 async function main() {
-  const accountKey = loadAccountKey();
+  const accountKey = loadAccountKey(DEV_VARS);
   const get = createGetter({ accountKey });
 
   if (DRY_RUN) {

--- a/cloudflare-clubworx/probes/run-51.mjs
+++ b/cloudflare-clubworx/probes/run-51.mjs
@@ -63,7 +63,11 @@ const perthDate = offsetDays => {
   return new Intl.DateTimeFormat('en-CA', { timeZone: 'Australia/Perth' }).format(d);
 };
 
-const DEV_VARS = path.join(HERE, '..', '.dev.vars');
+/** Points at a key outside the package — a git worktree, where .dev.vars is
+ * gitignored and so does not follow the checkout. */
+const DEV_VARS =
+  args.find(a => a.startsWith('--dev-vars='))?.split('=').slice(1).join('=') ||
+  path.join(HERE, '..', '.dev.vars');
 
 /** Run thunks with a bounded number in flight, preserving result order. */
 async function pool(thunks, concurrency) {


### PR DESCRIPTION
Closes #49. Part of the school-group booking map #46.

Probes and findings only — no page, no Worker, no `tools.json`. The full write-up
is `cloudflare-clubworx/probes/49-plus-addressed-duplicates.md`.

## The answer

**The school-marking scheme survives.** Every assumption #46 took on inference
from reads held up against a write. Three contacts were created against
production Clubworx on 2026-08-17; all three are permanent, and the cleanup list
is at the bottom of the findings doc.

- **`POST /api/v2/prospects` accepts a plus-addressed `noreply@`**, and stores
  the tag unchanged. It answers **`200`, not `201`** — a client checking for the
  exact code reads every successful write as a failure. Check `2xx`.
- **Email is *not* unique per contact.** A second contact was created on a
  byte-identical address and given its own `contact_key`. The sibling case works,
  and the fallback #49 named — a dedicated prospect status, which loses the
  which-school record — is **not needed**.
- **A full tag isolates its own contacts, and a bare `noreply%2B` finds all of
  them.** No cross-tag leakage in either direction. `email` is a partial match,
  so both halves the design needs are there.
- **`/members` and `/non_attending_contacts` returned nothing** — they are
  disjoint views by contact status, not three indexes over one table. #46's dedup
  pass therefore has to search all three and merge; that was already the plan, and
  now it has a reason.

## What this does not settle

The email filter on `/members` and `/non_attending_contacts` was **never
exercised** — those endpoints held none of the probe's contacts, so the filter
was never given a matching row. "Zero results" is consistent with a working
filter *and* with one that ignores `email` entirely. Proving it needs a contact
that is actually a member, which this probe cannot create and #50 may be able to
arrange. Recorded as a gap rather than smoothed into a "yes".

So #49 closes on three and a half of its four questions. Pagination is also
untested — three contacts sit far inside the default `page_size` of 50, and #48
found a real school list of 63.

## Safety

Contacts cannot be deleted through the Clubworx API (ACCESS.md §4), so the write
path is built to make an accidental write impossible rather than recoverable:

- It is **deliberately separate from `lib/http.mjs`**, which still issues `GET`
  and nothing else — a read-only probe cannot write by construction.
- `createPoster` is **inert unless explicitly made live**, and every contact must
  pass an identity guard before the network is touched. A write under anything
  resembling a real name is refused rather than reported afterwards.
- The probe **searches first and reuses what it finds** — verified: a second run
  reported `still to create: none` and made 0 writes.

Recognition is looser than writing on purpose. Requiring a `dob` on a read would
miss the probe's own contacts and create three more permanent records every run.

## The follow-up commit

`9f98576` closes what review of `c7f2579` found. Three were bugs in the safety
machinery, which is the part that has to be right:

- **The cleanup list could omit a contact that exists.** Built from
  `outcome === 'created'`, it dropped a POST the server honoured but whose
  response was lost — the one case where a permanent contact exists and nobody
  has its key. It now lists anything that `mayExist` and flags what did not
  confirm.
- **The collapse warning misdiagnosed any failure as uniqueness.** A 500, a
  timeout or a local identity refusal all printed "the scheme COLLAPSES",
  inventing the one conclusion #49 asked to be stated only when true. It now
  fires only on a conclusive 4xx.
- **The machine record contradicted the prose** — `partialFindsAll` was `false`
  where the findings doc says "not applicable". It is `null` there now.

Plus two doc-vs-code breaches: `--dev-vars` was advertised for either probe but
parsed by only one, and `--dry-run` promised "every request" while printing
arithmetic. It enumerates all 18 now, which is what makes a production write
reviewable beforehand.

## Cleanup owed

Three permanent contacts sort to the end of an alphabetical list under `Ztest`
and must be removed by hand in the Clubworx UI. Keys are in the findings doc.
**#50 should reuse them rather than create its own** — they are already the
membership-less prospects that ticket needs.

## Tests

Run by hand; `pages.yml` runs none.

| Package | Result |
|---|---|
| `cloudflare-clubworx` | 123 pass |
| `cloudflare-worker` | 81 pass (incl. `secret-hygiene`) |
| `cloudflare-payments-proxy` | 9 pass |
| `vouchers` | 216 pass, 1 pre-existing environmental failure |

The `vouchers` failure is `version.test.js > falls back to dev outside a git
repository` — it resolves the parent superrepo instead of finding no repo.
Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
