### PR TITLE
docs(clubworx): probes #50 and #60 — the school-group booking route, measured

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -301,3 +301,51 @@ appears in `/prospects` **only**, and moves when their status changes.
 
 So a lookup searches all three and merges. Which one holds a given student is a
 fact about their membership today, not about how they were created.
+
+## Clubworx school booking
+
+Terms for the route a student takes into a session. Decided 2026-08-18, after
+#50 showed the original prospect route does not work.
+
+### School Session
+
+The Clubworx **event type** for a school group's session. It accepts only
+contacts holding an active [School Pass](#school-pass), its capacity is set for
+the group, and it requires booking **at least one day ahead** — a deliberate
+guard against somebody booking themselves in on the day.
+
+*Avoid*: "school booking" as the event type's name. "Booking" already means the
+API object, the staff action, and the thing a School Pass grants; a fourth
+meaning is one too many.
+
+### School Pass
+
+The **membership plan** every imported student is given, valid **12 weeks** —
+long enough to cover a UJ [term](#uj-term-week) including its snapped edges. It
+is what makes a student bookable: a School Session admits pass-holders and
+nobody else.
+
+Deliberately a different noun from School Session. A *session* happens on a
+date; a *pass* is held by a person. The pair was otherwise easy to confuse in a
+dropdown or a sentence.
+
+The plan name is **never** renamed per student. Reporting aggregates by plan, so
+per-student names would fragment member counts and revenue; the school is
+already recorded by the [school marker](#school-marker) and the term is implied
+by the membership's `start_date`. The duration stays out of the name because
+`GET /membership_plans` exposes `membership_duration` already.
+
+### Prospect allowance
+
+Clubworx's per-**contact** limit on how many events a prospect may be booked
+into. It is the reason the prospect route failed: the limit is reached
+immediately for a returning student, the override exists **only in the Clubworx
+UI**, and the API reports hitting it as *"this class has no free spaces
+available"* — pointing at event capacity, which the same API reports as healthy.
+
+Not exposed by any endpoint. Measured in
+`cloudflare-clubworx/probes/50-membership-less-booking.md`.
+
+*Avoid*: reading a "no free spaces" refusal as a capacity problem without
+checking `spaces_available` first. The two are indistinguishable from the
+message alone.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -335,6 +335,32 @@ already recorded by the [school marker](#school-marker) and the term is implied
 by the membership's `start_date`. The duration stays out of the name because
 `GET /membership_plans` exposes `membership_duration` already.
 
+Proven end to end in #60: a member holding an active pass books, and the pass
+costs nothing and starts no billing schedule.
+
+### Active pass
+
+Whether a School Pass admits its holder *today*. A membership record carries
+`start_date` and `expiration_date` and **no `status` field**, so this is derived
+from the dates — inclusive at both ends, since a pass starting today is usable
+today. Code that looks for `status` reads `undefined` and would treat a live
+pass as inactive.
+
+*Avoid*: "has a School Pass" as a synonym. Holding the plan and holding an
+**active** one are different: an expired pass is still a returned row, and the
+session admits only the active kind.
+
+### Reversible write
+
+The one thing this system does that can be taken back: a **booking**.
+`DELETE /api/v2/bookings/:id` removes one, verified in #60 by re-reading rather
+than by its status code — and it needs `contact_key` alongside `account_key`,
+form-encoded in the body.
+
+Nothing else qualifies. A contact cannot be deleted, and a School Pass has no
+delete endpoint at all — it lapses at its `expiration_date`. So "undo" can
+unbook and can never uncreate, and any UI implying otherwise is lying.
+
 ### Prospect allowance
 
 Clubworx's per-**contact** limit on how many events a prospect may be booked

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -158,15 +158,15 @@ be deleted through the API.** Prospects, members and non-attending contacts
 expose list / show / create / update only. So each write probe leaves a
 **permanent** contact in production, removable only by hand in the Clubworx UI.
 
-**Nothing this key writes can be removed through the API — bookings included.**
-This paragraph previously named bookings as the exception, because
-`DELETE /api/v2/bookings/:id` is in the reference. #50 measured it on
-2026-08-18 and the endpoint answers **HTTP 401 "Authorization failed"** — with
-the same key, in the same run, that `GET`s a contact's bookings at 200 and
-reaches business-level validation on `POST /bookings`. So the key authenticates
-and is permitted to read and create, and is refused only on delete. Whether
-that is a per-key scope or a property of the API is unknown; either way there
-is no undo. See `probes/50-membership-less-booking.md`.
+Bookings are documented as the exception — `DELETE /api/v2/bookings/:id` — but
+that has **still not been demonstrated**, and one thing about it is now known
+the hard way: **`DELETE` requires `contact_key` as well as `account_key`, in a
+form-encoded body.** Omit the contact and it answers `HTTP 401 "Authorization
+failed"`, which is indistinguishable from a key that lacks delete permission.
+#50 sent it without the contact on 2026-08-18 and read the 401 as exactly that,
+briefly recording here that bookings could not be deleted at all. They may well
+be deletable; nobody has yet completed the call correctly against a live
+booking. See `probes/50-membership-less-booking.md`.
 
 **Rate limits are undocumented but no longer unknown.** Nothing in the reference
 describes throttling, retry-after, or a burst ceiling. Probe #51 has since
@@ -210,12 +210,12 @@ and this repo is public.
 - It does **not** make them disposable. Contacts cannot be deleted through the
   API, so every probe contact is permanent and removable only by hand in the
   Clubworx UI. Reuse the one identity; do not improvise new ones per run.
-- Bookings are **not** reversible either, contrary to what this section said
-  before #50 ran. `DELETE /api/v2/bookings/:id` answers HTTP 401 "Authorization
-  failed" for this key, which reads and creates without complaint. A booking a
-  probe or a tool creates is removable only by hand in the Clubworx UI, exactly
-  like a contact — so "it can be undone" must not be relied on when deciding
-  what a write probe may attempt.
+- Bookings are documented as reversible (`DELETE /api/v2/bookings/:id`), but
+  **treat that as unproven** until someone demonstrates it. The call needs
+  `contact_key` in a form-encoded body as well as `account_key`; without it the
+  answer is `401 "Authorization failed"`, which looks exactly like a missing
+  permission. Plan a write probe as though its bookings are permanent, and be
+  glad if they are not.
 - Probes are **#49 and #50's** work. #47 provisions access and stops there; it
   ran only a read-only `GET /locations` to prove the key authenticates.
 
@@ -258,7 +258,7 @@ verified to make zero writes. Any new write probe must do the same.
 |---|---|
 | No sandbox exists | All probing is against production; unavoidable, not a choice |
 | Contacts cannot be deleted via API | Every write probe leaves a permanent record |
-| **Bookings cannot be deleted either** (#50) | `DELETE /bookings/:id` is 401 "Authorization failed" on a key that reads and creates. Measured 2026-08-18, not inferred. Nothing written through this key has an undo, so a mistaken bulk booking is cleared by hand or not at all |
+| `DELETE /bookings/:id` needs **`contact_key`**, form-encoded in the body (#50) | Without it: `401 "Authorization failed"` — identical to a permissions failure, and misread as one. Whether the complete call succeeds is still undemonstrated, so booking reversibility remains a documented claim rather than a measured one |
 | Clubworx issues **one key per gym**, confirmed | Attribution by key is impossible; the `noreply+<school>@` marker is the only provenance signal. One key's leak or rotation hits every integration |
 | Rate limits undocumented **and unadvertised** | Confirmed live, and confirmed again *while being throttled* (#51): no `Retry-After` or `X-RateLimit-*` headers come back at any point. A client cannot self-throttle from response metadata or see a ceiling approaching — only hit it |
 | The ceiling is **tight**: ~50 fast requests, then ~18s of 429 (#51) | 75 req/min ran clean; 120 did not. Every caller must pace, and the allowance is shared across the whole gym key, so this tool can throttle HVT and vice versa |

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -158,15 +158,20 @@ be deleted through the API.** Prospects, members and non-attending contacts
 expose list / show / create / update only. So each write probe leaves a
 **permanent** contact in production, removable only by hand in the Clubworx UI.
 
-Bookings are documented as the exception — `DELETE /api/v2/bookings/:id` — but
-that has **still not been demonstrated**, and one thing about it is now known
-the hard way: **`DELETE` requires `contact_key` as well as `account_key`, in a
-form-encoded body.** Omit the contact and it answers `HTTP 401 "Authorization
+**Bookings are the exception, and this is now measured rather than inferred.**
+`DELETE /api/v2/bookings/:id` reversed a live booking on 2026-08-18 — HTTP 200,
+confirmed by re-reading the contact's bookings rather than trusting the status
+(#60). The call requires **`contact_key` as well as `account_key`, in a
+form-encoded body**; omit the contact and it answers `HTTP 401 "Authorization
 failed"`, which is indistinguishable from a key that lacks delete permission.
-#50 sent it without the contact on 2026-08-18 and read the 401 as exactly that,
-briefly recording here that bookings could not be deleted at all. They may well
-be deletable; nobody has yet completed the call correctly against a live
-booking. See `probes/50-membership-less-booking.md`.
+#50 sent it that way first and briefly recorded here that bookings could not be
+deleted at all.
+
+**Memberships are not the exception.** `POST /api/v2/memberships` creates one
+and no delete appears in the reference, so a School Pass is as permanent as a
+contact. It lapses on its `expiration_date` rather than being removed.
+
+See `probes/60-member-school-pass-booking.md`.
 
 **Rate limits are undocumented but no longer unknown.** Nothing in the reference
 describes throttling, retry-after, or a burst ceiling. Probe #51 has since
@@ -210,12 +215,16 @@ and this repo is public.
 - It does **not** make them disposable. Contacts cannot be deleted through the
   API, so every probe contact is permanent and removable only by hand in the
   Clubworx UI. Reuse the one identity; do not improvise new ones per run.
-- Bookings are documented as reversible (`DELETE /api/v2/bookings/:id`), but
-  **treat that as unproven** until someone demonstrates it. The call needs
+- Bookings **are** reversible, demonstrated in #60: `DELETE /api/v2/bookings/:id`
+  removed a live booking and the re-read confirmed it. The call needs
   `contact_key` in a form-encoded body as well as `account_key`; without it the
   answer is `401 "Authorization failed"`, which looks exactly like a missing
-  permission. Plan a write probe as though its bookings are permanent, and be
-  glad if they are not.
+  permission. So a write probe may create a booking and clean up after itself —
+  but it must still verify by re-reading, not by the status code.
+- **A membership is permanent.** `POST /api/v2/memberships` has no counterpart
+  delete. Assigning a School Pass to the wrong contact cannot be undone, so it
+  carries the same weight as creating a contact: search first, and reuse an
+  *active* pass rather than assigning a second.
 - Probes are **#49 and #50's** work. #47 provisions access and stops there; it
   ran only a read-only `GET /locations` to prove the key authenticates.
 
@@ -258,7 +267,10 @@ verified to make zero writes. Any new write probe must do the same.
 |---|---|
 | No sandbox exists | All probing is against production; unavoidable, not a choice |
 | Contacts cannot be deleted via API | Every write probe leaves a permanent record |
-| `DELETE /bookings/:id` needs **`contact_key`**, form-encoded in the body (#50) | Without it: `401 "Authorization failed"` — identical to a permissions failure, and misread as one. Whether the complete call succeeds is still undemonstrated, so booking reversibility remains a documented claim rather than a measured one |
+| `DELETE /bookings/:id` needs **`contact_key`**, form-encoded in the body (#50, #60) | Without it: `401 "Authorization failed"` — identical to a permissions failure, and misread as one. Sent correctly it reverses cleanly. Read a 401 here as a malformed request before concluding anything about permissions |
+| **Memberships have no delete** (#60) | `POST /memberships` creates a permanent record. A School Pass lapses at `expiration_date`; it cannot be removed. Search first and reuse an active one |
+| A membership record has **no `status` field** (#60) | Only `start_date` and `expiration_date`. Code checking `status` reads `undefined` and would treat a live pass as inactive — derive activity from the dates |
+| `GET /membership_plans` **truncates at 50** (#60) | UJ has 57 plans and `School Pass` was beyond the default page, so a name lookup reports "no such plan". Same trap as `/events` (#51). Always pass `page_size`, and treat a full page as truncated |
 | Clubworx issues **one key per gym**, confirmed | Attribution by key is impossible; the `noreply+<school>@` marker is the only provenance signal. One key's leak or rotation hits every integration |
 | Rate limits undocumented **and unadvertised** | Confirmed live, and confirmed again *while being throttled* (#51): no `Retry-After` or `X-RateLimit-*` headers come back at any point. A client cannot self-throttle from response metadata or see a ceiling approaching — only hit it |
 | The ceiling is **tight**: ~50 fast requests, then ~18s of 429 (#51) | 75 req/min ran clean; 120 did not. Every caller must pace, and the allowance is shared across the whole gym key, so this tool can throttle HVT and vice versa |

--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -157,8 +157,16 @@ This compounds a constraint already recorded on #46: **Clubworx contacts cannot
 be deleted through the API.** Prospects, members and non-attending contacts
 expose list / show / create / update only. So each write probe leaves a
 **permanent** contact in production, removable only by hand in the Clubworx UI.
-Bookings are the exception — `DELETE /api/v2/bookings/:id` exists, so the
-booking half of probe #50 is reversible; the contact it needs is not.
+
+**Nothing this key writes can be removed through the API — bookings included.**
+This paragraph previously named bookings as the exception, because
+`DELETE /api/v2/bookings/:id` is in the reference. #50 measured it on
+2026-08-18 and the endpoint answers **HTTP 401 "Authorization failed"** — with
+the same key, in the same run, that `GET`s a contact's bookings at 200 and
+reaches business-level validation on `POST /bookings`. So the key authenticates
+and is permitted to read and create, and is refused only on delete. Whether
+that is a per-key scope or a property of the API is unknown; either way there
+is no undo. See `probes/50-membership-less-booking.md`.
 
 **Rate limits are undocumented but no longer unknown.** Nothing in the reference
 describes throttling, retry-after, or a burst ceiling. Probe #51 has since
@@ -202,8 +210,12 @@ and this repo is public.
 - It does **not** make them disposable. Contacts cannot be deleted through the
   API, so every probe contact is permanent and removable only by hand in the
   Clubworx UI. Reuse the one identity; do not improvise new ones per run.
-- Bookings *are* reversible (`DELETE /api/v2/bookings/:id`), so #50 should clean
-  up the booking it creates even though it cannot clean up the contact.
+- Bookings are **not** reversible either, contrary to what this section said
+  before #50 ran. `DELETE /api/v2/bookings/:id` answers HTTP 401 "Authorization
+  failed" for this key, which reads and creates without complaint. A booking a
+  probe or a tool creates is removable only by hand in the Clubworx UI, exactly
+  like a contact — so "it can be undone" must not be relied on when deciding
+  what a write probe may attempt.
 - Probes are **#49 and #50's** work. #47 provisions access and stops there; it
   ran only a read-only `GET /locations` to prove the key authenticates.
 
@@ -245,7 +257,8 @@ verified to make zero writes. Any new write probe must do the same.
 | Caveat | Consequence |
 |---|---|
 | No sandbox exists | All probing is against production; unavoidable, not a choice |
-| Contacts cannot be deleted via API | Every write probe leaves a permanent record; bookings are reversible, contacts are not |
+| Contacts cannot be deleted via API | Every write probe leaves a permanent record |
+| **Bookings cannot be deleted either** (#50) | `DELETE /bookings/:id` is 401 "Authorization failed" on a key that reads and creates. Measured 2026-08-18, not inferred. Nothing written through this key has an undo, so a mistaken bulk booking is cleared by hand or not at all |
 | Clubworx issues **one key per gym**, confirmed | Attribution by key is impossible; the `noreply+<school>@` marker is the only provenance signal. One key's leak or rotation hits every integration |
 | Rate limits undocumented **and unadvertised** | Confirmed live, and confirmed again *while being throttled* (#51): no `Retry-After` or `X-RateLimit-*` headers come back at any point. A client cannot self-throttle from response metadata or see a ceiling approaching — only hit it |
 | The ceiling is **tight**: ~50 fast requests, then ~18s of 429 (#51) | 75 req/min ran clean; 120 did not. Every caller must pace, and the allowance is shared across the whole gym key, so this tool can throttle HVT and vice versa |

--- a/cloudflare-clubworx/probes/50-membership-less-booking.md
+++ b/cloudflare-clubworx/probes/50-membership-less-booking.md
@@ -15,14 +15,16 @@ booked into an event. It cannot — not because of anything in the documented
 API, but because Clubworx applies a **per-contact safety rule to prospects**
 that the API neither documents nor reports honestly.
 
-**And nothing written through this key can be taken back.** `DELETE
-/api/v2/bookings/:id` — which ACCESS.md recorded as the one reversible write on
-this map — answers **401 "Authorization failed"** for a key that reads and
-creates without complaint. So a mistaken booking is as permanent as a mistaken
-contact.
-
 This is the branch #50 asked to be flagged rather than absorbed. It is flagged
 in [What this costs #46](#what-this-costs-46).
+
+**A correction, recorded because it was briefly published as a finding.** An
+earlier version of this document reported that bookings cannot be deleted at
+all — that `DELETE /api/v2/bookings/:id` answers `401` for a key that reads and
+creates. The 401 was real; the conclusion was wrong. The endpoint **requires
+`contact_key` as well as `account_key`**, form-encoded in the body, and the
+probe sent neither. A missing required parameter and a missing permission are
+the same HTTP status here. See [question 4](#4-does-delete-bookingsid-reverse-a-booking--still-unproven).
 
 ## The four questions
 
@@ -72,34 +74,38 @@ reports as healthy.
 Nothing landed, so there was no first booking to duplicate. Asking it after a
 rejection would have measured two rejections and called it idempotency.
 
-### 4. Does `DELETE /bookings/:id` reverse a booking? — **No. It is refused.**
+### 4. Does `DELETE /bookings/:id` reverse a booking? — **Still unproven**
 
-The probe created nothing to cancel, but the UI attempt left booking
-`63499414` on `Ztest Wayfinder`, which answered the question at no cost:
+The probe created nothing to cancel. The UI attempt left booking `63499414` on
+`Ztest Wayfinder`, and the attempt to remove it produced:
 
 ```
 DELETE /api/v2/bookings/63499414   →   HTTP 401   "Authorization failed"
 ```
 
-The booking was still there afterwards — verified by re-counting, not assumed
-from the status.
+**That 401 was the probe's own bug, and it was briefly written up as a
+finding.** The reference documents `DELETE /api/v2/bookings/:id` as taking
+**`account_key` *and* `contact_key`**, form-encoded in the body. The probe sent
+`account_key` in the query string and no body at all. A missing required
+parameter and a missing permission produce the same status here, and the
+reasoning that followed — *the key reads at 200 and creates at 400, so it must
+be refused only on delete* — was consistent with the evidence and still wrong.
 
-**This is not a bad key.** In the same run, with the same key and the same
-`account_key` query parameter, `GET /bookings?contact_key=` answered **200**,
-and in the runs above `POST /bookings` reached **business-level validation**
-(a 400 about spaces, not an auth error). So the key authenticates, and is
-permitted to read and to create. It is refused **only on delete**.
+The call now sends both, taking the contact from the booking record rather than
+from the caller so it cannot be forgotten or mismatched. **It has not been
+re-run against a live booking**: by the time the fix was in, booking `63499414`
+was gone from the contact's list.
 
-Whether that is a per-key permission scope or a property of the API, this probe
-cannot say. The consequence is the same either way.
+So the honest state is:
 
-**ACCESS.md said the opposite, and has been corrected.** It recorded bookings as
-"the exception — `DELETE /api/v2/bookings/:id` exists, so the booking half of
-probe #50 is reversible". That came from the endpoint being in the reference,
-not from anyone calling it. It is now measured.
+| | |
+|---|---|
+| `DELETE` without `contact_key` | **401**, measured twice |
+| `DELETE` with `contact_key` | **not attempted** |
+| Bookings reversible? | documented, **never demonstrated** |
 
-So **nothing this key writes can be removed through the API.** Bookings sit
-beside contacts: permanent, and clearable only by hand in the Clubworx UI.
+Proving it needs a booking to cancel, which needs a contact that can be booked
+— so it is blocked behind the same thing questions 1 and 3 are.
 
 ## `spaces_available` cannot be trusted
 
@@ -151,16 +157,17 @@ tool creates, and it needs answers on:
 - **Plan choice** — which plan, with what duration and what it entitles.
 - **Clubworx reporting** — a cohort of members created per school changes member
   counts, retention and revenue reporting in ways prospects did not.
-- **Cleanup** — memberships are very likely as permanent as everything else.
-  Every write this key has been shown to make is irreversible through the API,
-  and there is no reason to expect memberships to differ. Assume they cannot be
-  removed until measured.
+- **Cleanup** — contacts cannot be deleted through the API, and memberships have
+  not been shown to be removable either. Assume a membership is permanent until
+  somebody measures otherwise; the `POST /memberships` endpoint exists, but no
+  delete for it appears in the reference.
 
-The no-undo finding raises the cost of getting this wrong. A tool that books a
-school group of 30 into the wrong session cannot retract it: someone clears 30
-bookings by hand in the Clubworx UI. That argues for the tool checking existing
-bookings before writing, and for a confirmation step that shows exactly what is
-about to be created — which is only possible if question 3 is answered first.
+Undo cannot be assumed. Cancelling a booking is documented but undemonstrated
+(question 4), and nothing else this tool creates has an undo at all. A tool that
+books a school group of 30 into the wrong session may have to be unpicked by
+hand, 30 rows at a time. That argues for checking existing bookings before
+writing, and for a confirmation step showing exactly what is about to be
+created — which is only worth building once question 3 is answered.
 
 Until those are settled, #52–#55 are designing against an approach this probe
 has shown does not work.
@@ -178,12 +185,10 @@ has shown does not work.
   bookings count against it, were not measured.
 - **Whether the member-with-membership route works** has not been probed at all.
   It is a proposal, not a finding.
-- **Question 3 — duplicate bookings — remains open**, and matters more now than
-  when it was written. It was a tidiness question while `DELETE` was believed to
-  work; with no undo, a tool that double-books has no way to correct itself. It
-  needs answering before anything books in bulk.
-- **Why `DELETE` is refused** — a per-key permission scope, or an API-wide rule —
-  was not established. Only that it is refused.
+- **Question 3 — duplicate bookings — remains open.** It needs answering before
+  anything books in bulk, and it is worth more than it looks: a tool that
+  silently double-books can only be corrected by whatever undo turns out to
+  exist, which is itself question 4.
 
 ## How it was run
 
@@ -216,10 +221,11 @@ map, and it is guarded harder than creating one.
 
 ## ⚠️ Cleanup — delete these by hand
 
-Booking **`63499414`** is still on `Ztest Wayfinder`
-(`e35218ef-4e96-4928-a05f-1c14f56e574f`), on test event `20481679`. It was made
-by hand in the UI, not by this probe, and the API **cannot remove it** — that is
-question 4's answer. It must be cancelled in the Clubworx UI.
+Booking **`63499414`** is **gone**. It was made by hand in the UI on
+`Ztest Wayfinder` (`e35218ef-4e96-4928-a05f-1c14f56e574f`) while diagnosing the
+refusal, and a later check found all three probe contacts holding zero bookings.
+The probe did not remove it — its one `DELETE` attempt was the malformed call
+described in question 4 — so it was cleared in the Clubworx UI.
 
 The three `Ztest` contacts from [#49](49-plus-addressed-duplicates.md) remain
 permanent and are still owed a manual deletion there too.

--- a/cloudflare-clubworx/probes/50-membership-less-booking.md
+++ b/cloudflare-clubworx/probes/50-membership-less-booking.md
@@ -1,14 +1,25 @@
 # Booking a membership-less prospect — the answer to #50
 
 Probed against production Clubworx on **2026-08-18**, into a purpose-made test
-event (`20481679`, "test school booking") created for this probe. Nothing
-permanent was created: two booking attempts, both refused by the server.
+event (`20481679`, "test school booking") created for this probe. **The probe
+created nothing**: two booking attempts, both refused by the server, and one
+`DELETE`, also refused.
+
+One booking does exist — `63499414`, made by hand in the Clubworx UI while
+diagnosing why the API refused. It is still there, because the API cannot remove
+it. See [Cleanup](#-cleanup--delete-these-by-hand).
 
 **The prospect route does not work, and #46's central assumption fails.** The
 feature was designed on the premise that a freshly created prospect can be
 booked into an event. It cannot — not because of anything in the documented
 API, but because Clubworx applies a **per-contact safety rule to prospects**
 that the API neither documents nor reports honestly.
+
+**And nothing written through this key can be taken back.** `DELETE
+/api/v2/bookings/:id` — which ACCESS.md recorded as the one reversible write on
+this map — answers **401 "Authorization failed"** for a key that reads and
+creates without complaint. So a mistaken booking is as permanent as a mistaken
+contact.
 
 This is the branch #50 asked to be flagged rather than absorbed. It is flagged
 in [What this costs #46](#what-this-costs-46).
@@ -51,18 +62,44 @@ counting *how many events this prospect has been booked into*, applied per
 contact rather than per event. The UI offers a human an override. **The API
 offers none**, and reports the refusal as a spaces problem.
 
-That last part is the trap: the API's stated reason is wrong. Anyone debugging
-this from the API alone would go looking at event capacity, which is fine.
+That last part is the trap. The API's stated reason is not merely vague, it
+points somewhere else: anyone debugging this from the API alone would go looking
+at event capacity, which is not where the problem is, and which the API itself
+reports as healthy.
 
 ### 3. Does booking the same contact twice duplicate? — **Unasked**
 
 Nothing landed, so there was no first booking to duplicate. Asking it after a
 rejection would have measured two rejections and called it idempotency.
 
-### 4. Does `DELETE /bookings/:id` reverse a booking? — **Unasked**
+### 4. Does `DELETE /bookings/:id` reverse a booking? — **No. It is refused.**
 
-Same reason: the probe created nothing to cancel. This is now answerable at zero
-cost against booking `63499414` — see [Cleanup](#cleanup).
+The probe created nothing to cancel, but the UI attempt left booking
+`63499414` on `Ztest Wayfinder`, which answered the question at no cost:
+
+```
+DELETE /api/v2/bookings/63499414   →   HTTP 401   "Authorization failed"
+```
+
+The booking was still there afterwards — verified by re-counting, not assumed
+from the status.
+
+**This is not a bad key.** In the same run, with the same key and the same
+`account_key` query parameter, `GET /bookings?contact_key=` answered **200**,
+and in the runs above `POST /bookings` reached **business-level validation**
+(a 400 about spaces, not an auth error). So the key authenticates, and is
+permitted to read and to create. It is refused **only on delete**.
+
+Whether that is a per-key permission scope or a property of the API, this probe
+cannot say. The consequence is the same either way.
+
+**ACCESS.md said the opposite, and has been corrected.** It recorded bookings as
+"the exception — `DELETE /api/v2/bookings/:id` exists, so the booking half of
+probe #50 is reversible". That came from the endpoint being in the reference,
+not from anyone calling it. It is now measured.
+
+So **nothing this key writes can be removed through the API.** Bookings sit
+beside contacts: permanent, and clearable only by hand in the Clubworx UI.
 
 ## `spaces_available` cannot be trusted
 
@@ -114,8 +151,16 @@ tool creates, and it needs answers on:
 - **Plan choice** — which plan, with what duration and what it entitles.
 - **Clubworx reporting** — a cohort of members created per school changes member
   counts, retention and revenue reporting in ways prospects did not.
-- **Cleanup** — memberships may be as permanent as contacts. Nothing here has
-  established that they can be removed through the API.
+- **Cleanup** — memberships are very likely as permanent as everything else.
+  Every write this key has been shown to make is irreversible through the API,
+  and there is no reason to expect memberships to differ. Assume they cannot be
+  removed until measured.
+
+The no-undo finding raises the cost of getting this wrong. A tool that books a
+school group of 30 into the wrong session cannot retract it: someone clears 30
+bookings by hand in the Clubworx UI. That argues for the tool checking existing
+bookings before writing, and for a confirmation step that shows exactly what is
+about to be created — which is only possible if question 3 is answered first.
 
 Until those are settled, #52–#55 are designing against an approach this probe
 has shown does not work.
@@ -133,17 +178,28 @@ has shown does not work.
   bookings count against it, were not measured.
 - **Whether the member-with-membership route works** has not been probed at all.
   It is a proposal, not a finding.
-- **Questions 3 and 4** — duplicate bookings and `DELETE` — remain open.
+- **Question 3 — duplicate bookings — remains open**, and matters more now than
+  when it was written. It was a tidiness question while `DELETE` was believed to
+  work; with no undo, a tool that double-books has no way to correct itself. It
+  needs answering before anything books in bulk.
+- **Why `DELETE` is refused** — a per-key permission scope, or an API-wide rule —
+  was not established. Only that it is refused.
 
 ## How it was run
 
 ```bash
 node probes/run-50.mjs --dry-run                    # the plan, zero requests
 node probes/run-50.mjs                              # read-only: contacts, then bookable events
-node probes/run-50.mjs --event=20481679 --write     # the two attempts above
+node probes/run-50.mjs --event=20481679 --write     # the two booking attempts above
+node probes/run-50.mjs --cancel=63499414 --write    # question 4
 ```
 
-10 requests across both runs, paced at one per 800ms (~75/min) per #51. The
+`--cancel` searches for the booking on a probe contact **before** it will touch
+it, which is why it takes a booking id and still goes looking. An id on its own
+is not evidence of whose booking it is, and this is the one operation on the map
+that could take a real member off a class they turn up to.
+
+14 requests across all runs, paced at one per 800ms (~75/min) per #51. The
 probe creates **no contacts** — ACCESS.md §4's three-contact authorisation is
 spent, and #50 reuses what #49 left behind; the runner stops rather than
 creating a fourth.
@@ -158,14 +214,15 @@ gated on an allowlist of contact keys that passed the identity guard, and
 for — cancelling a real member's class is the worst outcome available on this
 map, and it is guarded harder than creating one.
 
-## Cleanup
+## ⚠️ Cleanup — delete these by hand
 
-Booking **`63499414`** exists on `Ztest Wayfinder`
+Booking **`63499414`** is still on `Ztest Wayfinder`
 (`e35218ef-4e96-4928-a05f-1c14f56e574f`), on test event `20481679`. It was made
-by hand in the UI, not by this probe.
-
-It is **reversible** — unlike a contact — and cancelling it would answer
-question 4 at no cost. Left in place pending that decision.
+by hand in the UI, not by this probe, and the API **cannot remove it** — that is
+question 4's answer. It must be cancelled in the Clubworx UI.
 
 The three `Ztest` contacts from [#49](49-plus-addressed-duplicates.md) remain
-permanent and are still owed a manual deletion in the Clubworx UI.
+permanent and are still owed a manual deletion there too.
+
+Test event `20481679` ("test school booking", 2026-08-19 12:00) was created for
+this probe and can go once the booking is off it.

--- a/cloudflare-clubworx/probes/50-membership-less-booking.md
+++ b/cloudflare-clubworx/probes/50-membership-less-booking.md
@@ -1,0 +1,171 @@
+# Booking a membership-less prospect — the answer to #50
+
+Probed against production Clubworx on **2026-08-18**, into a purpose-made test
+event (`20481679`, "test school booking") created for this probe. Nothing
+permanent was created: two booking attempts, both refused by the server.
+
+**The prospect route does not work, and #46's central assumption fails.** The
+feature was designed on the premise that a freshly created prospect can be
+booked into an event. It cannot — not because of anything in the documented
+API, but because Clubworx applies a **per-contact safety rule to prospects**
+that the API neither documents nor reports honestly.
+
+This is the branch #50 asked to be flagged rather than absorbed. It is flagged
+in [What this costs #46](#what-this-costs-46).
+
+## The four questions
+
+### 1. Does booking a membership-less prospect succeed? — **No**
+
+`POST /api/v2/bookings` with `{ contact_key, event_id }` was refused:
+
+```
+HTTP 400   "Sorry, this class has no free spaces available."
+```
+
+The event was configured **to allow prospects to book**, and in the same minute
+`GET /api/v2/events` described it as:
+
+| Field | Value |
+|---|---|
+| `spaces_available` | **25** |
+| `event_full` | **false** |
+| `free_class` | `false` |
+
+Run twice, same result. The contact held **zero** bookings at the time, verified
+by `GET /bookings?contact_key=` immediately before and after each attempt.
+
+### 2. What does it require? — **Not a free class. A per-contact prospect allowance.**
+
+The probe could not answer this from the API alone, and the `free_class`
+comparison #50 proposed was never run — see [What is still
+unproven](#what-is-still-unproven). What answered it was the **Clubworx UI**.
+
+Booking the same contact into the same event by hand produced a warning that
+*the prospect had already booked once to an event*, and asked for confirmation
+to book them again (Jiri, 2026-08-18). Confirming it worked — the booking
+exists, as `63499414`.
+
+So the block is **not** capacity, and **not** `free_class`. It is a safety rule
+counting *how many events this prospect has been booked into*, applied per
+contact rather than per event. The UI offers a human an override. **The API
+offers none**, and reports the refusal as a spaces problem.
+
+That last part is the trap: the API's stated reason is wrong. Anyone debugging
+this from the API alone would go looking at event capacity, which is fine.
+
+### 3. Does booking the same contact twice duplicate? — **Unasked**
+
+Nothing landed, so there was no first booking to duplicate. Asking it after a
+rejection would have measured two rejections and called it idempotency.
+
+### 4. Does `DELETE /bookings/:id` reverse a booking? — **Unasked**
+
+Same reason: the probe created nothing to cancel. This is now answerable at zero
+cost against booking `63499414` — see [Cleanup](#cleanup).
+
+## `spaces_available` cannot be trusted
+
+Independent of everything above, and true whatever shape the tool ends up
+taking:
+
+> A booking can be refused **for spaces** by an event that reports 25 spaces
+> free and `event_full: false`.
+
+#46's picker was going to use `spaces_available` to warn staff before booking —
+"a school group of 30 into an event with 12 spaces is a failure the page can
+predict" ([#51's findings](51-events-and-burst.md)). It can still predict *that*
+failure, but it **cannot** predict this one: the number it reads is not the
+number the booking endpoint enforces against. A session showing plenty of room
+can refuse every student in the group.
+
+There is no field on `GET /events` that exposes the prospect allowance — the
+response carries `event_id`, `event_name`, `event_start_at`, `event_end_at`,
+`location_id`, `location_name`, `free_class`, `instructor_name`, `event_full`,
+`spaces_available`, `event_description`, and nothing else. So the tool cannot
+pre-validate a booking. It finds out by trying.
+
+## What this costs #46
+
+#50: *"If a membership or plan is required, the shape of the tool changes
+materially — it would have to assign a membership plan as well as create a
+contact, which is a new decision about cost, plan choice, and what that does to
+Clubworx reporting. Flag that loudly rather than absorbing it."*
+
+**Flagging it.** The prospect approach is not viable as designed:
+
+- A prospect gets a small number of bookings before Clubworx blocks further
+  ones. A school group is one booking *per student*, so the limit is reached
+  immediately for any returning student.
+- The override exists **only in the UI**. An automated tool has no way to
+  confirm past it.
+- The refusal is indistinguishable, from the API, from a genuinely full class.
+
+The direction proposed instead (Jiri, 2026-08-18): create the student as a
+**member** holding a dedicated *school booking* membership, configure the
+session so that only holders of that membership may book, then book the student
+in. That replaces a safety rule the tool cannot pass with one it controls.
+
+It is a **new decision, not an implementation detail** — it changes what the
+tool creates, and it needs answers on:
+
+- **Cost** — what a school-booking membership costs, and whether creating one
+  per student has a billing consequence.
+- **Plan choice** — which plan, with what duration and what it entitles.
+- **Clubworx reporting** — a cohort of members created per school changes member
+  counts, retention and revenue reporting in ways prospects did not.
+- **Cleanup** — memberships may be as permanent as contacts. Nothing here has
+  established that they can be removed through the API.
+
+Until those are settled, #52–#55 are designing against an approach this probe
+has shown does not work.
+
+## What is still unproven
+
+- **The `free_class` comparison was never run.** The three `free_class` events
+  in the window each had exactly one space and belonged to a third-party
+  trainer, so booking one would have taken the last place in a real class. It
+  was skipped deliberately. Since the mechanism turned out to be per-contact,
+  the comparison would probably not have been informative anyway — but that is
+  a prediction, not a measurement.
+- **The exact prospect allowance is unknown.** The UI said "booked once"; how
+  many bookings a prospect gets before the block applies, and whether cancelled
+  bookings count against it, were not measured.
+- **Whether the member-with-membership route works** has not been probed at all.
+  It is a proposal, not a finding.
+- **Questions 3 and 4** — duplicate bookings and `DELETE` — remain open.
+
+## How it was run
+
+```bash
+node probes/run-50.mjs --dry-run                    # the plan, zero requests
+node probes/run-50.mjs                              # read-only: contacts, then bookable events
+node probes/run-50.mjs --event=20481679 --write     # the two attempts above
+```
+
+10 requests across both runs, paced at one per 800ms (~75/min) per #51. The
+probe creates **no contacts** — ACCESS.md §4's three-contact authorisation is
+spent, and #50 reuses what #49 left behind; the runner stops rather than
+creating a fourth.
+
+The event is never chosen automatically: `--write` without `--event=<id>`
+refuses to run. A booking lands on a real class that staff see, so choosing one
+by sort order means choosing somebody's actual session.
+
+`lib/booking.mjs` is the only path here that can book or cancel. `book` is
+gated on an allowlist of contact keys that passed the identity guard, and
+`cancel` refuses any booking id it did not create or have explicitly vouched
+for — cancelling a real member's class is the worst outcome available on this
+map, and it is guarded harder than creating one.
+
+## Cleanup
+
+Booking **`63499414`** exists on `Ztest Wayfinder`
+(`e35218ef-4e96-4928-a05f-1c14f56e574f`), on test event `20481679`. It was made
+by hand in the UI, not by this probe.
+
+It is **reversible** — unlike a contact — and cancelling it would answer
+question 4 at no cost. Left in place pending that decision.
+
+The three `Ztest` contacts from [#49](49-plus-addressed-duplicates.md) remain
+permanent and are still owed a manual deletion in the Clubworx UI.

--- a/cloudflare-clubworx/probes/60-member-school-pass-booking.md
+++ b/cloudflare-clubworx/probes/60-member-school-pass-booking.md
@@ -1,0 +1,201 @@
+# The member + School Pass route — the answer to #60
+
+Probed against production Clubworx on **2026-08-18**, into a purpose-made
+School Session (`20481679`, "test school booking"). Successor to
+[#50](50-membership-less-booking.md), which showed the prospect route does not
+work.
+
+**The route works.** A member holding an active School Pass books into a School
+Session, the server refuses a duplicate by itself, and the booking can be
+undone. Every assumption #46 was about to design against is now measured.
+
+| | Question | Answer |
+|---|---|---|
+| 1 | Does `POST /memberships` work, and is the pass active at once? | **Yes** |
+| 2 | Can the plan be resolved by name? | **Yes — but not on the default page** |
+| 3 | Does a member with an active School Pass book? | **Yes**, HTTP 200 |
+| 4 | Does `spaces_available` predict bookability? | **Consistent, but not proven at the cap** |
+| 5 | What does the 1-day-ahead rule return? | `400 "this class is now closed for bookings"` |
+| 6 | Does booking twice duplicate? | **No — the server refuses it** |
+| 7 | Does `DELETE /bookings/:id` reverse a booking? | **Yes**, verified by re-count |
+
+Nothing was left behind: the booking was created and then cancelled. One
+permanent record was added, the School Pass itself — see [Cleanup](#cleanup).
+
+## 1. Assigning the pass
+
+`POST /api/v2/memberships`, **form-encoded**, with `account_key`, `contact_key`,
+`membership_plan_id` and `start_date`. Answered **HTTP 200**, and the pass was
+held and active on the next read:
+
+```
+id 2627746 · membership_plan_id 64189 · name "School Pass"
+start_date 2026-08-18 · expiration_date 2026-11-09
+class_access "Unlimited classes" · upfront_charge null · recurring_charge null
+classes_booked 0 · classes_attended 0 · classes_remaining null
+```
+
+`expiration_date` is **exactly the 12 weeks** the plan is configured for, so the
+tool never computes an expiry — it sends `start_date` and reads the end date
+back. That matters for the term-coverage requirement: the answer comes from
+Clubworx rather than from arithmetic that could drift from the plan.
+
+### There is no `status` field
+
+A membership record carries `start_date` and `expiration_date` and **nothing
+that says "active"**. Anything checking `status` gets `undefined`, and a live
+pass reads as inactive. Activity is derived from the two dates, inclusive at
+both ends — `summariseMemberships` does this, and distinguishes *holding the
+plan* from *holding an active one*, because an expired pass is still a returned
+row.
+
+## 2. Resolving the plan by name — and the trap under it
+
+The tool turns the plan **name** into a `membership_plan_id`, because a
+hard-coded id is a number nobody can check against the Clubworx UI.
+
+`GET /api/v2/membership_plans` returned **exactly 50** plans. UJ has **57**, and
+`School Pass` was among the seven that never arrived.
+
+This is [#51](51-events-and-burst.md)'s silent truncation — a full page is
+indistinguishable from a complete list, with no total, no next-page link and no
+header — landing in the one place where the answer decides whether anything can
+be booked at all. **A lookup on the default page reports "no such plan" and the
+whole run stops**, for a plan that plainly exists.
+
+Two rules follow, both implemented in `findPlanByName`:
+
+- Always request a `page_size` past the default, and **treat a full page as
+  truncated** rather than as an answer.
+- **Refuse an ambiguous name.** Two plans sharing a name is an error, not a
+  first-wins: assigning the wrong plan is permanent.
+
+Resolved: `id 64189`, `membership_duration "12 weeks"`, `upfront_payment_amount
+"0.0"`, no recurring charge — so a School Pass costs nothing and starts no
+billing schedule.
+
+## 3, 6, 7. Booking, double-booking, and undo
+
+Against the event moved to **2026-08-21 12:00 (+08:00)**, 68.4 hours ahead:
+
+| Step | Result | Bookings held |
+|---|---|---|
+| Before | — | 0 |
+| `POST /bookings` | **200 created**, booking `63510241` | 1 |
+| `POST /bookings` again | **400** `"Woops! You've already booked into this class!"` | 1 |
+| `DELETE /bookings/63510241` | **200** | **0** |
+
+### The server refuses duplicates itself
+
+This was the load-bearing unknown. Re-running the tool against an event
+**cannot** double-book a student: the second attempt is rejected outright, and
+the count confirms it — 1 before, 1 after. Judged on the re-count rather than on
+the status, because an accepted-but-silent duplicate would look identical to an
+idempotent server from the response alone.
+
+So a failed run is safely retryable on the booking half.
+
+### `DELETE` works, and #50's finding is now properly retired
+
+The booking left the contact's list — verified by re-reading, not assumed from
+the 200. [#50](50-membership-less-booking.md) reported that bookings could not
+be deleted at all, on the strength of a `401 "Authorization failed"`. That was a
+malformed request: **`DELETE /api/v2/bookings/:id` requires `contact_key` as
+well as `account_key`, form-encoded in the body.** Sent correctly, it reverses
+cleanly.
+
+`lib/booking.mjs` takes the contact from the booking record rather than from the
+caller, so it cannot be omitted or mismatched.
+
+## 5. The lead-time rule, and the error vocabulary
+
+The same event, same contact, same pass, at two distances:
+
+| Event starts | Result |
+|---|---|
+| 20.6h ahead | **400** `"Sorry! This class is now closed for bookings."` |
+| 68.4h ahead | **200 created** |
+
+The one-day minimum is real and enforced server-side. The tool should refuse
+anything inside it *before* writing, because the message a staff member would
+otherwise see says nothing about lead time.
+
+**Three distinct refusals now have known text**, and #53's failure model can
+tell them apart:
+
+| Message | Means |
+|---|---|
+| `"Sorry, this class has no free spaces available."` | the contact is a **prospect** hitting its allowance (#50) — *not* capacity |
+| `"Sorry! This class is now closed for bookings."` | inside the **lead time** |
+| `"Woops! You've already booked into this class!"` | **already booked** — safe, and the idempotency guarantee |
+
+None of them is machine-readable beyond the string. They arrive as
+`{"error": "..."}` with HTTP 400 in every case, so the status alone cannot
+distinguish a retryable problem from a permanent one.
+
+## 4. What `spaces_available` still does not prove
+
+It reported **25 free**, `event_full: false`, and the booking succeeded — so it
+was *consistent* here, where in #50 it was actively misleading.
+
+But only **one** booking was made against 25 spaces. Whether the number
+decrements, and whether it correctly refuses at the cap now that the event
+restricts to School Pass holders, is **unmeasured**. #46's picker plans to warn
+staff — "30 students, 12 spaces" — from exactly this field, so it is worth one
+more probe before that warning is trusted.
+
+## What this settles for #46
+
+- The **member + School Pass route is viable**, and is no longer a proposal.
+- **Booking is idempotent**, so a partial run can be re-run without
+  double-booking anyone.
+- **Bookings can be undone**; contacts and memberships cannot. That is the real
+  undo asymmetry for #53, and it is narrower than feared — but it is still an
+  asymmetry, and the UI must not imply that undo restores the prior state.
+- A School Pass **costs nothing** and starts no billing schedule, which removes
+  the cost question #50 raised about the new route.
+
+## Still open
+
+- Whether `spaces_available` blocks at the cap (question 4, above).
+- Whether a membership can be **removed**. No delete appears in the reference,
+  and none was attempted. An expired pass simply lapses.
+- Whether assigning a **second** School Pass to someone who already holds one
+  duplicates it. The probe reuses an active pass rather than testing this, on
+  purpose — memberships have no delete.
+- What a term's worth of school members does to Clubworx **reporting**. Open on
+  #46, unchanged by this probe.
+
+## How it was run
+
+```bash
+node probes/run-60.mjs --dry-run                 # the plan and every request, zero network
+node probes/run-60.mjs                           # read-only: contacts, plan, memberships, event
+node probes/run-60.mjs --event=20481679 --write  # the run above
+```
+
+13 reads and 3 writes, paced at one per 800ms (~75/min) per #51.
+
+The probe **creates no contacts** — ACCESS.md §4's authorisation is spent — and
+searches before both writes, so a re-run costs nothing permanent. It reuses an
+*active* pass rather than any pass: an expired one would leave the booking to
+fail for a reason already visible in the read.
+
+The contacts were converted from prospects to **members** by hand before this
+run. That broke `run-50.mjs`, which searched `/prospects` only; #49 had already
+established the three endpoints are disjoint views by status. `run-60.mjs`
+searches all three. **The real tool has the same exposure**: a student who takes
+a membership later moves out of `/prospects`, and a prospect-only lookup would
+silently stop finding them.
+
+## Cleanup
+
+The booking was cancelled by the probe — nothing is outstanding on the event.
+
+**Permanent:** School Pass `2627746` on `Ztest Wayfinder`
+(`e35218ef-4e96-4928-a05f-1c14f56e574f`), expiring 2026-11-09. Memberships have
+no delete endpoint; it will lapse on its own.
+
+The three `Ztest` contacts from [#49](49-plus-addressed-duplicates.md) remain
+permanent and are still owed a manual deletion in the Clubworx UI, along with
+the test event `20481679` once it is finished with.

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -11,7 +11,8 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-51.mjs` | The probe that produced it — read-only |
 | `49-plus-addressed-duplicates.md` | [#49](https://github.com/urbanjungleirc/staff-site/issues/49) — plus-addressed `noreply@`, duplicate emails, and whether a tag isolates a school |
 | `run-49.mjs` | The probe that produced it — **writes** |
-| `run-50.mjs` | [#50](https://github.com/urbanjungleirc/staff-site/issues/50) — can a membership-less prospect be booked into an event? **Writes, and deletes** |
+| `50-membership-less-booking.md` | [#50](https://github.com/urbanjungleirc/staff-site/issues/50) — **no**, a prospect cannot be booked: Clubworx applies a per-contact allowance the API cannot pass, and `spaces_available` does not predict it |
+| `run-50.mjs` | The probe that produced it — **writes, and deletes** |
 
 Access, authorisation and the key's whereabouts: `../ACCESS.md`.
 

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -51,6 +51,21 @@ spaces, so choosing by sort order means choosing somebody's actual session; the
 read-only run lists the candidates and a human picks one. Everything it books,
 it cancels — and it prints anything it could not.
 
+**Book it into a purpose-made test event.** Whether a membership-less prospect
+can book is a property of *the event*, not of the API: UJ's school sessions are
+configured with a limited number of prospect places, which is what stops
+somebody booking into a school group by accident on the day. An open-climb
+session is configured differently, so a booking there answers a different
+question to the one #46 needs. Create an event configured like a school session
+and pass its id.
+
+`GET /events` **does not expose that allowance** — its fields are `event_id`,
+`event_name`, `event_start_at`, `event_end_at`, `location_id`, `location_name`,
+`free_class`, `instructor_name`, `event_full`, `spaces_available` and
+`event_description` (verified 2026-08-18). So #46's picker cannot pre-validate
+it: a session whose prospect places are used up looks exactly like one with
+room, and the tool only finds out when a write is rejected.
+
 Runs write a JSON summary to `probes/out/`, which is gitignored.
 
 ## The rules these scripts follow

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -11,6 +11,7 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-51.mjs` | The probe that produced it — read-only |
 | `49-plus-addressed-duplicates.md` | [#49](https://github.com/urbanjungleirc/staff-site/issues/49) — plus-addressed `noreply@`, duplicate emails, and whether a tag isolates a school |
 | `run-49.mjs` | The probe that produced it — **writes** |
+| `run-50.mjs` | [#50](https://github.com/urbanjungleirc/staff-site/issues/50) — can a membership-less prospect be booked into an event? **Writes, and deletes** |
 
 Access, authorisation and the key's whereabouts: `../ACCESS.md`.
 
@@ -32,12 +33,23 @@ node probes/run-49.mjs --dry-run     # the plan and every request, zero network
 node probes/run-49.mjs               # read-only: search, then the isolation reads
 node probes/run-49.mjs --write       # ⚠️ creates up to 3 PERMANENT contacts
 
+node probes/run-50.mjs --dry-run     # the plan and every request, zero network
+node probes/run-50.mjs               # read-only: finds #49's contacts, lists bookable events
+node probes/run-50.mjs --event=<id> --write         # ⚠️ books a real class, then cancels it
+node probes/run-50.mjs --event=<id> --free-event=<id> --write
+
 npm test                             # the pure logic, no network
 ```
 
-`--dev-vars=<path>` points either probe at a key outside the package — a git
+`--dev-vars=<path>` points any probe at a key outside the package — a git
 worktree, for instance, where `.dev.vars` is gitignored and so does not follow
 the checkout.
+
+**`run-50.mjs` never picks the event itself.** `--write` without `--event=<id>`
+stops. A booking lands on a real class that staff see and consumes one of its
+spaces, so choosing by sort order means choosing somebody's actual session; the
+read-only run lists the candidates and a human picks one. Everything it books,
+it cancels — and it prints anything it could not.
 
 Runs write a JSON summary to `probes/out/`, which is gitignored.
 
@@ -45,11 +57,17 @@ Runs write a JSON summary to `probes/out/`, which is gitignored.
 
 Every one of them is a consequence of *production, public repo, no sandbox*.
 
-- **Read-only unless the ticket says otherwise.** There are two ways out to
+- **Read-only unless the ticket says otherwise.** There are three ways out to
   Clubworx and they are separate files on purpose. `lib/http.mjs` issues GET and
   nothing else, so a probe that imports only it *cannot* write — that is a
-  property of the script, not a claim about it. Creating anything means reaching
-  for `lib/write.mjs` deliberately.
+  property of the script, not a claim about it. Creating a contact means reaching
+  for `lib/write.mjs` deliberately, and booking or cancelling means reaching for
+  `lib/booking.mjs`.
+- **`DELETE` is guarded harder than `POST`, because it is the worse mistake.**
+  `lib/booking.mjs` refuses any booking id it did not create itself or have
+  explicitly vouched for against a probe contact — there is no way to hand it an
+  arbitrary id. A mistaken booking is untidy and reversible; cancelling a real
+  member's class takes somebody off a session they turn up to.
 - **Two controls in front of every write**, because Clubworx **cannot delete
   contacts through the API** and there is no sandbox. `createPoster` is inert
   unless `live` is explicitly true, so a forgotten flag costs nothing; and every
@@ -85,10 +103,13 @@ lib/report.mjs    response → publishable summary    (unit tested)
 lib/key.mjs       where the live key comes from     (unit tested)
 lib/http.mjs      the read path to Clubworx: GET    (unit tested)
 lib/write.mjs     the write path: POST, guarded     (unit tested)
+lib/booking.mjs   the booking path: POST + DELETE,  (unit tested)
+                  guarded harder — see below
 lib/identity.mjs  who a write may be, and what to   (unit tested)
                   create given what already exists
 run-51.mjs        the #51 probe itself — read-only
 run-49.mjs        the #49 probe itself — writes
+run-50.mjs        the #50 probe itself — writes and deletes
 ```
 
 The libraries are tested and the runner is not. That split is deliberate: the

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -11,8 +11,8 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-51.mjs` | The probe that produced it — read-only |
 | `49-plus-addressed-duplicates.md` | [#49](https://github.com/urbanjungleirc/staff-site/issues/49) — plus-addressed `noreply@`, duplicate emails, and whether a tag isolates a school |
 | `run-49.mjs` | The probe that produced it — **writes** |
-| `50-membership-less-booking.md` | [#50](https://github.com/urbanjungleirc/staff-site/issues/50) — **no**, a prospect cannot be booked: Clubworx applies a per-contact allowance the API cannot pass, and `spaces_available` does not predict it |
-| `run-50.mjs` | The probe that produced it — **writes, and deletes** |
+| `50-membership-less-booking.md` | [#50](https://github.com/urbanjungleirc/staff-site/issues/50) — **no**, a prospect cannot be booked: Clubworx applies a per-contact allowance the API cannot pass, `spaces_available` does not predict it, and **`DELETE` is refused, so no write here has an undo** |
+| `run-50.mjs` | The probe that produced it — **writes** |
 
 Access, authorisation and the key's whereabouts: `../ACCESS.md`.
 
@@ -36,8 +36,9 @@ node probes/run-49.mjs --write       # ⚠️ creates up to 3 PERMANENT contacts
 
 node probes/run-50.mjs --dry-run     # the plan and every request, zero network
 node probes/run-50.mjs               # read-only: finds #49's contacts, lists bookable events
-node probes/run-50.mjs --event=<id> --write         # ⚠️ books a real class, then cancels it
+node probes/run-50.mjs --event=<id> --write         # ⚠️ books a real class — and CANNOT undo it
 node probes/run-50.mjs --event=<id> --free-event=<id> --write
+node probes/run-50.mjs --cancel=<booking_id> --write # tries to remove a probe contact's booking
 
 npm test                             # the pure logic, no network
 ```
@@ -82,8 +83,13 @@ Every one of them is a consequence of *production, public repo, no sandbox*.
 - **`DELETE` is guarded harder than `POST`, because it is the worse mistake.**
   `lib/booking.mjs` refuses any booking id it did not create itself or have
   explicitly vouched for against a probe contact — there is no way to hand it an
-  arbitrary id. A mistaken booking is untidy and reversible; cancelling a real
-  member's class takes somebody off a session they turn up to.
+  arbitrary id. Cancelling a real member's class takes somebody off a session
+  they turn up to.
+- **Nothing written here can be undone.** #50 measured `DELETE /bookings/:id` at
+  **401 "Authorization failed"** on a key that reads at 200 and creates without
+  complaint. Bookings were previously believed to be the one reversible write on
+  this map; they are not. Plan every write as permanent, and assume the same of
+  any endpoint nobody has actually called.
 - **Two controls in front of every write**, because Clubworx **cannot delete
   contacts through the API** and there is no sandbox. `createPoster` is inert
   unless `live` is explicitly true, so a forgotten flag costs nothing; and every

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -13,6 +13,8 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-49.mjs` | The probe that produced it — **writes** |
 | `50-membership-less-booking.md` | [#50](https://github.com/urbanjungleirc/staff-site/issues/50) — **no**, a prospect cannot be booked: Clubworx applies a per-contact allowance the API cannot pass, and `spaces_available` does not predict it |
 | `run-50.mjs` | The probe that produced it — **writes** |
+| `60-member-school-pass-booking.md` | [#60](https://github.com/urbanjungleirc/staff-site/issues/60) — the member + **School Pass** route **works**: it books, the server refuses duplicates itself, and `DELETE` reverses cleanly |
+| `run-60.mjs` | The probe that produced it — **writes, and deletes** |
 
 Access, authorisation and the key's whereabouts: `../ACCESS.md`.
 
@@ -36,9 +38,13 @@ node probes/run-49.mjs --write       # ⚠️ creates up to 3 PERMANENT contacts
 
 node probes/run-50.mjs --dry-run     # the plan and every request, zero network
 node probes/run-50.mjs               # read-only: finds #49's contacts, lists bookable events
-node probes/run-50.mjs --event=<id> --write         # ⚠️ books a real class — and CANNOT undo it
+node probes/run-50.mjs --event=<id> --write         # ⚠️ books a real class
 node probes/run-50.mjs --event=<id> --free-event=<id> --write
 node probes/run-50.mjs --cancel=<booking_id> --write # tries to remove a probe contact's booking
+
+node probes/run-60.mjs --dry-run     # the plan and every request, zero network
+node probes/run-60.mjs               # read-only: contacts, plan, memberships, event
+node probes/run-60.mjs --event=<id> --write  # ⚠️ assigns a PERMANENT School Pass, then books
 
 npm test                             # the pure logic, no network
 ```
@@ -47,26 +53,25 @@ npm test                             # the pure logic, no network
 worktree, for instance, where `.dev.vars` is gitignored and so does not follow
 the checkout.
 
-**`run-50.mjs` never picks the event itself.** `--write` without `--event=<id>`
-stops. A booking lands on a real class that staff see and consumes one of its
-spaces, so choosing by sort order means choosing somebody's actual session; the
-read-only run lists the candidates and a human picks one. Everything it books,
-it cancels — and it prints anything it could not.
+**Neither booking probe picks the event itself.** `--write` without
+`--event=<id>` stops. A booking lands on a real class that staff see and consumes
+one of its spaces, so choosing by sort order means choosing somebody's actual
+session; a read-only run lists the candidates and a human picks one. Everything
+they book, they cancel — and they print anything they could not.
 
-**Book it into a purpose-made test event.** Whether a membership-less prospect
-can book is a property of *the event*, not of the API: UJ's school sessions are
-configured with a limited number of prospect places, which is what stops
-somebody booking into a school group by accident on the day. An open-climb
-session is configured differently, so a booking there answers a different
-question to the one #46 needs. Create an event configured like a school session
-and pass its id.
+**Book into a purpose-made test event.** Whether a contact can book is a property
+of *the event's configuration*, not of the API — which of these applies depends
+entirely on how the session is set up, and a generic open-climb session answers a
+different question to the one #46 needs.
 
-`GET /events` **does not expose that allowance** — its fields are `event_id`,
+**`GET /events` cannot tell you which is which.** Its fields are `event_id`,
 `event_name`, `event_start_at`, `event_end_at`, `location_id`, `location_name`,
 `free_class`, `instructor_name`, `event_full`, `spaces_available` and
-`event_description` (verified 2026-08-18). So #46's picker cannot pre-validate
-it: a session whose prospect places are used up looks exactly like one with
-room, and the tool only finds out when a write is rejected.
+`event_description` (verified 2026-08-18) — there is **no event-type field**, and
+nothing exposing what a session requires of a bookee. So #46's picker cannot
+pre-validate a booking; it finds out by trying, and must read the message that
+comes back. The three known refusals are tabulated in
+`60-member-school-pass-booking.md`.
 
 Runs write a JSON summary to `probes/out/`, which is gitignored.
 
@@ -74,25 +79,29 @@ Runs write a JSON summary to `probes/out/`, which is gitignored.
 
 Every one of them is a consequence of *production, public repo, no sandbox*.
 
-- **Read-only unless the ticket says otherwise.** There are three ways out to
+- **Read-only unless the ticket says otherwise.** There are four ways out to
   Clubworx and they are separate files on purpose. `lib/http.mjs` issues GET and
   nothing else, so a probe that imports only it *cannot* write — that is a
   property of the script, not a claim about it. Creating a contact means reaching
-  for `lib/write.mjs` deliberately, and booking or cancelling means reaching for
-  `lib/booking.mjs`.
+  for `lib/write.mjs` deliberately, booking or cancelling means `lib/booking.mjs`,
+  and assigning a membership means `lib/membership.mjs`.
 - **`DELETE` is guarded harder than `POST`, because it is the worse mistake.**
   `lib/booking.mjs` refuses any booking id it did not create itself or have
   explicitly vouched for against a probe contact — there is no way to hand it an
   arbitrary id. Cancelling a real member's class takes somebody off a session
   they turn up to.
-- **Assume no write can be undone, including bookings.** Contacts certainly
-  cannot be deleted. Bookings are *documented* as reversible, but #50 never
-  managed to demonstrate it — and learned that `DELETE /bookings/:id` needs
-  `contact_key` in a form-encoded body, without which it answers
-  `401 "Authorization failed"`. That is indistinguishable from a permissions
-  failure, and was written up as one before the reference was re-read. **Read
-  the endpoint's parameters before concluding anything from a 401**, and treat
-  any endpoint nobody has actually completed as unproven.
+- **Only bookings can be undone.** Contacts cannot be deleted, and memberships
+  have no delete either — a School Pass lapses at its `expiration_date` and is
+  otherwise permanent. `DELETE /bookings/:id` does reverse a booking (#60,
+  verified by re-reading rather than by the status), but it needs `contact_key`
+  in a form-encoded body; without it the answer is `401 "Authorization failed"`,
+  which #50 read as a permissions wall and wrote up as one. **Read an endpoint's
+  parameters before concluding anything from a 401**, and treat any endpoint
+  nobody has actually completed as unproven.
+- **A full page is not an answer.** `GET /membership_plans` returned exactly 50
+  of UJ's 57 plans and hid the one being looked for; `/events` does the same
+  (#51). Always pass a `page_size`, and treat a page that comes back full as
+  truncated rather than complete.
 - **Two controls in front of every write**, because Clubworx **cannot delete
   contacts through the API** and there is no sandbox. `createPoster` is inert
   unless `live` is explicitly true, so a forgotten flag costs nothing; and every
@@ -130,11 +139,14 @@ lib/http.mjs      the read path to Clubworx: GET    (unit tested)
 lib/write.mjs     the write path: POST, guarded     (unit tested)
 lib/booking.mjs   the booking path: POST + DELETE,  (unit tested)
                   guarded harder — see below
+lib/membership.mjs  assigning a membership: POST,    (unit tested)
+                  permanent, so guarded like a write
 lib/identity.mjs  who a write may be, and what to   (unit tested)
                   create given what already exists
 run-51.mjs        the #51 probe itself — read-only
 run-49.mjs        the #49 probe itself — writes
 run-50.mjs        the #50 probe itself — writes and deletes
+run-60.mjs        the #60 probe itself — writes and deletes
 ```
 
 The libraries are tested and the runner is not. That split is deliberate: the

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -11,7 +11,7 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-51.mjs` | The probe that produced it — read-only |
 | `49-plus-addressed-duplicates.md` | [#49](https://github.com/urbanjungleirc/staff-site/issues/49) — plus-addressed `noreply@`, duplicate emails, and whether a tag isolates a school |
 | `run-49.mjs` | The probe that produced it — **writes** |
-| `50-membership-less-booking.md` | [#50](https://github.com/urbanjungleirc/staff-site/issues/50) — **no**, a prospect cannot be booked: Clubworx applies a per-contact allowance the API cannot pass, `spaces_available` does not predict it, and **`DELETE` is refused, so no write here has an undo** |
+| `50-membership-less-booking.md` | [#50](https://github.com/urbanjungleirc/staff-site/issues/50) — **no**, a prospect cannot be booked: Clubworx applies a per-contact allowance the API cannot pass, and `spaces_available` does not predict it |
 | `run-50.mjs` | The probe that produced it — **writes** |
 
 Access, authorisation and the key's whereabouts: `../ACCESS.md`.
@@ -85,11 +85,14 @@ Every one of them is a consequence of *production, public repo, no sandbox*.
   explicitly vouched for against a probe contact — there is no way to hand it an
   arbitrary id. Cancelling a real member's class takes somebody off a session
   they turn up to.
-- **Nothing written here can be undone.** #50 measured `DELETE /bookings/:id` at
-  **401 "Authorization failed"** on a key that reads at 200 and creates without
-  complaint. Bookings were previously believed to be the one reversible write on
-  this map; they are not. Plan every write as permanent, and assume the same of
-  any endpoint nobody has actually called.
+- **Assume no write can be undone, including bookings.** Contacts certainly
+  cannot be deleted. Bookings are *documented* as reversible, but #50 never
+  managed to demonstrate it — and learned that `DELETE /bookings/:id` needs
+  `contact_key` in a form-encoded body, without which it answers
+  `401 "Authorization failed"`. That is indistinguishable from a permissions
+  failure, and was written up as one before the reference was re-read. **Read
+  the endpoint's parameters before concluding anything from a 401**, and treat
+  any endpoint nobody has actually completed as unproven.
 - **Two controls in front of every write**, because Clubworx **cannot delete
   contacts through the API** and there is no sandbox. `createPoster` is inert
   unless `live` is explicitly true, so a forgotten flag costs nothing; and every

--- a/cloudflare-clubworx/probes/lib/booking.mjs
+++ b/cloudflare-clubworx/probes/lib/booking.mjs
@@ -1,0 +1,273 @@
+/**
+ * The booking write path: `POST /bookings` and `DELETE /bookings/:id`.
+ *
+ * A third file beside `lib/http.mjs` (GET only) and `lib/write.mjs` (creates
+ * contacts), for the same structural reason as the split between those two: a
+ * probe that does not import this module cannot book or cancel anything, and
+ * that is a property of the script rather than a claim about it.
+ *
+ * Bookings differ from contacts in both directions, and the guards here follow
+ * the difference rather than copying `lib/write.mjs`:
+ *
+ *   - A booking **is** reversible (`DELETE /bookings/:id`, ACCESS.md section 4),
+ *     so the cost of a mistaken create is lower than it is for a contact.
+ *   - But `DELETE` is a verb no probe has had before, and it points at a
+ *     production database holding real customers' bookings. **Cancelling
+ *     somebody's real class is a worse outcome than any accidental create on
+ *     this map**, and unlike a contact it is not merely untidy — a member turns
+ *     up to a session they are no longer booked into.
+ *
+ * So the asymmetry is deliberate: `book` is guarded by an allowlist of probe
+ * contact keys, and `cancel` refuses any booking id this module did not either
+ * create itself or have explicitly vouched for. There is no way to hand it an
+ * arbitrary id.
+ */
+
+import { buildUrl, redact } from './request.mjs';
+import { rateLimitHeaders } from './report.mjs';
+
+/** Fields that exist for the write-up, not for Clubworx. */
+const BOOKKEEPING = new Set(['label', 'why']);
+
+const payloadOf = booking =>
+  Object.fromEntries(Object.entries(booking).filter(([name]) => !BOOKKEEPING.has(name)));
+
+/**
+ * Refuse to book anything that is not one of the known probe contacts.
+ *
+ * `assertProbeIdentity` cannot do this job. It validates a contact's *shape* —
+ * name, dob, email — and a booking payload carries none of those, only an
+ * opaque `contact_key`. There is nothing in a UUID to recognise, so the control
+ * has to be an allowlist supplied by the caller, built from rows that already
+ * passed `isProbeRow`.
+ *
+ * @param {{contact_key?: string, event_id?: unknown}} booking
+ * @param {Set<string>|Array<string>} allowedContactKeys
+ */
+export function assertProbeBooking(booking, allowedContactKeys) {
+  const allowed = allowedContactKeys instanceof Set ? allowedContactKeys : new Set(allowedContactKeys ?? []);
+  const { contact_key, event_id } = booking ?? {};
+
+  if (allowed.size === 0) {
+    throw new Error(
+      'refusing to book: no probe contacts were recognised, so there is no contact this probe may book',
+    );
+  }
+  if (typeof contact_key !== 'string' || !contact_key) {
+    throw new Error(`refusing to book without a contact_key (got ${JSON.stringify(contact_key)})`);
+  }
+  if (!allowed.has(contact_key)) {
+    // The whole point of the control: a key that did not come out of the
+    // identity-filtered search belongs to somebody real.
+    throw new Error(
+      `refusing to book a contact that is not a recognised probe contact (${contact_key}) — ` +
+        'this key did not come from a row that passed the identity guard',
+    );
+  }
+  if (event_id === undefined || event_id === null || event_id === '') {
+    throw new Error(`refusing to book without an event_id (got ${JSON.stringify(event_id)})`);
+  }
+
+  return booking;
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.accountKey
+ * @param {Set<string>|Array<string>} [opts.allowedContactKeys] Probe contacts this may book.
+ * @param {boolean} [opts.live] Must be explicitly true before anything is booked or cancelled.
+ * @param {typeof fetch} [opts.fetchImpl]
+ */
+export function createBooker({ accountKey, allowedContactKeys = [], live = false, fetchImpl = fetch }) {
+  const allowed = allowedContactKeys instanceof Set ? allowedContactKeys : new Set(allowedContactKeys);
+
+  /**
+   * Booking ids this module is willing to DELETE.
+   *
+   * Populated by `book` on success, and by `allowCancel` for bookings an
+   * earlier run left behind. Nothing else can add to it, so `cancel` cannot be
+   * pointed at a real customer's booking even by a runner bug.
+   */
+  const cancellable = new Set();
+
+  const send = async ({ method, path, payload }) => {
+    const url = buildUrl({ path, accountKey });
+    const safeUrl = redact(url, accountKey);
+    const started = performance.now();
+
+    try {
+      const res = await fetchImpl(url, {
+        method,
+        headers: {
+          Accept: 'application/json',
+          ...(payload ? { 'Content-Type': 'application/json' } : {}),
+        },
+        ...(payload ? { body: JSON.stringify(payload) } : {}),
+      });
+      const ms = Math.round(performance.now() - started);
+      const bodyText = await res.text();
+
+      // A rejection for "no membership" is the answer to question 2, and it may
+      // well arrive as HTML from a WAF or a validation layer. Parsing must not
+      // decide whether the sample survives.
+      let body = null;
+      try {
+        body = JSON.parse(bodyText);
+      } catch {
+        body = null;
+      }
+
+      return {
+        url: safeUrl,
+        method,
+        status: res.status,
+        ms,
+        headers: rateLimitHeaders(res.headers),
+        contentType: res.headers.get?.('content-type') ?? null,
+        body,
+        bodyText: body === null ? redact(bodyText, accountKey).slice(0, 500) : null,
+        error: null,
+        refused: null,
+        dryRun: false,
+        ...(payload ? { sent: payload } : {}),
+      };
+    } catch (err) {
+      // The url is interpolated into node's own connection errors. A failed
+      // booking may still have landed, which is why the caller treats this as
+      // "may exist" rather than "did not happen".
+      return {
+        url: safeUrl,
+        method,
+        status: null,
+        ms: Math.round(performance.now() - started),
+        headers: {},
+        contentType: null,
+        body: null,
+        bodyText: null,
+        error: redact(err.code ?? err.message ?? 'unknown error', accountKey),
+        refused: null,
+        dryRun: false,
+        ...(payload ? { sent: payload } : {}),
+      };
+    }
+  };
+
+  const inert = ({ method, url, extra = {} }) => ({
+    url,
+    method,
+    status: null,
+    ms: 0,
+    headers: {},
+    contentType: null,
+    body: null,
+    bodyText: null,
+    error: null,
+    refused: null,
+    dryRun: true,
+    ...extra,
+  });
+
+  /**
+   * Book a probe contact into an event.
+   *
+   * @param {{contact_key: string, event_id: string|number, label?: string, why?: string}} booking
+   */
+  const book = async booking => {
+    const safeUrl = redact(buildUrl({ path: 'bookings', accountKey }), accountKey);
+
+    // Before the live check, so a dry run exercises the guard rather than only
+    // the plumbing — the same order `lib/write.mjs` uses.
+    let payload;
+    try {
+      assertProbeBooking(booking, allowed);
+      payload = payloadOf(booking);
+    } catch (err) {
+      return { ...inert({ method: 'POST', url: safeUrl }), refused: err.message, dryRun: !live };
+    }
+
+    if (!live) return inert({ method: 'POST', url: safeUrl, extra: { wouldSend: payload } });
+
+    book.writes += 1;
+    const res = await send({ method: 'POST', path: 'bookings', payload });
+
+    const id = bookingIdOf(res.body);
+    // Only a booking this run created may later be cancelled.
+    if (id) cancellable.add(String(id));
+
+    return { ...res, bookingId: id };
+  };
+
+  /**
+   * Cancel a booking — but only one this module knows to be the probe's own.
+   *
+   * @param {string|number} bookingId
+   */
+  const cancel = async bookingId => {
+    const id = String(bookingId ?? '');
+    const safeUrl = redact(buildUrl({ path: `bookings/${id}`, accountKey }), accountKey);
+
+    if (!cancellable.has(id)) {
+      return {
+        ...inert({ method: 'DELETE', url: safeUrl }),
+        refused:
+          `refusing to cancel booking ${JSON.stringify(bookingId)} — this probe did not create it ` +
+          'and it was not vouched for as a probe contact’s booking. Cancelling a real ' +
+          'customer’s class is the worst outcome available on this map.',
+        dryRun: !live,
+      };
+    }
+
+    if (!live) return inert({ method: 'DELETE', url: safeUrl, extra: { wouldCancel: id } });
+
+    cancel.writes += 1;
+    const res = await send({ method: 'DELETE', path: `bookings/${id}` });
+    return { ...res, bookingId: id };
+  };
+
+  /**
+   * Vouch for a booking id found by searching a probe contact's own bookings.
+   *
+   * The cleanup path needs this: a booking left behind by an earlier run was
+   * not created by *this* process, so `cancellable` does not hold it. The
+   * caller must have read it out of `GET /bookings?contact_key=<a probe
+   * contact>`, which is why the contact key is required here rather than
+   * assumed — an id alone would let any booking through.
+   *
+   * @param {string|number} bookingId
+   * @param {string} contactKey The probe contact whose bookings this id came from.
+   */
+  const allowCancel = (bookingId, contactKey) => {
+    if (!allowed.has(contactKey)) {
+      throw new Error(
+        `refusing to vouch for booking ${bookingId}: ${contactKey} is not a recognised probe contact`,
+      );
+    }
+    cancellable.add(String(bookingId));
+    return bookingId;
+  };
+
+  book.writes = 0;
+  cancel.writes = 0;
+
+  return { book, cancel, allowCancel, cancellable };
+}
+
+/**
+ * A booking id out of a create response, wherever this API chose to put it.
+ *
+ * `run-49.mjs` needed the same tolerance for `contact_key`: the reference is
+ * incomplete, and the shape of a create response is not something to guess at
+ * from documentation that has already been wrong twice on this map.
+ *
+ * @param {unknown} body
+ */
+export function bookingIdOf(body) {
+  return (
+    body?.booking_id ??
+    body?.id ??
+    body?.booking?.booking_id ??
+    body?.booking?.id ??
+    (Array.isArray(body) ? (body[0]?.booking_id ?? body[0]?.id) : null) ??
+    null
+  );
+}

--- a/cloudflare-clubworx/probes/lib/booking.mjs
+++ b/cloudflare-clubworx/probes/lib/booking.mjs
@@ -82,15 +82,20 @@ export function createBooker({ accountKey, allowedContactKeys = [], live = false
   const allowed = allowedContactKeys instanceof Set ? allowedContactKeys : new Set(allowedContactKeys);
 
   /**
-   * Booking ids this module is willing to DELETE.
+   * Booking ids this module is willing to DELETE, each mapped to the contact
+   * that holds it.
    *
    * Populated by `book` on success, and by `allowCancel` for bookings an
    * earlier run left behind. Nothing else can add to it, so `cancel` cannot be
    * pointed at a real customer's booking even by a runner bug.
+   *
+   * It is a map rather than a set because `DELETE /bookings/:id` **requires
+   * `contact_key`** as well as the id — see `cancel`. Keeping the contact
+   * beside the id means the caller cannot supply a mismatched one.
    */
-  const cancellable = new Set();
+  const cancellable = new Map();
 
-  const send = async ({ method, path, payload }) => {
+  const send = async ({ method, path, payload, form }) => {
     const url = buildUrl({ path, accountKey });
     const safeUrl = redact(url, accountKey);
     const started = performance.now();
@@ -101,8 +106,13 @@ export function createBooker({ accountKey, allowedContactKeys = [], live = false
         headers: {
           Accept: 'application/json',
           ...(payload ? { 'Content-Type': 'application/json' } : {}),
+          ...(form ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {}),
         },
         ...(payload ? { body: JSON.stringify(payload) } : {}),
+        // The reference documents DELETE's parameters as a form-encoded body,
+        // not query string. Sending them the other way is how this probe first
+        // read a missing parameter as a permissions failure.
+        ...(form ? { body: new URLSearchParams(form).toString() } : {}),
       });
       const ms = Math.round(performance.now() - started);
       const bodyText = await res.text();
@@ -191,14 +201,23 @@ export function createBooker({ accountKey, allowedContactKeys = [], live = false
     const res = await send({ method: 'POST', path: 'bookings', payload });
 
     const id = bookingIdOf(res.body);
-    // Only a booking this run created may later be cancelled.
-    if (id) cancellable.add(String(id));
+    // Only a booking this run created may later be cancelled, and only for the
+    // contact it was created for.
+    if (id) cancellable.set(String(id), payload.contact_key);
 
     return { ...res, bookingId: id };
   };
 
   /**
    * Cancel a booking — but only one this module knows to be the probe's own.
+   *
+   * `DELETE /api/v2/bookings/:id` requires **`contact_key` as well as
+   * `account_key`**, and the reference puts both in a form-encoded body. Omit
+   * the contact and it answers `401 "Authorization failed"` — which reads
+   * exactly like a key without delete permission, and was misdiagnosed as one
+   * on the first #50 run. The contact is therefore taken from `cancellable`
+   * rather than from the caller: it cannot be forgotten, and it cannot be a
+   * different contact's.
    *
    * @param {string|number} bookingId
    */
@@ -217,10 +236,18 @@ export function createBooker({ accountKey, allowedContactKeys = [], live = false
       };
     }
 
-    if (!live) return inert({ method: 'DELETE', url: safeUrl, extra: { wouldCancel: id } });
+    const contact_key = cancellable.get(id);
+
+    if (!live) {
+      return inert({ method: 'DELETE', url: safeUrl, extra: { wouldCancel: id, wouldSend: { contact_key } } });
+    }
 
     cancel.writes += 1;
-    const res = await send({ method: 'DELETE', path: `bookings/${id}` });
+    const res = await send({
+      method: 'DELETE',
+      path: `bookings/${id}`,
+      form: { account_key: accountKey, contact_key },
+    });
     return { ...res, bookingId: id };
   };
 
@@ -242,7 +269,7 @@ export function createBooker({ accountKey, allowedContactKeys = [], live = false
         `refusing to vouch for booking ${bookingId}: ${contactKey} is not a recognised probe contact`,
       );
     }
-    cancellable.add(String(bookingId));
+    cancellable.set(String(bookingId), contactKey);
     return bookingId;
   };
 

--- a/cloudflare-clubworx/probes/lib/booking.test.js
+++ b/cloudflare-clubworx/probes/lib/booking.test.js
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { createBooker, assertProbeBooking, bookingIdOf } from './booking.mjs';
+
+// The booking path is the first place on this map that can issue DELETE against
+// a production database full of real customers' bookings. A mistaken create is
+// reversible here — that is the one thing bookings have over contacts — but a
+// mistaken *cancellation* takes a real member off a class they turn up to.
+//
+// So the assertions below are weighted accordingly: most of them are about what
+// this module refuses to do.
+
+const key = 'unique-not-a-real-key';
+const OURS = 'ck-probe-a';
+const STRANGER = 'ck-somebody-real';
+const EVENT = 4242;
+
+const fakeFetch = (calls, response = {}) => async (url, init) => {
+  calls.push({ url, init });
+  return {
+    status: response.status ?? 200,
+    headers: new Headers(response.headers ?? { 'content-type': 'application/json' }),
+    text: async () => response.text ?? '{"booking_id":"bk-1"}',
+  };
+};
+
+const booker = (calls, opts = {}) =>
+  createBooker({
+    accountKey: key,
+    allowedContactKeys: [OURS],
+    fetchImpl: fakeFetch(calls, opts.response),
+    ...opts,
+  });
+
+describe('assertProbeBooking', () => {
+  it('refuses a contact_key that did not come from the identity-filtered search', () => {
+    // The control that matters. A key reaching here that was not recognised as
+    // a probe contact belongs to one of ~60,000 real people.
+    expect(() => assertProbeBooking({ contact_key: STRANGER, event_id: EVENT }, [OURS])).toThrow(
+      /not a recognised probe contact/,
+    );
+  });
+
+  it('refuses when no probe contacts were recognised at all', () => {
+    // An empty allowlist means the search found nothing. Booking anything at
+    // that point is booking a guess.
+    expect(() => assertProbeBooking({ contact_key: OURS, event_id: EVENT }, [])).toThrow(
+      /no probe contacts were recognised/,
+    );
+  });
+
+  it('refuses a booking with no contact_key or no event_id', () => {
+    expect(() => assertProbeBooking({ event_id: EVENT }, [OURS])).toThrow(/without a contact_key/);
+    expect(() => assertProbeBooking({ contact_key: OURS }, [OURS])).toThrow(/without an event_id/);
+  });
+
+  it('accepts a recognised probe contact', () => {
+    expect(() => assertProbeBooking({ contact_key: OURS, event_id: EVENT }, [OURS])).not.toThrow();
+  });
+
+  it('accepts event_id 0 rather than treating it as absent', () => {
+    // A falsy-but-present id is a real id. Rejecting it would be a bug that
+    // only shows up against whichever gym numbers its events from zero.
+    expect(() => assertProbeBooking({ contact_key: OURS, event_id: 0 }, [OURS])).not.toThrow();
+  });
+});
+
+describe('createBooker.book', () => {
+  it('does not touch the network unless writing is explicitly enabled', async () => {
+    const calls = [];
+    const { book } = booker(calls);
+
+    const res = await book({ contact_key: OURS, event_id: EVENT });
+
+    expect(calls).toHaveLength(0);
+    expect(res.dryRun).toBe(true);
+  });
+
+  it('reports what a dry run would have sent, so --dry-run is reviewable', async () => {
+    const { book } = booker([]);
+    const res = await book({ contact_key: OURS, event_id: EVENT, label: 'Q1', why: 'baseline' });
+
+    expect(res.wouldSend).toEqual({ contact_key: OURS, event_id: EVENT });
+    expect(res.status).toBeNull();
+  });
+
+  it('runs the guard on a dry run too, so the refusal is proven without writing', async () => {
+    const calls = [];
+    const { book } = booker(calls);
+
+    const res = await book({ contact_key: STRANGER, event_id: EVENT });
+
+    expect(res.refused).toMatch(/not a recognised probe contact/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('refuses a stranger even when live, without issuing a request', async () => {
+    const calls = [];
+    const { book } = booker(calls, { live: true });
+
+    const res = await book({ contact_key: STRANGER, event_id: EVENT });
+
+    expect(res.refused).toMatch(/not a recognised probe contact/);
+    expect(calls).toHaveLength(0);
+    expect(book.writes).toBe(0);
+  });
+
+  it('POSTs the booking as JSON when live, dropping bookkeeping fields', async () => {
+    const calls = [];
+    const { book } = booker(calls, { live: true });
+
+    await book({ contact_key: OURS, event_id: EVENT, label: 'Q1', why: 'baseline' });
+
+    expect(calls[0].init.method).toBe('POST');
+    expect(calls[0].init.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(calls[0].init.body)).toEqual({ contact_key: OURS, event_id: EVENT });
+  });
+
+  it('never lets the account key reach the recorded url', async () => {
+    const { book } = booker([], { live: true });
+    const res = await book({ contact_key: OURS, event_id: EVENT });
+
+    expect(res.url).not.toContain(key);
+    expect(res.url).toContain('<CLUBWORX_ACCOUNT_KEY>');
+  });
+
+  it('keeps a non-JSON body as redacted text rather than dropping it', async () => {
+    // A rejection for "no membership" is the answer to question 2 and may well
+    // arrive as HTML from a WAF or a validation layer.
+    const { book } = booker([], {
+      live: true,
+      response: { status: 422, text: `<html>no plan for ${key}</html>`, headers: { 'content-type': 'text/html' } },
+    });
+
+    const res = await book({ contact_key: OURS, event_id: EVENT });
+
+    expect(res.status).toBe(422);
+    expect(res.bodyText).toContain('no plan');
+    expect(res.bodyText).not.toContain(key);
+  });
+
+  it('redacts the key out of a connection error', async () => {
+    const { book } = createBooker({
+      accountKey: key,
+      allowedContactKeys: [OURS],
+      live: true,
+      fetchImpl: async () => {
+        throw new Error(`connect ECONNREFUSED for account_key=${key}`);
+      },
+    });
+
+    const res = await book({ contact_key: OURS, event_id: EVENT });
+
+    expect(res.error).not.toContain(key);
+    expect(res.error).toContain('<CLUBWORX_ACCOUNT_KEY>');
+  });
+});
+
+describe('createBooker.cancel', () => {
+  it('refuses any booking id it did not create', async () => {
+    // The single most important assertion in this file. An arbitrary id is a
+    // real customer's booking.
+    const calls = [];
+    const { cancel } = booker(calls, { live: true });
+
+    const res = await cancel('bk-somebody-elses');
+
+    expect(res.refused).toMatch(/did not create it/);
+    expect(calls).toHaveLength(0);
+    expect(cancel.writes).toBe(0);
+  });
+
+  it('cancels a booking it created itself', async () => {
+    const calls = [];
+    const { book, cancel } = booker(calls, { live: true });
+
+    const created = await book({ contact_key: OURS, event_id: EVENT });
+    const res = await cancel(created.bookingId);
+
+    expect(res.refused).toBeNull();
+    expect(calls[1].init.method).toBe('DELETE');
+    expect(calls[1].url).toContain('bookings/bk-1');
+  });
+
+  it('sends no body on DELETE', async () => {
+    const calls = [];
+    const { book, cancel } = booker(calls, { live: true });
+
+    const created = await book({ contact_key: OURS, event_id: EVENT });
+    await cancel(created.bookingId);
+
+    expect(calls[1].init.body).toBeUndefined();
+  });
+
+  it('does not touch the network on a dry run, even for a booking it created', async () => {
+    const calls = [];
+    const { book, cancel, allowCancel } = booker(calls);
+
+    await book({ contact_key: OURS, event_id: EVENT });
+    allowCancel('bk-1', OURS);
+    const res = await cancel('bk-1');
+
+    expect(calls).toHaveLength(0);
+    expect(res.dryRun).toBe(true);
+    expect(res.wouldCancel).toBe('bk-1');
+  });
+
+  it('does not record a cancellable id when the create failed', async () => {
+    // A booking that never came into existence must not leave an id behind that
+    // a later DELETE could point at.
+    const { book, cancel } = booker([], {
+      live: true,
+      response: { status: 422, text: '{}' },
+    });
+
+    await book({ contact_key: OURS, event_id: EVENT });
+    const res = await cancel('bk-1');
+
+    expect(res.refused).toMatch(/did not create it/);
+  });
+});
+
+describe('createBooker.allowCancel', () => {
+  it('vouches for a booking found on a probe contact, so an earlier run can be cleaned up', async () => {
+    const calls = [];
+    const { cancel, allowCancel } = booker(calls, { live: true });
+
+    allowCancel('bk-from-yesterday', OURS);
+    const res = await cancel('bk-from-yesterday');
+
+    expect(res.refused).toBeNull();
+    expect(calls[0].init.method).toBe('DELETE');
+  });
+
+  it('refuses to vouch for a booking on a contact that is not ours', () => {
+    // Without the contact key, an id alone would let any booking through — which
+    // would defeat the whole point of the cancellable set.
+    const { allowCancel } = booker([], { live: true });
+
+    expect(() => allowCancel('bk-1', STRANGER)).toThrow(/not a recognised probe contact/);
+  });
+});
+
+describe('bookingIdOf', () => {
+  it('finds the id wherever this API chose to put it', () => {
+    expect(bookingIdOf({ booking_id: 'a' })).toBe('a');
+    expect(bookingIdOf({ id: 'b' })).toBe('b');
+    expect(bookingIdOf({ booking: { booking_id: 'c' } })).toBe('c');
+    expect(bookingIdOf([{ booking_id: 'd' }])).toBe('d');
+  });
+
+  it('returns null rather than guessing when there is nothing to find', () => {
+    expect(bookingIdOf(null)).toBeNull();
+    expect(bookingIdOf({})).toBeNull();
+    expect(bookingIdOf('nope')).toBeNull();
+  });
+});

--- a/cloudflare-clubworx/probes/lib/booking.test.js
+++ b/cloudflare-clubworx/probes/lib/booking.test.js
@@ -181,14 +181,32 @@ describe('createBooker.cancel', () => {
     expect(calls[1].url).toContain('bookings/bk-1');
   });
 
-  it('sends no body on DELETE', async () => {
+  it('sends contact_key in a form-encoded body, which DELETE requires', async () => {
+    // Omitting it answers 401 "Authorization failed" — indistinguishable from a
+    // key with no delete permission, and misdiagnosed as exactly that on the
+    // first #50 run against production.
     const calls = [];
     const { book, cancel } = booker(calls, { live: true });
 
     const created = await book({ contact_key: OURS, event_id: EVENT });
     await cancel(created.bookingId);
 
-    expect(calls[1].init.body).toBeUndefined();
+    const sent = new URLSearchParams(calls[1].init.body);
+    expect(sent.get('contact_key')).toBe(OURS);
+    expect(sent.get('account_key')).toBe(key);
+    expect(calls[1].init.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+  });
+
+  it('takes the contact from the booking, so it cannot be forgotten or mismatched', async () => {
+    // The caller passes only an id. There is no parameter through which a
+    // different contact's key could be supplied.
+    const calls = [];
+    const { allowCancel, cancel } = booker(calls, { live: true });
+
+    allowCancel('bk-7', OURS);
+    await cancel('bk-7');
+
+    expect(new URLSearchParams(calls[0].init.body).get('contact_key')).toBe(OURS);
   });
 
   it('does not touch the network on a dry run, even for a booking it created', async () => {

--- a/cloudflare-clubworx/probes/lib/membership.mjs
+++ b/cloudflare-clubworx/probes/lib/membership.mjs
@@ -1,0 +1,194 @@
+/**
+ * The membership write path: `POST /api/v2/memberships`.
+ *
+ * The fourth way out to Clubworx, beside `lib/http.mjs` (GET), `lib/write.mjs`
+ * (creates a contact) and `lib/booking.mjs` (books and cancels). Same structural
+ * argument as the others: a probe that does not import this module cannot
+ * assign a membership, and that is a property of the script rather than a claim
+ * about it.
+ *
+ * Assigning a membership is treated as **irreversible**. The reference exposes
+ * list and create for memberships and **no delete**, so a School Pass given to
+ * the wrong contact is another permanent mark on a real person's record — the
+ * same class of mistake as creating a contact, and guarded the same way:
+ *
+ *   1. `live` defaults to false, so an import or a forgotten flag costs nothing.
+ *   2. The contact must be one of the recognised probe contacts, checked before
+ *      the network is touched.
+ *
+ * The body is **form-encoded**, not JSON. The reference documents
+ * `account_key=…&contact_key=…&membership_plan_id=…&start_date=…`, and #50
+ * learned the hard way that guessing a request's shape here produces a status
+ * code that looks like something else entirely.
+ */
+
+import { buildUrl, redact } from './request.mjs';
+import { rateLimitHeaders } from './report.mjs';
+
+/**
+ * Refuse to assign a membership to anything but a known probe contact.
+ *
+ * Same reasoning as `assertProbeBooking`: a membership payload carries an
+ * opaque `contact_key` and no name, dob or email, so there is nothing in its
+ * shape to recognise. The control has to be an allowlist built from rows that
+ * already passed the identity guard.
+ *
+ * @param {{contact_key?: string, membership_plan_id?: unknown}} membership
+ * @param {Set<string>|Array<string>} allowedContactKeys
+ */
+export function assertProbeMembership(membership, allowedContactKeys) {
+  const allowed =
+    allowedContactKeys instanceof Set ? allowedContactKeys : new Set(allowedContactKeys ?? []);
+  const { contact_key, membership_plan_id } = membership ?? {};
+
+  if (allowed.size === 0) {
+    throw new Error(
+      'refusing to assign a membership: no probe contacts were recognised, so there is nobody this probe may assign one to',
+    );
+  }
+  if (typeof contact_key !== 'string' || !contact_key) {
+    throw new Error(
+      `refusing to assign a membership without a contact_key (got ${JSON.stringify(contact_key)})`,
+    );
+  }
+  if (!allowed.has(contact_key)) {
+    throw new Error(
+      `refusing to assign a membership to a contact that is not a recognised probe contact (${contact_key}) — ` +
+        'memberships have no delete endpoint, so this would be permanent',
+    );
+  }
+  if (membership_plan_id === undefined || membership_plan_id === null || membership_plan_id === '') {
+    throw new Error(
+      `refusing to assign a membership without a membership_plan_id (got ${JSON.stringify(membership_plan_id)})`,
+    );
+  }
+
+  return membership;
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.accountKey
+ * @param {Set<string>|Array<string>} [opts.allowedContactKeys]
+ * @param {boolean} [opts.live] Must be explicitly true before anything is assigned.
+ * @param {typeof fetch} [opts.fetchImpl]
+ */
+export function createMembershipAssigner({
+  accountKey,
+  allowedContactKeys = [],
+  live = false,
+  fetchImpl = fetch,
+}) {
+  const allowed =
+    allowedContactKeys instanceof Set ? allowedContactKeys : new Set(allowedContactKeys);
+
+  /**
+   * @param {{contact_key: string, membership_plan_id: string|number, start_date?: string}} membership
+   */
+  const assign = async membership => {
+    const url = buildUrl({ path: 'memberships', accountKey });
+    const safeUrl = redact(url, accountKey);
+
+    // Before the live check, so a dry run exercises the guard rather than only
+    // the plumbing.
+    let form;
+    try {
+      assertProbeMembership(membership, allowed);
+      form = {
+        account_key: accountKey,
+        contact_key: membership.contact_key,
+        membership_plan_id: String(membership.membership_plan_id),
+        ...(membership.start_date ? { start_date: membership.start_date } : {}),
+      };
+    } catch (err) {
+      return {
+        url: safeUrl,
+        status: null,
+        ms: 0,
+        headers: {},
+        contentType: null,
+        body: null,
+        bodyText: null,
+        error: null,
+        refused: err.message,
+        dryRun: !live,
+      };
+    }
+
+    // What a dry run reports must not include the key, even though the real
+    // request has to send it.
+    const { account_key, ...shown } = form;
+
+    if (!live) {
+      return {
+        url: safeUrl,
+        status: null,
+        ms: 0,
+        headers: {},
+        contentType: null,
+        body: null,
+        bodyText: null,
+        error: null,
+        refused: null,
+        dryRun: true,
+        wouldSend: shown,
+      };
+    }
+
+    assign.writes += 1;
+    const started = performance.now();
+
+    try {
+      const res = await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams(form).toString(),
+      });
+      const ms = Math.round(performance.now() - started);
+      const bodyText = await res.text();
+
+      let body = null;
+      try {
+        body = JSON.parse(bodyText);
+      } catch {
+        body = null;
+      }
+
+      return {
+        url: safeUrl,
+        status: res.status,
+        ms,
+        headers: rateLimitHeaders(res.headers),
+        contentType: res.headers.get?.('content-type') ?? null,
+        body,
+        bodyText: body === null ? redact(bodyText, accountKey).slice(0, 500) : null,
+        error: null,
+        refused: null,
+        dryRun: false,
+        sent: shown,
+      };
+    } catch (err) {
+      // A failed assignment may still have landed. Memberships have no delete,
+      // so this is reported as "may exist" rather than as a no-op.
+      return {
+        url: safeUrl,
+        status: null,
+        ms: Math.round(performance.now() - started),
+        headers: {},
+        contentType: null,
+        body: null,
+        bodyText: null,
+        error: redact(err.code ?? err.message ?? 'unknown error', accountKey),
+        refused: null,
+        dryRun: false,
+        sent: shown,
+      };
+    }
+  };
+
+  assign.writes = 0;
+  return { assign };
+}

--- a/cloudflare-clubworx/probes/lib/membership.test.js
+++ b/cloudflare-clubworx/probes/lib/membership.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { createMembershipAssigner, assertProbeMembership } from './membership.mjs';
+
+// Memberships have list and create in the reference and **no delete**, so an
+// assignment is as permanent as a contact — a lasting mark on a real person's
+// record. The assertions here are mostly about what this module refuses to do.
+
+const key = 'unique-not-a-real-key';
+const OURS = 'ck-probe-a';
+const STRANGER = 'ck-somebody-real';
+const PLAN = 64189;
+
+const fakeFetch = (calls, response = {}) => async (url, init) => {
+  calls.push({ url, init });
+  return {
+    status: response.status ?? 200,
+    headers: new Headers(response.headers ?? { 'content-type': 'application/json' }),
+    text: async () => response.text ?? '{"membership_plan_id":64189}',
+  };
+};
+
+const assigner = (calls, opts = {}) =>
+  createMembershipAssigner({
+    accountKey: key,
+    allowedContactKeys: [OURS],
+    fetchImpl: fakeFetch(calls, opts.response),
+    ...opts,
+  });
+
+describe('assertProbeMembership', () => {
+  it('refuses a contact that did not come from the identity-filtered search', () => {
+    expect(() =>
+      assertProbeMembership({ contact_key: STRANGER, membership_plan_id: PLAN }, [OURS]),
+    ).toThrow(/not a recognised probe contact/);
+  });
+
+  it('refuses when no probe contacts were recognised at all', () => {
+    expect(() => assertProbeMembership({ contact_key: OURS, membership_plan_id: PLAN }, [])).toThrow(
+      /no probe contacts were recognised/,
+    );
+  });
+
+  it('refuses without a plan id, rather than assigning some default', () => {
+    expect(() => assertProbeMembership({ contact_key: OURS }, [OURS])).toThrow(
+      /without a membership_plan_id/,
+    );
+  });
+
+  it('accepts a recognised contact with a plan', () => {
+    expect(() =>
+      assertProbeMembership({ contact_key: OURS, membership_plan_id: PLAN }, [OURS]),
+    ).not.toThrow();
+  });
+});
+
+describe('createMembershipAssigner', () => {
+  it('does not touch the network unless writing is explicitly enabled', async () => {
+    const calls = [];
+    const { assign } = assigner(calls);
+
+    const res = await assign({ contact_key: OURS, membership_plan_id: PLAN });
+
+    expect(calls).toHaveLength(0);
+    expect(res.dryRun).toBe(true);
+  });
+
+  it('runs the guard on a dry run too, and issues nothing', async () => {
+    const calls = [];
+    const { assign } = assigner(calls);
+
+    const res = await assign({ contact_key: STRANGER, membership_plan_id: PLAN });
+
+    expect(res.refused).toMatch(/not a recognised probe contact/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('refuses a stranger even when live, without issuing a request', async () => {
+    const calls = [];
+    const { assign } = assigner(calls, { live: true });
+
+    const res = await assign({ contact_key: STRANGER, membership_plan_id: PLAN });
+
+    expect(res.refused).toBeTruthy();
+    expect(calls).toHaveLength(0);
+    expect(assign.writes).toBe(0);
+  });
+
+  it('sends a form-encoded body, which is what the reference documents', async () => {
+    // #50 sent DELETE's parameters the wrong way and read the result as a
+    // permissions failure. Guessing a request's shape here is expensive.
+    const calls = [];
+    const { assign } = assigner(calls, { live: true });
+
+    await assign({ contact_key: OURS, membership_plan_id: PLAN, start_date: '2026-08-18' });
+
+    expect(calls[0].init.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    const sent = new URLSearchParams(calls[0].init.body);
+    expect(sent.get('contact_key')).toBe(OURS);
+    expect(sent.get('membership_plan_id')).toBe(String(PLAN));
+    expect(sent.get('start_date')).toBe('2026-08-18');
+    expect(sent.get('account_key')).toBe(key);
+  });
+
+  it('omits start_date rather than sending an empty one', async () => {
+    const calls = [];
+    const { assign } = assigner(calls, { live: true });
+
+    await assign({ contact_key: OURS, membership_plan_id: PLAN });
+
+    expect(new URLSearchParams(calls[0].init.body).has('start_date')).toBe(false);
+  });
+
+  it('keeps the account key out of what it reports, while still sending it', async () => {
+    const calls = [];
+    const { assign } = assigner(calls, { live: true });
+
+    const res = await assign({ contact_key: OURS, membership_plan_id: PLAN });
+
+    expect(JSON.stringify(res)).not.toContain(key);
+    expect(res.sent.account_key).toBeUndefined();
+    expect(new URLSearchParams(calls[0].init.body).get('account_key')).toBe(key);
+  });
+
+  it('keeps a non-JSON error body as redacted text', async () => {
+    const { assign } = assigner([], {
+      live: true,
+      response: {
+        status: 422,
+        text: `<html>bad plan for ${key}</html>`,
+        headers: { 'content-type': 'text/html' },
+      },
+    });
+
+    const res = await assign({ contact_key: OURS, membership_plan_id: PLAN });
+
+    expect(res.status).toBe(422);
+    expect(res.bodyText).toContain('bad plan');
+    expect(res.bodyText).not.toContain(key);
+  });
+
+  it('redacts the key out of a connection error', async () => {
+    const { assign } = createMembershipAssigner({
+      accountKey: key,
+      allowedContactKeys: [OURS],
+      live: true,
+      fetchImpl: async () => {
+        throw new Error(`ECONNREFUSED account_key=${key}`);
+      },
+    });
+
+    const res = await assign({ contact_key: OURS, membership_plan_id: PLAN });
+
+    expect(res.error).not.toContain(key);
+    expect(res.error).toContain('<CLUBWORX_ACCOUNT_KEY>');
+  });
+});

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -298,3 +298,291 @@ export function describeIsolation({
     returnedCount: returned.length,
   };
 }
+
+/**
+ * Reduce a bookings response to something publishable.
+ *
+ * `GET /bookings?contact_key=` is scoped to one contact, so unlike the contact
+ * searches this is not sifting a 60,000-person database — but the rule from
+ * `summariseContacts` holds anyway. The endpoint is not *guaranteed* to scope:
+ * staff-site#51 found `/events` ignoring `contact_key` outright while the
+ * reference called it required, so a row that arrives for somebody else is
+ * counted and dropped rather than trusted and printed.
+ *
+ * @param {unknown} body
+ * @param {string[]} [ourKeys] Contact keys belonging to probe contacts.
+ */
+export function summariseBookings(body, ourKeys = []) {
+  if (!Array.isArray(body)) {
+    return { count: 0, fields: [], ids: [], ours: 0, strangers: 0, notAnArray: true };
+  }
+
+  const known = new Set(ourKeys);
+  const fields = new Set();
+  const ids = [];
+  let ours = 0;
+  let strangers = 0;
+
+  for (const row of body) {
+    for (const key of Object.keys(row ?? {})) fields.add(key);
+
+    // A row with no contact_key at all came back from a query that was already
+    // scoped to one contact, so it counts as ours. Calling it a stranger would
+    // make the before/after counts that answer questions 3 and 4 unreadable.
+    const key = row?.contact_key;
+    if (key === undefined || known.has(key)) {
+      ours += 1;
+      const id = row?.booking_id ?? row?.id;
+      if (id !== undefined && id !== null) ids.push(String(id));
+    } else {
+      strangers += 1;
+    }
+  }
+
+  return {
+    count: body.length,
+    fields: [...fields],
+    ids: ids.sort(),
+    ours,
+    strangers,
+    notAnArray: false,
+  };
+}
+
+/**
+ * Question 2: what does a booking actually require?
+ *
+ * staff-site#50 asks this only if question 1 fails, and names the candidate
+ * discriminator itself: `GET /events` returns a `free_class` boolean. Comparing
+ * a paid event against a free one is what separates "a membership-less contact
+ * cannot book at all" from "it can book, but only a free class" — and those two
+ * answers change #46's tool in very different ways.
+ *
+ * One attempt cannot answer it, so an unattempted half is `null` rather than a
+ * guess. The ticket asks for a failure here to be flagged loudly, which the
+ * caller can only do if it can tell "no" from "not asked".
+ *
+ * @param {{paid?: object|null, free?: object|null}} outcomes Results of classifyWrite.
+ */
+export function describeBookingRequirement({ paid = null, free = null }) {
+  const ok = sample => sample?.outcome === 'created';
+  const rejected = sample => sample?.outcome === 'rejected';
+
+  if (ok(paid)) {
+    return {
+      requirement: 'none',
+      entitlementNeeded: false,
+      freeClassOnly: false,
+      inconclusive: false,
+      summary: 'a membership-less prospect can be booked into an ordinary paid event',
+    };
+  }
+
+  if (rejected(paid) && ok(free)) {
+    return {
+      requirement: 'free_class',
+      entitlementNeeded: false,
+      freeClassOnly: true,
+      inconclusive: false,
+      summary:
+        'a membership-less prospect can only be booked into an event flagged free_class — ' +
+        'the picker must filter on it',
+    };
+  }
+
+  if (rejected(paid) && rejected(free)) {
+    return {
+      requirement: 'entitlement',
+      entitlementNeeded: true,
+      freeClassOnly: false,
+      inconclusive: false,
+      summary:
+        'a membership-less prospect cannot be booked at all — a membership or plan is required, ' +
+        'which changes the shape of the tool',
+    };
+  }
+
+  // Everything else — a timeout, a 500, or a comparison never run — is not an
+  // answer. Reporting it as one would send someone to re-decide a design over a
+  // dropped packet, which is the trap `schemeCollapses` exists to avoid.
+  return {
+    requirement: null,
+    entitlementNeeded: null,
+    freeClassOnly: null,
+    inconclusive: true,
+    summary:
+      paid === null
+        ? 'no booking was attempted'
+        : 'the attempt did not complete conclusively — re-run before concluding anything',
+  };
+}
+
+/**
+ * Question 3: is booking the same contact into the same event twice idempotent?
+ *
+ * The safety model of #46's tool assumes re-running it against an event cannot
+ * double-book a student. Two outcomes are safe and one is not, and they are
+ * told apart by what the server *did*, not by what it said:
+ *
+ *   - a rejection is safe and explicit;
+ *   - a success that produced no second booking is safe and idempotent;
+ *   - a success that produced a second booking is the dangerous one, and it is
+ *     invisible unless the bookings are counted before and after.
+ *
+ * @param {{second?: object|null, countBefore?: number|null, countAfter?: number|null}} opts
+ */
+export function describeDuplicateBooking({ second = null, countBefore = null, countAfter = null }) {
+  if (second?.outcome === 'rejected') {
+    return {
+      duplicated: false,
+      idempotent: true,
+      rejected: true,
+      inconclusive: false,
+      summary: 'the second booking was rejected — re-running the tool cannot double-book',
+    };
+  }
+
+  if (second?.outcome !== 'created') {
+    return {
+      duplicated: null,
+      idempotent: null,
+      rejected: false,
+      inconclusive: true,
+      summary: 'the second attempt did not complete — it says nothing about idempotency',
+    };
+  }
+
+  if (typeof countBefore !== 'number' || typeof countAfter !== 'number') {
+    // Accepted, but nobody counted. This is exactly the case that must not be
+    // reported as safe: from the response alone, a silent second booking looks
+    // identical to an idempotent one.
+    return {
+      duplicated: null,
+      idempotent: null,
+      rejected: false,
+      inconclusive: true,
+      summary: 'the second booking was accepted but the bookings were not counted — unproven',
+    };
+  }
+
+  const duplicated = countAfter > countBefore;
+  return {
+    duplicated,
+    idempotent: !duplicated,
+    rejected: false,
+    inconclusive: false,
+    summary: duplicated
+      ? `the second booking was accepted AND created another (${countBefore} → ${countAfter}) — ` +
+        're-running the tool double-books'
+      : `the second booking was accepted but created nothing new (${countBefore} → ${countAfter}) — ` +
+        'the server is idempotent',
+  };
+}
+
+/**
+ * Question 4: did `DELETE` actually reverse the booking?
+ *
+ * "HTTP 200" is not the finding. The booking either left the contact's list or
+ * it did not, and only a re-read can say which — so a cancellation is judged on
+ * the count afterwards, and a 2xx with the booking still present is reported as
+ * a failure rather than a success. #46 plans to rely on this to undo a mistaken
+ * bulk booking, so a false "reversible" here is worse than no answer.
+ *
+ * @param {{cancel?: object|null, countBefore?: number|null, countAfter?: number|null}} opts
+ */
+export function describeCancellation({ cancel = null, countBefore = null, countAfter = null }) {
+  if (!cancel || cancel.refused) {
+    return {
+      reversed: null,
+      inconclusive: true,
+      summary: cancel?.refused
+        ? 'the cancellation was refused locally'
+        : 'no cancellation was attempted',
+    };
+  }
+
+  const accepted = typeof cancel.status === 'number' && cancel.status >= 200 && cancel.status < 300;
+
+  if (typeof countBefore !== 'number' || typeof countAfter !== 'number') {
+    return {
+      reversed: null,
+      inconclusive: true,
+      summary: `DELETE answered ${cancel.status ?? 'nothing'}, but the bookings were not re-counted — unproven`,
+    };
+  }
+
+  const gone = countAfter < countBefore;
+
+  if (accepted && gone) {
+    return {
+      reversed: true,
+      inconclusive: false,
+      summary: `DELETE reversed the booking cleanly (${countBefore} → ${countAfter})`,
+    };
+  }
+  if (accepted && !gone) {
+    return {
+      reversed: false,
+      inconclusive: false,
+      summary:
+        `DELETE answered ${cancel.status} but the booking is still there (${countBefore} → ${countAfter}) — ` +
+        'the tool cannot rely on it to undo a mistake',
+    };
+  }
+  return {
+    reversed: false,
+    inconclusive: false,
+    summary:
+      `DELETE was rejected (HTTP ${cancel.status ?? 'n/a'}) — the booking remains and must be ` +
+      'removed by hand',
+  };
+}
+
+/**
+ * Which events a probe may safely be booked into.
+ *
+ * A booking is a real row on a real class that staff see, so the choice of
+ * event is not arbitrary. It must be in the **future**, so nobody is standing
+ * in a gym waiting for a `Ztest`; and it must have **room**, because consuming
+ * the last space would cause #46's own worst case — a school group arriving at
+ * an event with fewer spaces than students.
+ *
+ * Both kinds come back separately because question 2 needs the comparison: an
+ * event flagged `free_class` and an ordinary one.
+ *
+ * @param {unknown} body A `GET /events` response.
+ * @param {{now?: string}} [opts]
+ */
+export function pickBookableEvents(body, { now = new Date().toISOString() } = {}) {
+  if (!Array.isArray(body)) return { free: [], paid: [], skipped: 0 };
+
+  const free = [];
+  const paid = [];
+  let skipped = 0;
+
+  for (const row of body) {
+    const starts = row?.event_start_at ?? null;
+    const roomy = row?.event_full !== true && (row?.spaces_available ?? 0) > 0;
+
+    if (!starts || starts <= now || !roomy) {
+      skipped += 1;
+      continue;
+    }
+
+    // The name travels because a human has to recognise the class they are
+    // about to put a test booking on. An event name is a timetable entry —
+    // nothing here describes a person.
+    const event = {
+      event_id: row.event_id,
+      event_name: row.event_name ?? null,
+      event_start_at: starts,
+      spaces_available: row.spaces_available ?? null,
+      free_class: row.free_class === true,
+    };
+
+    (event.free_class ? free : paid).push(event);
+  }
+
+  const byStart = (a, b) => String(a.event_start_at).localeCompare(String(b.event_start_at));
+  return { free: free.sort(byStart), paid: paid.sort(byStart), skipped };
+}

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -350,6 +350,44 @@ export function summariseBookings(body, ourKeys = []) {
 }
 
 /**
+ * The error message out of a rejected write.
+ *
+ * A deliberate, bounded exception to *never record a row of production data*.
+ * The rule exists because probe responses are drawn from a 60,000-person
+ * database — but this reads the server's complaint about **the probe's own
+ * request**, which is the only place the reason for a rejection is written
+ * down. Discarding it leaves staff-site#50 with "HTTP 400" and no answer to
+ * what a booking actually requires, which is the question the ticket is for.
+ *
+ * Bounded three ways: only the `error`-shaped fields are read, never the whole
+ * body; the result is truncated; and the caller redacts before it is printed or
+ * written.
+ *
+ * @param {unknown} body
+ * @param {{limit?: number}} [opts]
+ * @returns {string|null}
+ */
+export function errorMessageOf(body, { limit = 300 } = {}) {
+  if (body === null || typeof body !== 'object') return null;
+
+  const raw = body.error ?? body.errors ?? body.message ?? null;
+  if (raw === null || raw === undefined) return null;
+
+  // Rails-shaped APIs answer with either a string, a list, or field → messages.
+  const text = Array.isArray(raw)
+    ? raw.map(String).join('; ')
+    : typeof raw === 'object'
+      ? Object.entries(raw)
+          .map(([field, messages]) => `${field}: ${[].concat(messages).map(String).join(', ')}`)
+          .join('; ')
+      : String(raw);
+
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  return trimmed.length > limit ? `${trimmed.slice(0, limit)}…` : trimmed;
+}
+
+/**
  * Question 2: what does a booking actually require?
  *
  * staff-site#50 asks this only if question 1 fails, and names the candidate

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -592,6 +592,149 @@ export function describeCancellation({ cancel = null, countBefore = null, countA
 }
 
 /**
+ * Resolve a membership plan by name, and refuse to guess.
+ *
+ * The tool has to turn a plan *name* into a `membership_plan_id`, because a
+ * hard-coded id is a number nobody can check against the Clubworx UI. Two
+ * things make that lookup treacherous, and both are real here:
+ *
+ * **The list truncates silently.** `GET /membership_plans` returned exactly 50
+ * — the default `page_size` — on 2026-08-18, and UJ has 57 plans. `School Pass`
+ * was among the seven missing. A caller using the default page would conclude
+ * the plan does not exist, which is the same trap #51 documented on `/events`
+ * and the reason `requestedPageSize` is reported back here.
+ *
+ * **A near-duplicate name would be ambiguous.** Assigning the wrong plan is a
+ * permanent mark on a real person, so more than one match is an error rather
+ * than a first-wins.
+ *
+ * @param {unknown} body A `GET /membership_plans` response.
+ * @param {string} name Exact plan name, compared case-insensitively.
+ * @param {{requestedPageSize?: number}} [opts]
+ */
+export function findPlanByName(body, name, { requestedPageSize = null } = {}) {
+  if (!Array.isArray(body)) {
+    return { plan: null, matches: 0, truncated: false, count: 0, notAnArray: true };
+  }
+
+  const wanted = String(name ?? '').trim().toLowerCase();
+  const matches = body.filter(p => String(p?.name ?? '').trim().toLowerCase() === wanted);
+
+  // A page that came back exactly full is indistinguishable from a complete
+  // list — there is no total and no next-page link — so "not found" on a full
+  // page is not an answer.
+  const truncated = requestedPageSize !== null && body.length >= requestedPageSize;
+
+  return {
+    plan: matches.length === 1 ? matches[0] : null,
+    matches: matches.length,
+    ambiguous: matches.length > 1,
+    truncated,
+    count: body.length,
+    notAnArray: false,
+  };
+}
+
+/**
+ * Reduce a memberships response to something publishable.
+ *
+ * `GET /memberships?contact_key=` is how a probe answers "does this contact
+ * already hold the pass?" before assigning another one. Memberships have no
+ * delete endpoint, so search-first is not a courtesy here — it is the only
+ * thing standing between a re-run and a pile of duplicate permanent records.
+ *
+ * **There is no `status` field.** A membership record carries `start_date` and
+ * `expiration_date` and nothing that says "active" — verified against a real
+ * record on 2026-08-18. Whether a School Pass is active, which is what a School
+ * Session actually checks, has to be derived from those two dates. A caller
+ * looking for `status` would find `undefined` and could read a live pass as
+ * inactive.
+ *
+ * @param {unknown} body
+ * @param {string|number} [planId] The plan being looked for.
+ * @param {{on?: string}} [opts] The date to judge activity against.
+ */
+export function summariseMemberships(body, planId = null, { on = null } = {}) {
+  if (!Array.isArray(body)) {
+    return { count: 0, fields: [], holdsPlan: false, holdsActivePlan: false, planStates: [], notAnArray: true };
+  }
+
+  const today = (on ?? new Date().toISOString()).slice(0, 10);
+  const fields = new Set();
+  const planStates = [];
+  let holdsPlan = false;
+  let holdsActivePlan = false;
+
+  for (const row of body) {
+    for (const key of Object.keys(row ?? {})) fields.add(key);
+
+    if (planId !== null && String(row?.membership_plan_id) === String(planId)) {
+      holdsPlan = true;
+
+      const start = row?.start_date ?? null;
+      const expires = row?.expiration_date ?? null;
+      // Dates are plain `YYYY-MM-DD`, so string comparison is the date
+      // comparison — no timezone to get wrong. Inclusive at both ends: a pass
+      // starting today is usable today.
+      const active =
+        (!start || start <= today) && (!expires || expires >= today);
+
+      if (active) holdsActivePlan = true;
+
+      planStates.push({
+        start_date: start,
+        expiration_date: expires,
+        active,
+        classes_booked: row?.classes_booked ?? null,
+        classes_remaining: row?.classes_remaining ?? null,
+        class_access: row?.class_access ?? null,
+      });
+    }
+  }
+
+  return {
+    count: body.length,
+    fields: [...fields],
+    holdsPlan,
+    holdsActivePlan,
+    planStates,
+    notAnArray: false,
+  };
+}
+
+/**
+ * How long until an event starts, and whether a lead-time rule would allow it.
+ *
+ * UJ's School Sessions require booking at least a day ahead, so that somebody
+ * cannot book themselves in on the day. The tool has to pre-empt that rather
+ * than surface a raw rejection — but the rule lives in Clubworx's configuration
+ * and is exposed by no endpoint, so this computes the *observable* part and
+ * leaves the verdict to a measurement.
+ *
+ * @param {string} eventStartAt ISO timestamp, with offset.
+ * @param {{now?: string, minLeadHours?: number}} [opts]
+ */
+export function describeLeadTime(eventStartAt, { now = new Date().toISOString(), minLeadHours = 24 } = {}) {
+  const starts = Date.parse(eventStartAt);
+  const from = Date.parse(now);
+
+  if (Number.isNaN(starts) || Number.isNaN(from)) {
+    return { hoursAhead: null, withinLeadTime: null, past: null, unreadable: true };
+  }
+
+  const hoursAhead = (starts - from) / 3_600_000;
+
+  return {
+    hoursAhead: Math.round(hoursAhead * 10) / 10,
+    past: hoursAhead <= 0,
+    // "Within the lead time" means too close to book, not comfortably ahead.
+    withinLeadTime: hoursAhead > 0 && hoursAhead < minLeadHours,
+    minLeadHours,
+    unreadable: false,
+  };
+}
+
+/**
  * Which events a probe may safely be booked into.
  *
  * A booking is a real row on a real class that staff see, so the choice of

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -547,6 +547,13 @@ export function describeCancellation({ cancel = null, countBefore = null, countA
     };
   }
 
+  // A dry run is not a rejection. Without this it falls through to the final
+  // branch and reports "DELETE was rejected — the booking must be removed by
+  // hand", which invents a failure out of a request nobody sent.
+  if (cancel.dryRun) {
+    return { reversed: null, inconclusive: true, summary: 'dry run — no DELETE was sent' };
+  }
+
   const accepted = typeof cancel.status === 'number' && cancel.status >= 200 && cancel.status < 300;
 
   if (typeof countBefore !== 'number' || typeof countAfter !== 'number') {

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -354,9 +354,17 @@ export function summariseBookings(body, ourKeys = []) {
  *
  * staff-site#50 asks this only if question 1 fails, and names the candidate
  * discriminator itself: `GET /events` returns a `free_class` boolean. Comparing
- * a paid event against a free one is what separates "a membership-less contact
- * cannot book at all" from "it can book, but only a free class" — and those two
+ * one event against another is what separates "a membership-less contact cannot
+ * book at all" from "it can book, but only into certain events" — and those two
  * answers change #46's tool in very different ways.
+ *
+ * `free_class` is a *candidate* discriminator, not a confirmed one. UJ's school
+ * sessions are configured with a limited number of prospect places, which is the
+ * mechanism staff actually rely on, and `GET /events` does not return it at all
+ * (verified 2026-08-18). So `paid` and `free` here are really "the event asked
+ * about" and "an event configured differently" — the names follow the ticket's
+ * wording rather than a proven mechanism, and a caller must record *which
+ * events* were compared, not just the verdict.
  *
  * One attempt cannot answer it, so an unattempted half is `null` rather than a
  * guess. The ticket asks for a failure here to be flagged loudly, which the

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -603,6 +603,20 @@ describe('describeCancellation', () => {
     expect(describeCancellation({ cancel: { refused: 'nope' } }).summary).toMatch(/refused locally/);
     expect(describeCancellation({}).summary).toMatch(/no cancellation was attempted/);
   });
+
+  it('does not report a dry run as a rejected DELETE', () => {
+    // Observed: a --cancel read-only run printed "DELETE was rejected — the
+    // booking remains and must be removed by hand", inventing a failure out of
+    // a request nobody sent.
+    const v = describeCancellation({
+      cancel: { dryRun: true, status: null },
+      countBefore: 1,
+      countAfter: 1,
+    });
+    expect(v.reversed).toBeNull();
+    expect(v.inconclusive).toBe(true);
+    expect(v.summary).not.toMatch(/rejected|by hand/);
+  });
 });
 
 describe('pickBookableEvents', () => {

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -17,6 +17,9 @@ import {
   describeDuplicateBooking,
   describeCancellation,
   pickBookableEvents,
+  findPlanByName,
+  summariseMemberships,
+  describeLeadTime,
 } from './report.mjs';
 
 // What a probe is allowed to write down. Everything here is counts, ids, status
@@ -667,5 +670,132 @@ describe('pickBookableEvents', () => {
 
   it('survives a non-array body', () => {
     expect(pickBookableEvents(null)).toEqual({ free: [], paid: [], skipped: 0 });
+  });
+});
+
+describe('findPlanByName', () => {
+  const plans = [
+    { id: 1, name: 'Adult Monthly' },
+    { id: 64189, name: 'School Pass' },
+  ];
+
+  it('resolves an exact name to one plan', () => {
+    const v = findPlanByName(plans, 'School Pass');
+    expect(v.plan.id).toBe(64189);
+    expect(v.matches).toBe(1);
+  });
+
+  it('matches case-insensitively and ignores surrounding space', () => {
+    expect(findPlanByName(plans, '  school pass ').plan.id).toBe(64189);
+  });
+
+  it('refuses to pick when two plans share a name', () => {
+    // Assigning the wrong plan is a permanent mark on a real person, so an
+    // ambiguous lookup must fail rather than take the first.
+    const v = findPlanByName([...plans, { id: 999, name: 'School Pass' }], 'School Pass');
+    expect(v.plan).toBeNull();
+    expect(v.ambiguous).toBe(true);
+    expect(v.matches).toBe(2);
+  });
+
+  it('flags a full page, because "not found" there is not an answer', () => {
+    // Observed 2026-08-18: GET /membership_plans returned exactly 50 (the
+    // default page_size) and School Pass was one of the seven beyond it.
+    const fifty = Array.from({ length: 50 }, (_, i) => ({ id: i, name: `Plan ${i}` }));
+    const v = findPlanByName(fifty, 'School Pass', { requestedPageSize: 50 });
+    expect(v.plan).toBeNull();
+    expect(v.truncated).toBe(true);
+  });
+
+  it('does not flag truncation on a short page', () => {
+    expect(findPlanByName(plans, 'School Pass', { requestedPageSize: 200 }).truncated).toBe(false);
+  });
+
+  it('survives a non-array body', () => {
+    expect(findPlanByName(null, 'School Pass').notAnArray).toBe(true);
+  });
+});
+
+describe('summariseMemberships', () => {
+  it('reports whether the contact already holds the plan', () => {
+    const v = summariseMemberships(
+      [{ membership_plan_id: 64189, start_date: '2026-08-18', expiration_date: '2026-11-09' }],
+      64189,
+      { on: '2026-08-18' },
+    );
+    expect(v.holdsPlan).toBe(true);
+    expect(v.holdsActivePlan).toBe(true);
+  });
+
+  it('derives active from the dates, since the record carries no status field', () => {
+    // Verified against a real record 2026-08-18: start_date and
+    // expiration_date, and nothing that says "active".
+    const rows = [{ membership_plan_id: 64189, start_date: '2026-08-18', expiration_date: '2026-11-09' }];
+    expect(summariseMemberships(rows, 64189, { on: '2026-11-10' }).holdsActivePlan).toBe(false);
+    expect(summariseMemberships(rows, 64189, { on: '2026-08-17' }).holdsActivePlan).toBe(false);
+    // Inclusive at both ends: a pass starting today is usable today.
+    expect(summariseMemberships(rows, 64189, { on: '2026-11-09' }).holdsActivePlan).toBe(true);
+  });
+
+  it('separates holding an expired pass from holding an active one', () => {
+    const v = summariseMemberships(
+      [{ membership_plan_id: 64189, start_date: '2026-01-01', expiration_date: '2026-03-01' }],
+      64189,
+      { on: '2026-08-18' },
+    );
+    expect(v.holdsPlan).toBe(true);
+    expect(v.holdsActivePlan).toBe(false);
+  });
+
+  it('does not confuse a different plan for the one being looked for', () => {
+    const v = summariseMemberships([{ membership_plan_id: 1, status: 'active' }], 64189);
+    expect(v.holdsPlan).toBe(false);
+    expect(v.count).toBe(1);
+  });
+
+  it('compares ids as strings, so 64189 and "64189" agree', () => {
+    expect(summariseMemberships([{ membership_plan_id: '64189' }], 64189).holdsPlan).toBe(true);
+  });
+
+  it('reports field names without values', () => {
+    const v = summariseMemberships([{ membership_plan_id: 1, member_name: 'A Real Person' }], 1);
+    expect(v.fields).toContain('member_name');
+    expect(JSON.stringify(v)).not.toContain('A Real Person');
+  });
+
+  it('survives a non-array body', () => {
+    expect(summariseMemberships(null, 1).notAnArray).toBe(true);
+  });
+});
+
+describe('describeLeadTime', () => {
+  const NOW = '2026-08-18T07:00:00Z';
+
+  it('flags an event closer than the lead time', () => {
+    const v = describeLeadTime('2026-08-19T04:00:00Z', { now: NOW });
+    expect(v.withinLeadTime).toBe(true);
+    expect(v.hoursAhead).toBe(21);
+  });
+
+  it('allows an event comfortably ahead', () => {
+    const v = describeLeadTime('2026-08-25T04:00:00Z', { now: NOW });
+    expect(v.withinLeadTime).toBe(false);
+    expect(v.past).toBe(false);
+  });
+
+  it('tells a past event from one that is merely too close', () => {
+    const v = describeLeadTime('2026-08-17T04:00:00Z', { now: NOW });
+    expect(v.past).toBe(true);
+    expect(v.withinLeadTime).toBe(false);
+  });
+
+  it('respects an offset rather than assuming UTC', () => {
+    // Clubworx returns Perth-local timestamps with a +08:00 offset.
+    const v = describeLeadTime('2026-08-19T12:00:00.000+08:00', { now: NOW });
+    expect(v.hoursAhead).toBe(21);
+  });
+
+  it('reports an unreadable timestamp rather than guessing', () => {
+    expect(describeLeadTime('not a date', { now: NOW }).unreadable).toBe(true);
   });
 });

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -11,6 +11,11 @@ import {
   describeIsolation,
   classifyWrite,
   schemeCollapses,
+  summariseBookings,
+  describeBookingRequirement,
+  describeDuplicateBooking,
+  describeCancellation,
+  pickBookableEvents,
 } from './report.mjs';
 
 // What a probe is allowed to write down. Everything here is counts, ids, status
@@ -417,5 +422,202 @@ describe('describeIsolation', () => {
     });
     expect(v.applicable).toBe(true);
     expect(v.isolated).toBe(true);
+  });
+});
+
+describe('summariseBookings', () => {
+  const OURS = 'ck-probe-a';
+
+  it('counts a row with no contact_key as ours, since the query was already scoped', () => {
+    const v = summariseBookings([{ booking_id: 'bk-1' }, { booking_id: 'bk-2' }], [OURS]);
+    expect(v.ours).toBe(2);
+    expect(v.strangers).toBe(0);
+    expect(v.ids).toEqual(['bk-1', 'bk-2']);
+  });
+
+  it('counts a row belonging to somebody else without recording it', () => {
+    // /events ignored contact_key entirely (#51) while the reference called it
+    // required, so a scoped endpoint is not something to take on trust.
+    const v = summariseBookings(
+      [{ booking_id: 'bk-1', contact_key: OURS }, { booking_id: 'bk-9', contact_key: 'ck-real' }],
+      [OURS],
+    );
+    expect(v.ours).toBe(1);
+    expect(v.strangers).toBe(1);
+    expect(v.ids).toEqual(['bk-1']);
+    expect(JSON.stringify(v)).not.toContain('bk-9');
+  });
+
+  it('reports field names without values', () => {
+    const v = summariseBookings([{ booking_id: 'bk-1', event_name: 'Youth Squad' }], [OURS]);
+    expect(v.fields).toContain('event_name');
+    expect(JSON.stringify(v)).not.toContain('Youth Squad');
+  });
+
+  it('survives a non-array body', () => {
+    expect(summariseBookings(null).notAnArray).toBe(true);
+    expect(summariseBookings('<html>').count).toBe(0);
+  });
+});
+
+describe('describeBookingRequirement', () => {
+  const created = { outcome: 'created' };
+  const rejected = { outcome: 'rejected' };
+  const failed = { outcome: 'failed' };
+
+  it('reports no requirement when a paid event accepts a membership-less prospect', () => {
+    const v = describeBookingRequirement({ paid: created });
+    expect(v.requirement).toBe('none');
+    expect(v.entitlementNeeded).toBe(false);
+  });
+
+  it('identifies free_class as the discriminator when paid fails and free succeeds', () => {
+    const v = describeBookingRequirement({ paid: rejected, free: created });
+    expect(v.requirement).toBe('free_class');
+    expect(v.freeClassOnly).toBe(true);
+  });
+
+  it('reports an entitlement requirement when both are rejected — the answer that changes the tool', () => {
+    const v = describeBookingRequirement({ paid: rejected, free: rejected });
+    expect(v.requirement).toBe('entitlement');
+    expect(v.entitlementNeeded).toBe(true);
+  });
+
+  it('will not conclude from a rejected paid event alone', () => {
+    // The free comparison is what separates "cannot book at all" from "free
+    // classes only", and they change #46 in very different ways.
+    const v = describeBookingRequirement({ paid: rejected, free: null });
+    expect(v.inconclusive).toBe(true);
+    expect(v.requirement).toBeNull();
+  });
+
+  it('treats a timeout as no answer rather than as a rejection', () => {
+    const v = describeBookingRequirement({ paid: failed, free: created });
+    expect(v.inconclusive).toBe(true);
+  });
+
+  it('says so when nothing was attempted', () => {
+    expect(describeBookingRequirement({}).summary).toMatch(/no booking was attempted/);
+  });
+});
+
+describe('describeDuplicateBooking', () => {
+  const created = { outcome: 'created' };
+
+  it('reports a rejected second booking as safe', () => {
+    const v = describeDuplicateBooking({ second: { outcome: 'rejected' } });
+    expect(v.rejected).toBe(true);
+    expect(v.idempotent).toBe(true);
+    expect(v.duplicated).toBe(false);
+  });
+
+  it('catches a silent second booking by counting, not by reading the status', () => {
+    // The dangerous case: HTTP 200 both times, and a student booked twice.
+    const v = describeDuplicateBooking({ second: created, countBefore: 1, countAfter: 2 });
+    expect(v.duplicated).toBe(true);
+    expect(v.idempotent).toBe(false);
+    expect(v.summary).toMatch(/double-books/);
+  });
+
+  it('reports an accepted-but-unchanged second booking as idempotent', () => {
+    const v = describeDuplicateBooking({ second: created, countBefore: 1, countAfter: 1 });
+    expect(v.duplicated).toBe(false);
+    expect(v.idempotent).toBe(true);
+  });
+
+  it('refuses to call an uncounted success safe', () => {
+    // From the response alone a silent duplicate is indistinguishable from an
+    // idempotent server, so this must not resolve to `idempotent: true`.
+    const v = describeDuplicateBooking({ second: created });
+    expect(v.inconclusive).toBe(true);
+    expect(v.idempotent).toBeNull();
+  });
+
+  it('says nothing about idempotency when the second attempt did not complete', () => {
+    const v = describeDuplicateBooking({ second: { outcome: 'failed' }, countBefore: 1, countAfter: 1 });
+    expect(v.inconclusive).toBe(true);
+  });
+});
+
+describe('describeCancellation', () => {
+  it('confirms a reversal only when the booking actually left the list', () => {
+    const v = describeCancellation({ cancel: { status: 200 }, countBefore: 1, countAfter: 0 });
+    expect(v.reversed).toBe(true);
+  });
+
+  it('reports a 2xx that changed nothing as a failure, not a success', () => {
+    // #46 plans to rely on DELETE to undo a mistaken bulk booking, so a false
+    // "reversible" is worse than no answer at all.
+    const v = describeCancellation({ cancel: { status: 200 }, countBefore: 1, countAfter: 1 });
+    expect(v.reversed).toBe(false);
+    expect(v.summary).toMatch(/still there/);
+  });
+
+  it('reports a rejected DELETE as a booking that must be removed by hand', () => {
+    const v = describeCancellation({ cancel: { status: 403 }, countBefore: 1, countAfter: 1 });
+    expect(v.reversed).toBe(false);
+    expect(v.summary).toMatch(/removed by hand/);
+  });
+
+  it('will not judge a cancellation nobody re-counted', () => {
+    const v = describeCancellation({ cancel: { status: 200 } });
+    expect(v.inconclusive).toBe(true);
+    expect(v.reversed).toBeNull();
+  });
+
+  it('distinguishes a local refusal from an attempt', () => {
+    expect(describeCancellation({ cancel: { refused: 'nope' } }).summary).toMatch(/refused locally/);
+    expect(describeCancellation({}).summary).toMatch(/no cancellation was attempted/);
+  });
+});
+
+describe('pickBookableEvents', () => {
+  const NOW = '2026-08-18T00:00:00Z';
+  const event = (over = {}) => ({
+    event_id: 1,
+    event_name: 'Open Climb',
+    event_start_at: '2026-08-20T09:00:00Z',
+    spaces_available: 10,
+    event_full: false,
+    free_class: false,
+    ...over,
+  });
+
+  it('separates free events from paid ones, so question 2 has its comparison', () => {
+    const v = pickBookableEvents([event(), event({ event_id: 2, free_class: true })], { now: NOW });
+    expect(v.paid.map(e => e.event_id)).toEqual([1]);
+    expect(v.free.map(e => e.event_id)).toEqual([2]);
+  });
+
+  it('skips events in the past — nobody should be waiting in a gym for a Ztest', () => {
+    const v = pickBookableEvents([event({ event_start_at: '2026-08-01T09:00:00Z' })], { now: NOW });
+    expect(v.paid).toHaveLength(0);
+    expect(v.skipped).toBe(1);
+  });
+
+  it('skips full events and events with no spaces left', () => {
+    // Consuming the last space would cause #46's own worst case: a school group
+    // arriving at an event with fewer spaces than students.
+    const v = pickBookableEvents(
+      [event({ event_full: true }), event({ event_id: 2, spaces_available: 0 })],
+      { now: NOW },
+    );
+    expect(v.paid).toHaveLength(0);
+    expect(v.skipped).toBe(2);
+  });
+
+  it('orders by start time, so the soonest usable event is first', () => {
+    const v = pickBookableEvents(
+      [
+        event({ event_id: 1, event_start_at: '2026-09-01T09:00:00Z' }),
+        event({ event_id: 2, event_start_at: '2026-08-19T09:00:00Z' }),
+      ],
+      { now: NOW },
+    );
+    expect(v.paid.map(e => e.event_id)).toEqual([2, 1]);
+  });
+
+  it('survives a non-array body', () => {
+    expect(pickBookableEvents(null)).toEqual({ free: [], paid: [], skipped: 0 });
   });
 });

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -12,6 +12,7 @@ import {
   classifyWrite,
   schemeCollapses,
   summariseBookings,
+  errorMessageOf,
   describeBookingRequirement,
   describeDuplicateBooking,
   describeCancellation,
@@ -457,6 +458,39 @@ describe('summariseBookings', () => {
   it('survives a non-array body', () => {
     expect(summariseBookings(null).notAnArray).toBe(true);
     expect(summariseBookings('<html>').count).toBe(0);
+  });
+});
+
+describe('errorMessageOf', () => {
+  it('reads a plain string error — the shape Clubworx actually answers with', () => {
+    expect(errorMessageOf({ error: 'Contact has no active membership' })).toBe(
+      'Contact has no active membership',
+    );
+  });
+
+  it('joins a list of errors', () => {
+    expect(errorMessageOf({ errors: ['too late', 'no spaces'] })).toBe('too late; no spaces');
+  });
+
+  it('flattens field → messages, the Rails shape', () => {
+    expect(errorMessageOf({ errors: { base: ['not permitted'], event: 'is full' } })).toBe(
+      'base: not permitted; event: is full',
+    );
+  });
+
+  it('truncates rather than recording an unbounded body', () => {
+    const v = errorMessageOf({ error: 'x'.repeat(500) }, { limit: 20 });
+    expect(v).toHaveLength(21); // 20 + the ellipsis
+    expect(v.endsWith('…')).toBe(true);
+  });
+
+  it('returns null when there is no error to read', () => {
+    // It must never fall back to serialising the whole body — that is how a row
+    // of production data would end up in probes/out/.
+    expect(errorMessageOf({ booking_id: 'bk-1', contact_key: 'ck-real' })).toBeNull();
+    expect(errorMessageOf(null)).toBeNull();
+    expect(errorMessageOf('<html>')).toBeNull();
+    expect(errorMessageOf({ error: '   ' })).toBeNull();
   });
 });
 

--- a/cloudflare-clubworx/probes/run-50.mjs
+++ b/cloudflare-clubworx/probes/run-50.mjs
@@ -11,13 +11,14 @@
  * ⚠️ `--write` puts a real booking on a real class that staff can see, and
  * consumes one of its spaces.
  *
- * **It cannot take it back.** This probe set out assuming it could — ACCESS.md
- * recorded bookings as the one reversible write on this map, because
- * `DELETE /bookings/:id` is in the reference. Question 4 measured it on
- * 2026-08-18: **HTTP 401 "Authorization failed"**, from the same key that reads
- * at 200 and reaches business validation on POST. So a booking is as permanent
- * as a contact, and the run prints anything it could not undo — which is
- * everything it creates.
+ * **Do not count on taking it back.** `DELETE /bookings/:id` is in the
+ * reference, but #50 never demonstrated it working. What it did establish is
+ * that the endpoint needs **`contact_key` as well as `account_key`**,
+ * form-encoded in the body: without it the answer is `401 "Authorization
+ * failed"`, which is indistinguishable from a key that may not delete — and was
+ * misread as exactly that. `cancel` now sends both, taking the contact from the
+ * booking record so it cannot be forgotten, but nothing has re-run it against a
+ * live booking. Treat every booking as permanent until that changes.
  *
  * **The event is never chosen automatically.** `--event` is required for a
  * write, because picking one by algorithm means a booking lands on whichever
@@ -446,9 +447,9 @@ function printDryRun() {
     `\n${n} requests, paced at one per ${GAP_MS}ms (~${Math.round(60_000 / GAP_MS)}/min), per #51.`,
   );
   console.log(
-    '⚠️  A booking this run creates CANNOT be undone. It attempts a cancel, but\n' +
-      '    DELETE /bookings/:id answers 401 for this key (#50, measured) — so every\n' +
-      '    booking below is permanent until somebody clears it in the Clubworx UI.\n' +
+    '⚠️  Treat a booking this run creates as permanent. It attempts a cancel, but\n' +
+      '    DELETE /bookings/:id has never been demonstrated to work here (#50) — so\n' +
+      '    assume anything booked below is cleared by hand in the Clubworx UI.\n' +
       'Contacts are reused from #49 and never created — ACCESS.md §4, the\n' +
       'three-contact authorisation is spent.',
   );

--- a/cloudflare-clubworx/probes/run-50.mjs
+++ b/cloudflare-clubworx/probes/run-50.mjs
@@ -9,10 +9,15 @@
  *   node probes/run-50.mjs --dev-vars=<path>
  *
  * ⚠️ `--write` puts a real booking on a real class that staff can see, and
- * consumes one of its spaces until the run cancels it again. Unlike #49's
- * contacts this **is** reversible (`DELETE /bookings/:id`, ACCESS.md section 4)
- * — that reversibility is question 4, so the run proves it rather than assuming
- * it, and prints anything it could not undo.
+ * consumes one of its spaces.
+ *
+ * **It cannot take it back.** This probe set out assuming it could — ACCESS.md
+ * recorded bookings as the one reversible write on this map, because
+ * `DELETE /bookings/:id` is in the reference. Question 4 measured it on
+ * 2026-08-18: **HTTP 401 "Authorization failed"**, from the same key that reads
+ * at 200 and reaches business validation on POST. So a booking is as permanent
+ * as a contact, and the run prints anything it could not undo — which is
+ * everything it creates.
  *
  * **The event is never chosen automatically.** `--event` is required for a
  * write, because picking one by algorithm means a booking lands on whichever
@@ -95,6 +100,7 @@ const DRY_RUN = args.includes('--dry-run');
 const WRITE = args.includes('--write');
 const EVENT_ID = flag('event') ?? null;
 const FREE_EVENT_ID = flag('free-event') ?? null;
+const CANCEL_ID = flag('cancel') ?? null;
 const DEV_VARS = flag('dev-vars') || path.join(HERE, '..', '.dev.vars');
 
 /** The two plus-tags #49 created, derived rather than restated. */
@@ -180,6 +186,81 @@ async function listEvents(get) {
   }
 
   return { summary, bookable, status: res.status };
+}
+
+/**
+ * Cancel a booking that already exists on a probe contact.
+ *
+ * The cleanup path, and the one place `allowCancel` is used. A booking made by
+ * hand in the Clubworx UI is not one this process created, so `cancel` will not
+ * touch it until it has been **found on a probe contact** — which is why this
+ * searches for it rather than taking the id on trust. An id alone would let any
+ * booking through, including a real member's.
+ *
+ * It also answers question 4 without creating anything, when the UI has already
+ * left a booking behind.
+ */
+async function cancelExisting(get, booker, { contacts, bookingId, accountKey }) {
+  rule(`Cancel booking ${bookingId} (Q4)`);
+
+  const reasonOf = sample => {
+    const message = errorMessageOf(sample?.body);
+    return message ? redact(message, accountKey) : null;
+  };
+
+  for (const contact of contacts) {
+    const held = await countBookings(get, contact.contact_key);
+    const found = held.ids.includes(String(bookingId));
+    line(
+      `${contact.last_name} holds`,
+      `${held.ours} booking(s)${found ? ' — including this one' : ''}`,
+    );
+    await sleep(GAP_MS);
+
+    if (!found) continue;
+
+    // Vouched for only now that it has been seen on a contact that passed the
+    // identity guard. This is the whole reason allowCancel takes a contact key.
+    booker.allowCancel(bookingId, contact.contact_key);
+
+    const res = await booker.cancel(bookingId);
+    line(
+      'DELETE',
+      res.refused
+        ? `REFUSED locally: ${res.refused}`
+        : res.dryRun
+          ? 'would DELETE — pass --write to do it'
+          : `HTTP ${res.status ?? 'n/a'}${res.error ? ` · ${res.error}` : ''}` +
+            (reasonOf(res) ? ` · "${reasonOf(res)}"` : '') +
+            (res.bodyText ? ` · ${res.bodyText.slice(0, 200)}` : ''),
+    );
+    if (!res.dryRun) await sleep(GAP_MS);
+
+    const after = await countBookings(get, contact.contact_key);
+    line('bookings held after', `HTTP ${after.status} · ${after.ours}`);
+
+    // Judged on the re-count, never on the status: a 2xx that removed nothing
+    // is a failure, and #46 plans to rely on this to undo a mistaken bulk
+    // booking.
+    const reversal = describeCancellation({
+      cancel: res,
+      countBefore: held.ours,
+      countAfter: after.ours,
+    });
+
+    rule('Verdict');
+    line('Q4  DELETE reverses a booking', String(reversal.reversed));
+    console.log(`  ${reversal.summary}`);
+
+    return { bookingId, contact_key: contact.contact_key, reversal, status: res.status ?? null, reason: reasonOf(res), bodyText: res.bodyText ?? null, counts: { before: held.ours, after: after.ours } };
+  }
+
+  console.log(
+    `\n  Booking ${bookingId} is not held by any probe contact, so it will not be\n` +
+      '  cancelled. Cancelling a real member\'s class is the worst outcome available\n' +
+      '  on this map, and an id alone is not evidence of whose booking it is.',
+  );
+  return { bookingId, contact_key: null, reversal: null, refused: 'not held by a probe contact' };
 }
 
 /** Bookings currently held by a probe contact — the before/after count. */
@@ -365,8 +446,11 @@ function printDryRun() {
     `\n${n} requests, paced at one per ${GAP_MS}ms (~${Math.round(60_000 / GAP_MS)}/min), per #51.`,
   );
   console.log(
-    'Every booking this run creates, it also cancels. Contacts are reused from\n' +
-      '#49 and never created — ACCESS.md §4, the three-contact authorisation is spent.',
+    '⚠️  A booking this run creates CANNOT be undone. It attempts a cancel, but\n' +
+      '    DELETE /bookings/:id answers 401 for this key (#50, measured) — so every\n' +
+      '    booking below is permanent until somebody clears it in the Clubworx UI.\n' +
+      'Contacts are reused from #49 and never created — ACCESS.md §4, the\n' +
+      'three-contact authorisation is spent.',
   );
 }
 
@@ -401,6 +485,30 @@ async function main() {
         '  there, and ask before creating anything.',
     );
     process.exitCode = 1;
+    return;
+  }
+
+  // The cleanup path. It needs no event list, so it runs before one is fetched.
+  if (CANCEL_ID) {
+    const booker = createBooker({
+      accountKey,
+      allowedContactKeys: contacts.map(c => c.contact_key),
+      live: WRITE,
+    });
+
+    record.cancelled = await cancelExisting(get, booker, {
+      contacts,
+      bookingId: CANCEL_ID,
+      accountKey,
+    });
+    if (!WRITE) console.log('\n  Read-only run — nothing was cancelled. Re-run with --write.');
+
+    mkdirSync(OUT_DIR, { recursive: true });
+    const outFile = path.join(OUT_DIR, `50-cancel-${record.ranAt.replace(/[:.]/g, '-')}.json`);
+    writeFileSync(outFile, JSON.stringify(record, null, 2));
+    console.log(
+      `\n${get.calls} reads, ${booker.cancel.writes} writes. Summary written to probes/out/${path.basename(outFile)}`,
+    );
     return;
   }
 

--- a/cloudflare-clubworx/probes/run-50.mjs
+++ b/cloudflare-clubworx/probes/run-50.mjs
@@ -81,7 +81,9 @@ import {
   describeDuplicateBooking,
   describeCancellation,
   pickBookableEvents,
+  errorMessageOf,
 } from './lib/report.mjs';
+import { redact } from './lib/request.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(HERE, 'out');
@@ -194,8 +196,15 @@ async function countBookings(get, contactKey) {
  * silent duplicate and an idempotent server return the same status code, and so
  * do a DELETE that worked and one that only said it did.
  */
-async function probeBooking(get, booker, { contactKey, eventId, label }) {
+async function probeBooking(get, booker, { contactKey, eventId, label, accountKey }) {
   rule(`${label} — event ${eventId}`);
+
+  // Why the server refused is the answer to question 2, and it exists nowhere
+  // else. Redacted on the way out like every other string this probe prints.
+  const reasonOf = sample => {
+    const message = errorMessageOf(sample?.body);
+    return message ? redact(message, accountKey) : null;
+  };
 
   const before = await countBookings(get, contactKey);
   line('bookings held before', `HTTP ${before.status} · ${before.ours}`);
@@ -212,6 +221,7 @@ async function probeBooking(get, booker, { contactKey, eventId, label }) {
         : `HTTP ${first.status ?? 'n/a'} ${firstClass.outcome}` +
           (first.bookingId ? ` · booking ${first.bookingId}` : '') +
           (first.error ? ` · ${first.error}` : '') +
+          (reasonOf(first) ? ` · "${reasonOf(first)}"` : '') +
           (first.bodyText ? ` · ${first.bodyText.slice(0, 160)}` : ''),
   );
   if (!first.dryRun) await sleep(GAP_MS);
@@ -235,6 +245,7 @@ async function probeBooking(get, booker, { contactKey, eventId, label }) {
         ? `REFUSED locally: ${second.refused}`
         : `HTTP ${second.status ?? 'n/a'} ${secondClass.outcome}` +
           (second.bookingId ? ` · booking ${second.bookingId}` : '') +
+          (reasonOf(second) ? ` · "${reasonOf(second)}"` : '') +
           (second.bodyText ? ` · ${second.bodyText.slice(0, 160)}` : ''),
     );
     await sleep(GAP_MS);
@@ -289,9 +300,13 @@ async function probeBooking(get, booker, { contactKey, eventId, label }) {
       bookingId: first.bookingId ?? null,
       refused: first.refused ?? null,
       error: first.error ?? null,
+      // The server's own words. Without this a rejection is just "HTTP 400",
+      // and question 2 has nothing to work from.
+      reason: reasonOf(first),
       bodyText: first.bodyText ?? null,
       fields: first.body && !Array.isArray(first.body) ? Object.keys(first.body) : [],
     },
+    secondReason: second ? reasonOf(second) : null,
     second: secondClass,
     counts: {
       before: before.ours,
@@ -466,6 +481,7 @@ async function main() {
       contactKey: subject.contact_key,
       eventId: EVENT_ID,
       label: '2. Paid event (Q1, Q3, Q4)',
+      accountKey,
     });
   }
 
@@ -478,6 +494,7 @@ async function main() {
       contactKey: subject.contact_key,
       eventId: FREE_EVENT_ID,
       label: '3. free_class event (Q2)',
+      accountKey,
     });
   } else if (FREE_EVENT_ID) {
     rule('3. free_class event (Q2) — SKIPPED');
@@ -505,6 +522,7 @@ async function main() {
 
     rule('Verdicts');
     line('Q1  membership-less prospect books', String(record.paid?.outcome?.outcome ?? 'not attempted'));
+    if (record.paid?.first?.reason) line('    the server said', `"${record.paid.first.reason}"`);
     line('Q2  what it requires', requirement.requirement ?? 'inconclusive');
     line('Q3  double-booking', record.paid?.duplicate?.summary ?? 'not asked');
     line('Q4  DELETE reverses it', record.paid?.reversal?.summary ?? 'not asked');

--- a/cloudflare-clubworx/probes/run-50.mjs
+++ b/cloudflare-clubworx/probes/run-50.mjs
@@ -1,0 +1,513 @@
+#!/usr/bin/env node
+/**
+ * staff-site#50 — can a membership-less prospect be booked into an event?
+ *
+ *   node probes/run-50.mjs --dry-run           # the plan and every request, zero network
+ *   node probes/run-50.mjs                     # read-only: find the contacts, list bookable events
+ *   node probes/run-50.mjs --event=<id> --write # books, double-books, then cancels
+ *   node probes/run-50.mjs --event=<id> --free-event=<id> --write
+ *   node probes/run-50.mjs --dev-vars=<path>
+ *
+ * ⚠️ `--write` puts a real booking on a real class that staff can see, and
+ * consumes one of its spaces until the run cancels it again. Unlike #49's
+ * contacts this **is** reversible (`DELETE /bookings/:id`, ACCESS.md section 4)
+ * — that reversibility is question 4, so the run proves it rather than assuming
+ * it, and prints anything it could not undo.
+ *
+ * **The event is never chosen automatically.** `--event` is required for a
+ * write, because picking one by algorithm means a booking lands on whichever
+ * class happened to sort first — a real session, with real staff and real
+ * customers. A read-only run lists the candidates for a human to choose from.
+ *
+ * Four questions, all from #46's map. The whole feature assumes the answer to
+ * the first is yes, and nothing in the API reference settles it:
+ *
+ *   1. Does booking a membership-less prospect succeed at all?
+ *   2. If not, what does it need — a membership, a plan, or an event flagged
+ *      `free_class`?
+ *   3. Does booking the same contact into the same event twice error, or
+ *      silently create a second booking? #46's safety model assumes re-running
+ *      the tool is idempotent.
+ *   4. Does `DELETE /bookings/:id` cleanly reverse a booking made this way?
+ *
+ * This probe **creates no contacts**. ACCESS.md section 4: the three-contact
+ * authorisation is spent, and #50 must reuse what #49 left behind. If those
+ * contacts are missing the run stops rather than creating a fourth.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createGetter } from './lib/http.mjs';
+import { createBooker } from './lib/booking.mjs';
+import { loadAccountKey } from './lib/key.mjs';
+import { PROBE_CONTACTS, pickProbeRows, plusTag } from './lib/identity.mjs';
+import {
+  summariseContacts,
+  summariseBookings,
+  summariseEvents,
+  classifyWrite,
+  describeBookingRequirement,
+  describeDuplicateBooking,
+  describeCancellation,
+  pickBookableEvents,
+} from './lib/report.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(HERE, 'out');
+
+const args = process.argv.slice(2);
+const flag = name => args.find(a => a.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+
+const DRY_RUN = args.includes('--dry-run');
+const WRITE = args.includes('--write');
+const EVENT_ID = flag('event') ?? null;
+const FREE_EVENT_ID = flag('free-event') ?? null;
+const DEV_VARS = flag('dev-vars') || path.join(HERE, '..', '.dev.vars');
+
+/** The two plus-tags #49 created, derived rather than restated. */
+const TAG_EMAILS = [...new Set(PROBE_CONTACTS.map(c => c.email))];
+
+/**
+ * How far ahead to look for a bookable event.
+ *
+ * #51: the date window is the one genuinely required parameter on `/events`
+ * (no window is HTTP 422), and a full page is silent truncation — so this asks
+ * for a narrow window and a page big enough to see past the default 50.
+ */
+const WINDOW_DAYS = 14;
+const PAGE_SIZE = 200;
+
+/** 75 requests/minute, one in flight — the ceiling measured in #51. */
+const GAP_MS = 800;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const line = (label, value) => console.log(`  ${label.padEnd(38)} ${value}`);
+const rule = title => console.log(`\n── ${title} ${'─'.repeat(Math.max(0, 58 - title.length))}`);
+
+const isoDay = offsetDays => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+};
+
+/**
+ * Find the contacts #49 left behind. This probe may not create any.
+ *
+ * Everything returned has passed `isProbeRow` via `pickProbeRows`, which is
+ * what makes it safe to hand these keys to the booker as its allowlist — a
+ * stranger who happens to share the probe address is counted and dropped.
+ */
+async function findProbeContacts(get) {
+  rule('0. Find the contacts #49 created — this probe creates none');
+
+  const found = [];
+  let strangers = 0;
+
+  for (const email of TAG_EMAILS) {
+    const res = await get('prospects', { email });
+    const rows = pickProbeRows(res.body);
+    const summary = summariseContacts(
+      res.body,
+      rows.map(r => r.contact_key),
+    );
+    found.push(...rows);
+    strangers += summary.strangers;
+
+    line(
+      `prospects email=+${plusTag(email)}`,
+      `HTTP ${res.status} · ${summary.count} returned · ${rows.length} are ours`,
+    );
+    await sleep(GAP_MS);
+  }
+
+  if (strangers) line('rows returned that are not ours', `${strangers} (counted, not recorded)`);
+
+  const byKey = new Map(found.map(row => [row.contact_key, row]));
+  return [...byKey.values()];
+}
+
+/** What is bookable in the next fortnight, for a human to choose from. */
+async function listEvents(get) {
+  rule('1. Events — which of these could a test booking go on?');
+
+  const res = await get('events', {
+    event_starts_after: isoDay(0),
+    event_ends_before: isoDay(WINDOW_DAYS),
+    page_size: PAGE_SIZE,
+  });
+  const summary = summariseEvents(res.body);
+  const bookable = pickBookableEvents(res.body);
+
+  line('events in the window', `HTTP ${res.status} · ${summary.count} returned`);
+  line('bookable (future, with spaces)', `${bookable.paid.length} paid · ${bookable.free.length} free_class`);
+  if (summary.count >= PAGE_SIZE) {
+    // #51: a full page is indistinguishable from a complete list by anything in
+    // the response — no total, no next-page link, no header.
+    line('⚠️  page came back full', 'the list is truncated — narrow the window');
+  }
+
+  return { summary, bookable, status: res.status };
+}
+
+/** Bookings currently held by a probe contact — the before/after count. */
+async function countBookings(get, contactKey) {
+  const res = await get('bookings', { contact_key: contactKey });
+  const summary = summariseBookings(res.body, [contactKey]);
+  return { status: res.status, ...summary };
+}
+
+/**
+ * Questions 1–4, against one event.
+ *
+ * The counts either side of every write are what actually answer 3 and 4: a
+ * silent duplicate and an idempotent server return the same status code, and so
+ * do a DELETE that worked and one that only said it did.
+ */
+async function probeBooking(get, booker, { contactKey, eventId, label }) {
+  rule(`${label} — event ${eventId}`);
+
+  const before = await countBookings(get, contactKey);
+  line('bookings held before', `HTTP ${before.status} · ${before.ours}`);
+  await sleep(GAP_MS);
+
+  const first = await booker.book({ contact_key: contactKey, event_id: eventId, label });
+  const firstClass = classifyWrite(first);
+  line(
+    'book (Q1)',
+    first.refused
+      ? `REFUSED locally: ${first.refused}`
+      : first.dryRun
+        ? `would POST ${JSON.stringify(first.wouldSend)}`
+        : `HTTP ${first.status ?? 'n/a'} ${firstClass.outcome}` +
+          (first.bookingId ? ` · booking ${first.bookingId}` : '') +
+          (first.error ? ` · ${first.error}` : '') +
+          (first.bodyText ? ` · ${first.bodyText.slice(0, 160)}` : ''),
+  );
+  if (!first.dryRun) await sleep(GAP_MS);
+
+  const afterFirst = await countBookings(get, contactKey);
+  line('bookings held after', `HTTP ${afterFirst.status} · ${afterFirst.ours}`);
+  await sleep(GAP_MS);
+
+  // Question 3 only means something if the first booking landed. Asking it
+  // after a rejection would measure two rejections and call it idempotency.
+  let second = null;
+  let secondClass = null;
+  let afterSecond = null;
+
+  if (firstClass.outcome === 'created') {
+    second = await booker.book({ contact_key: contactKey, event_id: eventId, label: `${label} again` });
+    secondClass = classifyWrite(second);
+    line(
+      'book the same again (Q3)',
+      second.refused
+        ? `REFUSED locally: ${second.refused}`
+        : `HTTP ${second.status ?? 'n/a'} ${secondClass.outcome}` +
+          (second.bookingId ? ` · booking ${second.bookingId}` : '') +
+          (second.bodyText ? ` · ${second.bodyText.slice(0, 160)}` : ''),
+    );
+    await sleep(GAP_MS);
+
+    afterSecond = await countBookings(get, contactKey);
+    line('bookings held after the second', `HTTP ${afterSecond.status} · ${afterSecond.ours}`);
+    await sleep(GAP_MS);
+  } else if (!first.dryRun) {
+    line('book the same again (Q3)', 'SKIPPED — the first booking did not land');
+  }
+
+  const duplicate = describeDuplicateBooking({
+    second: secondClass,
+    countBefore: afterFirst.ours,
+    countAfter: afterSecond?.ours ?? null,
+  });
+
+  // Question 4: undo everything this run created, and prove it left.
+  const cancellations = [];
+  const ids = [first.bookingId, second?.bookingId].filter(Boolean);
+  const uniqueIds = [...new Set(ids.map(String))];
+
+  for (const id of uniqueIds) {
+    const res = await booker.cancel(id);
+    cancellations.push({ id, status: res.status ?? null, refused: res.refused ?? null, error: res.error ?? null });
+    line(
+      `cancel ${id} (Q4)`,
+      res.refused
+        ? `REFUSED locally: ${res.refused}`
+        : res.dryRun
+          ? 'would DELETE'
+          : `HTTP ${res.status ?? 'n/a'}${res.error ? ` · ${res.error}` : ''}`,
+    );
+    if (!res.dryRun) await sleep(GAP_MS);
+  }
+
+  const afterCancel = uniqueIds.length ? await countBookings(get, contactKey) : null;
+  if (afterCancel) line('bookings held after cancelling', `HTTP ${afterCancel.status} · ${afterCancel.ours}`);
+
+  const lastCancel = cancellations[cancellations.length - 1] ?? null;
+  const reversal = describeCancellation({
+    cancel: lastCancel,
+    countBefore: afterSecond?.ours ?? afterFirst.ours,
+    countAfter: afterCancel?.ours ?? null,
+  });
+
+  return {
+    eventId,
+    outcome: firstClass,
+    first: {
+      status: first.status ?? null,
+      bookingId: first.bookingId ?? null,
+      refused: first.refused ?? null,
+      error: first.error ?? null,
+      bodyText: first.bodyText ?? null,
+      fields: first.body && !Array.isArray(first.body) ? Object.keys(first.body) : [],
+    },
+    second: secondClass,
+    counts: {
+      before: before.ours,
+      afterFirst: afterFirst.ours,
+      afterSecond: afterSecond?.ours ?? null,
+      afterCancel: afterCancel?.ours ?? null,
+    },
+    duplicate,
+    cancellations,
+    reversal,
+    // Anything still standing when the run ends is somebody's job to remove.
+    leftBehind: (afterCancel?.ours ?? 0) > before.ours,
+  };
+}
+
+function printDryRun() {
+  console.log('--dry-run: no requests issued, nothing booked.\n');
+
+  let n = 0;
+  const req = (verb, p, params) =>
+    console.log(`  ${String(++n).padStart(2)}. ${verb.padEnd(6)} /${p}${params ? `?${params}` : ''}`);
+
+  console.log('0. Find #49\'s contacts — this probe creates none:');
+  for (const email of TAG_EMAILS) req('GET', 'prospects', `email=${email}`);
+
+  console.log('\n1. Events in the next fortnight:');
+  req('GET', 'events', `event_starts_after=${isoDay(0)}&event_ends_before=${isoDay(WINDOW_DAYS)}&page_size=${PAGE_SIZE}`);
+
+  const plan = [['2. Paid event (Q1, Q3, Q4)', EVENT_ID], ['3. free_class event (Q2)', FREE_EVENT_ID]].filter(
+    ([, id]) => id,
+  );
+
+  if (!plan.length) {
+    console.log(
+      '\n2. Booking — NOTHING PLANNED.\n' +
+        '   No --event=<id> was given, so there is no booking to describe. Run\n' +
+        '   read-only first: it lists the events that could take a test booking,\n' +
+        '   and a human picks one. The event is never chosen automatically.',
+    );
+  }
+
+  for (const [title, id] of plan) {
+    console.log(`\n${title} — event ${id}:`);
+    req('GET', 'bookings', 'contact_key=<probe contact>');
+    req('POST', 'bookings');
+    console.log('        { contact_key: <probe contact>, event_id: ' + id + ' }');
+    req('GET', 'bookings', 'contact_key=<probe contact>');
+    req('POST', 'bookings');
+    console.log('        the same again — does it duplicate? (Q3)');
+    req('GET', 'bookings', 'contact_key=<probe contact>');
+    req('DELETE', `bookings/<id created above>`);
+    req('GET', 'bookings', 'contact_key=<probe contact>');
+  }
+
+  console.log(
+    `\n${n} requests, paced at one per ${GAP_MS}ms (~${Math.round(60_000 / GAP_MS)}/min), per #51.`,
+  );
+  console.log(
+    'Every booking this run creates, it also cancels. Contacts are reused from\n' +
+      '#49 and never created — ACCESS.md §4, the three-contact authorisation is spent.',
+  );
+}
+
+async function main() {
+  if (DRY_RUN) {
+    printDryRun();
+    return;
+  }
+
+  const accountKey = loadAccountKey(DEV_VARS);
+  const get = createGetter({ accountKey });
+
+  console.log(
+    WRITE
+      ? 'staff-site#50 probe — WRITES ENABLED, against production Clubworx'
+      : 'staff-site#50 probe — read-only. It lists what could be booked; pass --event=<id> --write to book.',
+  );
+
+  const record = { probe: 'staff-site#50', ranAt: new Date().toISOString(), write: WRITE };
+
+  const contacts = await findProbeContacts(get);
+  record.contacts = contacts.map(c => ({ contact_key: c.contact_key, last_name: c.last_name }));
+
+  if (!contacts.length) {
+    // ACCESS.md §4: the three-contact authorisation is spent. Creating a fourth
+    // is a new decision, not something a probe may take on its own.
+    rule('Stopped');
+    console.log(
+      '  No probe contacts found. #50 must reuse the three #49 created, and the\n' +
+        '  authorisation to create contacts is spent (ACCESS.md §4) — so this probe\n' +
+        '  will not create a fourth. Run `node probes/run-49.mjs` to check what is\n' +
+        '  there, and ask before creating anything.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Contact A is the baseline: a prospect with no membership and no class pass.
+  const subject = contacts[0];
+  line('booking as', `${subject.last_name} · ${subject.contact_key}`);
+  await sleep(GAP_MS);
+
+  const events = await listEvents(get);
+  record.events = {
+    status: events.status,
+    count: events.summary.count,
+    fields: events.summary.fields,
+    bookable: { paid: events.bookable.paid.length, free: events.bookable.free.length },
+  };
+
+  const show = (title, list) => {
+    console.log(`\n  ${title}`);
+    if (!list.length) {
+      console.log('    none in this window');
+      return;
+    }
+    for (const e of list.slice(0, 8)) {
+      console.log(
+        `    event_id ${String(e.event_id).padEnd(10)} ${String(e.event_start_at).slice(0, 16)}  ` +
+          `${String(e.spaces_available).padStart(3)} spaces  ${e.event_name ?? ''}`,
+      );
+    }
+    if (list.length > 8) console.log(`    … and ${list.length - 8} more`);
+  };
+
+  if (!WRITE) {
+    show('Paid events that could take a test booking:', events.bookable.paid);
+    show('free_class events (needed for Q2):', events.bookable.free);
+    console.log(
+      '\n  Read-only run — nothing was booked. Pick an event above and re-run:\n' +
+        '    node probes/run-50.mjs --event=<id> --write\n' +
+        '  Add --free-event=<id> to answer Q2 if the paid booking is rejected.',
+    );
+    record.candidates = events.bookable;
+  }
+
+  const booker = createBooker({
+    accountKey,
+    allowedContactKeys: contacts.map(c => c.contact_key),
+    live: WRITE,
+  });
+
+  if (WRITE && !EVENT_ID) {
+    rule('Stopped');
+    console.log(
+      '  --write needs --event=<id>. The event is never chosen automatically:\n' +
+        '  a booking lands on a real class that staff see, and picking one by\n' +
+        '  sort order means picking somebody\'s actual session. Run without\n' +
+        '  --write to list the candidates.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (EVENT_ID) {
+    record.paid = await probeBooking(get, booker, {
+      contactKey: subject.contact_key,
+      eventId: EVENT_ID,
+      label: '2. Paid event (Q1, Q3, Q4)',
+    });
+  }
+
+  // Question 2 only needs asking if question 1 failed. Booking a second event
+  // after a success is a booking nobody needed.
+  const paidRejected = record.paid?.outcome?.outcome === 'rejected';
+
+  if (FREE_EVENT_ID && paidRejected) {
+    record.free = await probeBooking(get, booker, {
+      contactKey: subject.contact_key,
+      eventId: FREE_EVENT_ID,
+      label: '3. free_class event (Q2)',
+    });
+  } else if (FREE_EVENT_ID) {
+    rule('3. free_class event (Q2) — SKIPPED');
+    console.log('  The paid booking was not rejected, so there is nothing for free_class to explain.');
+  } else if (paidRejected) {
+    rule('3. free_class event (Q2) — NOT ASKED');
+    console.log(
+      '  The paid booking was rejected and no --free-event=<id> was given, so\n' +
+        '  what a booking requires is UNANSWERED. Re-run with --free-event to tell\n' +
+        '  "free classes only" from "an entitlement is required" — they change the\n' +
+        '  tool in very different ways.',
+    );
+  }
+
+  if (EVENT_ID) {
+    const requirement = describeBookingRequirement({
+      paid: record.paid?.outcome ?? null,
+      free: record.free?.outcome ?? null,
+    });
+    record.verdicts = {
+      requirement,
+      duplicate: record.paid?.duplicate ?? null,
+      reversal: record.paid?.reversal ?? null,
+    };
+
+    rule('Verdicts');
+    line('Q1  membership-less prospect books', String(record.paid?.outcome?.outcome ?? 'not attempted'));
+    line('Q2  what it requires', requirement.requirement ?? 'inconclusive');
+    line('Q3  double-booking', record.paid?.duplicate?.summary ?? 'not asked');
+    line('Q4  DELETE reverses it', record.paid?.reversal?.summary ?? 'not asked');
+
+    if (requirement.entitlementNeeded) {
+      // #50: "Flag that loudly rather than absorbing it."
+      console.log(
+        `\n  ⚠️  ${requirement.summary}.\n` +
+          '      #46\'s tool would have to assign a membership plan as well as create a\n' +
+          '      contact — a new decision about cost, plan choice, and what that does to\n' +
+          '      Clubworx reporting. This is not a detail to absorb into the design.',
+      );
+    }
+
+    if (record.paid?.duplicate?.duplicated) {
+      console.log(
+        '\n  ⚠️  Booking the same contact into the same event twice creates TWO bookings.\n' +
+          '      Re-running the tool against an event double-books every student, so it\n' +
+          '      must check existing bookings before writing — the safety model assumed\n' +
+          '      the server would refuse.',
+      );
+    }
+
+    const stranded = [record.paid, record.free].filter(r => r?.leftBehind);
+    if (stranded.length) {
+      rule('⚠️  Cleanup — bookings this run could not undo');
+      for (const r of stranded) {
+        console.log(
+          `  event ${r.eventId}: ${r.counts.afterCancel} booking(s) still held by ` +
+            `${subject.last_name} (${subject.contact_key}).\n` +
+            '  Remove them in the Clubworx UI.',
+        );
+      }
+    }
+  }
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `50-${record.ranAt.replace(/[:.]/g, '-')}.json`);
+  writeFileSync(file, JSON.stringify(record, null, 2));
+
+  const writes = booker.book.writes + booker.cancel.writes;
+  console.log(
+    `\n${get.calls} reads, ${writes} writes. Summary written to probes/out/${path.basename(file)}`,
+  );
+}
+
+main().catch(err => {
+  console.error(`probe failed: ${err.message}`);
+  process.exitCode = 1;
+});

--- a/cloudflare-clubworx/probes/run-50.mjs
+++ b/cloudflare-clubworx/probes/run-50.mjs
@@ -33,6 +33,35 @@
  * This probe **creates no contacts**. ACCESS.md section 4: the three-contact
  * authorisation is spent, and #50 must reuse what #49 left behind. If those
  * contacts are missing the run stops rather than creating a fourth.
+ *
+ * ## The answer is per-event, and the API does not show why
+ *
+ * A school session at UJ is normally configured to accept a **limited number of
+ * prospects** — that limit is what stops somebody booking themselves into a
+ * school group by accident on the day, and allowing prospects at all is what
+ * means a student needs no membership (Jiri, 2026-08-18). So questions 1 and 2
+ * are not properties of the API: they are properties of *the event booked into*.
+ *
+ * That matters twice over.
+ *
+ * **`GET /events` does not expose it.** The fields are `event_id`,
+ * `event_name`, `event_start_at`, `event_end_at`, `location_id`,
+ * `location_name`, `free_class`, `instructor_name`, `event_full`,
+ * `spaces_available` and `event_description` — verified against production on
+ * 2026-08-18, and there is no prospect allowance among them. #46's picker
+ * therefore **cannot pre-validate** it: a session whose prospect places are
+ * exhausted looks identical to one with room, and the tool finds out only when
+ * a write is rejected. Whatever this probe records, that gap is already real.
+ *
+ * **So `free_class` may not be the discriminator #50 guessed at.** The ticket
+ * named it as the likely candidate, but a per-event prospect allowance is the
+ * mechanism staff actually use. `--free-event=<id>` is therefore better read as
+ * "a comparison event configured differently" than as "a free class"; what
+ * separates the two answers is the configuration, not the flag's name.
+ *
+ * Booking a generic open-climb session would answer a *different question* to
+ * the one #46 needs — which is why the event is a deliberate choice rather than
+ * a default.
  */
 
 import { writeFileSync, mkdirSync } from 'node:fs';
@@ -398,6 +427,21 @@ async function main() {
     );
     record.candidates = events.bookable;
   }
+
+  // Which event was booked is part of the finding, not run metadata: the answer
+  // is a property of the event's configuration, so a verdict recorded without
+  // the event beside it cannot be read later. `null` when the id is outside the
+  // listed window — a purpose-made test event may well be, and the probe still
+  // books it by id.
+  const describeTarget = id =>
+    [...events.bookable.paid, ...events.bookable.free].find(
+      e => String(e.event_id) === String(id),
+    ) ?? null;
+
+  record.targets = {
+    paid: EVENT_ID ? { event_id: EVENT_ID, ...(describeTarget(EVENT_ID) ?? {}) } : null,
+    free: FREE_EVENT_ID ? { event_id: FREE_EVENT_ID, ...(describeTarget(FREE_EVENT_ID) ?? {}) } : null,
+  };
 
   const booker = createBooker({
     accountKey,

--- a/cloudflare-clubworx/probes/run-60.mjs
+++ b/cloudflare-clubworx/probes/run-60.mjs
@@ -1,0 +1,553 @@
+#!/usr/bin/env node
+/**
+ * staff-site#60 — does the member + School Pass route actually book?
+ *
+ *   node probes/run-60.mjs --dry-run              # the plan and every request, zero network
+ *   node probes/run-60.mjs                        # read-only: contacts, plan, memberships, event
+ *   node probes/run-60.mjs --event=<id> --write   # assigns a pass if missing, then books
+ *   node probes/run-60.mjs --dev-vars=<path>
+ *
+ * #50 proved the prospect route does not work: Clubworx applies a per-contact
+ * prospect allowance the API cannot pass and does not report honestly. The
+ * replacement — student as **member**, holding a **School Pass**, booked into a
+ * **School Session** — was a proposal with nothing behind it. This probe is what
+ * puts something behind it, before #52–#55 design against it.
+ *
+ * ⚠️ Two irreversible writes live here, and they are not equally reversible:
+ *
+ *   - **Assigning a School Pass is permanent.** The reference exposes list and
+ *     create for memberships and *no delete*. A pass on the wrong contact is a
+ *     lasting mark on a real person's record.
+ *   - **A booking may or may not be.** `DELETE /bookings/:id` is documented but
+ *     has never been demonstrated here — #50 tried, sent it malformed, and read
+ *     the resulting 401 as a permissions wall. Question 7 settles that.
+ *
+ * Both are searched for first, so a re-run costs nothing permanent.
+ *
+ * The questions, from #60:
+ *
+ *   1. Does `POST /memberships` work as documented, and is the pass active at once?
+ *   2. Can the plan be resolved by *name*? (It could not be, with default paging —
+ *      see `resolvePlan`.)
+ *   3. Does a member holding an active School Pass book into a School Session?
+ *   4. Does `spaces_available` predict bookability now, where it did not in #50?
+ *   5. What does the 1-day-ahead rule return?
+ *   6. Does booking the same member into the same event twice duplicate?
+ *   7. Does `DELETE /bookings/:id` reverse a booking, when sent correctly?
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createGetter } from './lib/http.mjs';
+import { createBooker } from './lib/booking.mjs';
+import { createMembershipAssigner } from './lib/membership.mjs';
+import { loadAccountKey } from './lib/key.mjs';
+import { PROBE_CONTACTS, pickProbeRows, plusTag } from './lib/identity.mjs';
+import { redact } from './lib/request.mjs';
+import {
+  summariseContacts,
+  summariseBookings,
+  summariseMemberships,
+  summariseEvents,
+  classifyWrite,
+  describeDuplicateBooking,
+  describeCancellation,
+  findPlanByName,
+  describeLeadTime,
+  errorMessageOf,
+} from './lib/report.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(HERE, 'out');
+
+const args = process.argv.slice(2);
+const flag = name => args.find(a => a.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+
+const DRY_RUN = args.includes('--dry-run');
+const WRITE = args.includes('--write');
+const EVENT_ID = flag('event') ?? null;
+const PLAN_NAME = flag('plan') ?? 'School Pass';
+const DEV_VARS = flag('dev-vars') || path.join(HERE, '..', '.dev.vars');
+
+/**
+ * The three disjoint status views. #49: a contact appears in exactly one of
+ * them, and moves when their status changes — so a probe that searches only
+ * `/prospects` stops finding its own contacts the moment somebody converts
+ * them, which is exactly what happened here on 2026-08-18.
+ */
+const CONTACT_TYPES = ['prospects', 'members', 'non_attending_contacts'];
+
+const TAG_EMAILS = [...new Set(PROBE_CONTACTS.map(c => c.email))];
+
+/** Big enough to see past the default 50, which silently hid this plan (#51). */
+const PAGE_SIZE = 200;
+const WINDOW_DAYS = 21;
+
+const GAP_MS = 800;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const line = (label, value) => console.log(`  ${label.padEnd(38)} ${value}`);
+const rule = title => console.log(`\n── ${title} ${'─'.repeat(Math.max(0, 58 - title.length))}`);
+
+const isoDay = offsetDays => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+};
+
+/** Find the probe's contacts wherever their status has put them. */
+async function findProbeContacts(get) {
+  rule('0. Find the probe contacts — this probe creates none');
+
+  const found = [];
+  for (const type of CONTACT_TYPES) {
+    let hereCount = 0;
+    for (const email of TAG_EMAILS) {
+      const res = await get(type, { email });
+      const rows = pickProbeRows(res.body);
+      const summary = summariseContacts(res.body, rows.map(r => r.contact_key));
+      hereCount += rows.length;
+      found.push(...rows.map(r => ({ ...r, status_endpoint: type })));
+      if (summary.strangers) {
+        line(`${type} +${plusTag(email)}`, `${summary.strangers} row(s) not ours (counted, dropped)`);
+      }
+      await sleep(GAP_MS);
+    }
+    line(type, hereCount ? `${hereCount} of ours` : 'none');
+  }
+
+  const byKey = new Map(found.map(row => [row.contact_key, row]));
+  return [...byKey.values()];
+}
+
+/**
+ * Turn the plan *name* into an id — and refuse to guess.
+ *
+ * A hard-coded id is a number nobody can check against the Clubworx UI, so the
+ * tool will look it up by name. On 2026-08-18 the default page returned exactly
+ * 50 plans out of 57, and `School Pass` was among the seven that never arrived —
+ * the same silent truncation #51 found on `/events`, and a "plan not found" that
+ * would have been entirely wrong.
+ */
+async function resolvePlan(get) {
+  rule(`1–2. Resolve the membership plan by name — "${PLAN_NAME}"`);
+
+  const res = await get('membership_plans', { page_size: PAGE_SIZE });
+  const found = findPlanByName(res.body, PLAN_NAME, { requestedPageSize: PAGE_SIZE });
+
+  line('plans returned', `HTTP ${res.status} · ${found.count}`);
+
+  if (found.truncated) {
+    line('⚠️  page came back full', `${found.count} = page_size — the list is truncated`);
+  }
+  if (found.ambiguous) {
+    line('⚠️  ambiguous', `${found.matches} plans named "${PLAN_NAME}" — refusing to pick one`);
+  }
+  if (found.plan) {
+    line('resolved', `id ${found.plan.id} · duration ${found.plan.membership_duration ?? 'n/a'}`);
+    line('cost', `upfront ${found.plan.upfront_payment_amount ?? 'n/a'} · recurring ${found.plan.recurring_payment_amount ?? 'none'}`);
+  } else {
+    line('resolved', 'NOT FOUND');
+  }
+
+  return { ...found, status: res.status };
+}
+
+/** Question 1: does the contact hold an active pass, and assign one if not. */
+async function ensureMembership(get, assigner, { contact, plan, live }) {
+  rule('1. School Pass — does the contact hold one?');
+
+  const before = await get('memberships', { contact_key: contact.contact_key });
+  const held = summariseMemberships(before.body, plan.id);
+  line('memberships held', `HTTP ${before.status} · ${held.count} · holds this plan: ${held.holdsPlan} (active ${held.holdsActivePlan})`);
+  if (held.planStates.length) {
+    for (const s of held.planStates) {
+      line('  state', `start ${s.start_date ?? 'n/a'} · expires ${s.expiration_date ?? 'n/a'} · active ${s.active} · ${s.class_access ?? 'n/a'}`);
+    }
+  }
+  line('fields returned', held.fields.join(', ') || '(none)');
+  await sleep(GAP_MS);
+
+  // Search-first is not a courtesy here: memberships have no delete, so a
+  // re-run that skipped this check would pile up permanent duplicates.
+  // Reuse an *active* pass. An expired one is still a held plan, and treating
+  // that as good enough would leave the booking to fail for a reason the probe
+  // had already seen and ignored.
+  if (held.holdsActivePlan) {
+    line('assign', 'SKIPPED — an active pass is already held, nothing permanent to add');
+    return { assigned: null, before: held, after: held, reused: true };
+  }
+
+  const res = await assigner.assign({
+    contact_key: contact.contact_key,
+    membership_plan_id: plan.id,
+    start_date: isoDay(0),
+  });
+  const outcome = classifyWrite(res);
+  const reason = res.body ? redact(errorMessageOf(res.body) ?? '', ' ') : null;
+
+  line(
+    'assign',
+    res.refused
+      ? `REFUSED locally: ${res.refused}`
+      : res.dryRun
+        ? `would POST ${JSON.stringify(res.wouldSend)}`
+        : `HTTP ${res.status ?? 'n/a'} ${outcome.outcome}` +
+          (reason ? ` · "${reason}"` : '') +
+          (res.bodyText ? ` · ${res.bodyText.slice(0, 160)}` : ''),
+  );
+  if (!res.dryRun) await sleep(GAP_MS);
+
+  // Whether it is *active* is the question, not whether it was accepted.
+  let after = held;
+  if (live && outcome.outcome === 'created') {
+    const recheck = await get('memberships', { contact_key: contact.contact_key });
+    after = summariseMemberships(recheck.body, plan.id);
+    line('now holds this plan', String(after.holdsPlan));
+    for (const s of after.planStates) {
+      line('  state', `start ${s.start_date ?? 'n/a'} · expires ${s.expiration_date ?? 'n/a'} · active ${s.active} · ${s.class_access ?? 'n/a'}`);
+    }
+    await sleep(GAP_MS);
+  }
+
+  return {
+    assigned: { status: res.status ?? null, outcome, reason, bodyText: res.bodyText ?? null },
+    before: held,
+    after,
+    reused: false,
+  };
+}
+
+/** Questions 4 and 5: what the API says about the event before anything is written. */
+async function inspectEvent(get, eventId) {
+  rule('4–5. The event — capacity and lead time');
+
+  const res = await get('events', {
+    event_starts_after: isoDay(-1),
+    event_ends_before: isoDay(WINDOW_DAYS),
+    page_size: PAGE_SIZE,
+  });
+  const summary = summariseEvents(res.body);
+  const row = Array.isArray(res.body)
+    ? res.body.find(e => String(e.event_id) === String(eventId))
+    : null;
+
+  if (!row) {
+    line('event', `${eventId} NOT in the next ${WINDOW_DAYS} days (${summary.count} events seen)`);
+    return { found: false, count: summary.count };
+  }
+
+  const lead = describeLeadTime(row.event_start_at);
+  line('event', `${row.event_id} · ${row.event_name}`);
+  line('starts', `${row.event_start_at} (${lead.hoursAhead}h away)`);
+  line('capacity', `spaces_available ${row.spaces_available} · event_full ${row.event_full}`);
+  line('free_class', String(row.free_class));
+
+  if (lead.past) {
+    line('⚠️  lead time', 'this event has already started');
+  } else if (lead.withinLeadTime) {
+    line('⚠️  lead time', `inside ${lead.minLeadHours}h — the 1-day-ahead rule may refuse this`);
+  }
+
+  return {
+    found: true,
+    event_id: row.event_id,
+    event_name: row.event_name,
+    event_start_at: row.event_start_at,
+    spaces_available: row.spaces_available,
+    event_full: row.event_full,
+    free_class: row.free_class,
+    lead,
+    count: summary.count,
+  };
+}
+
+/** Questions 3, 6 and 7. */
+async function probeBooking(get, booker, { contact, eventId, accountKey }) {
+  rule('3, 6–7. Book, double-book, then cancel');
+
+  const reasonOf = sample => {
+    const message = errorMessageOf(sample?.body);
+    return message ? redact(message, accountKey) : null;
+  };
+  const count = async () => {
+    const res = await get('bookings', { contact_key: contact.contact_key });
+    return summariseBookings(res.body, [contact.contact_key]);
+  };
+
+  const before = await count();
+  line('bookings held before', String(before.ours));
+  await sleep(GAP_MS);
+
+  const first = await booker.book({ contact_key: contact.contact_key, event_id: eventId });
+  const firstClass = classifyWrite(first);
+  line(
+    'book (Q3)',
+    first.refused
+      ? `REFUSED locally: ${first.refused}`
+      : first.dryRun
+        ? `would POST ${JSON.stringify(first.wouldSend)}`
+        : `HTTP ${first.status ?? 'n/a'} ${firstClass.outcome}` +
+          (first.bookingId ? ` · booking ${first.bookingId}` : '') +
+          (reasonOf(first) ? ` · "${reasonOf(first)}"` : '') +
+          (first.bodyText ? ` · ${first.bodyText.slice(0, 160)}` : ''),
+  );
+  if (first.dryRun) return { dryRun: true };
+  await sleep(GAP_MS);
+
+  const afterFirst = await count();
+  line('bookings held after', String(afterFirst.ours));
+  await sleep(GAP_MS);
+
+  let second = null;
+  let secondClass = null;
+  let afterSecond = null;
+
+  if (firstClass.outcome === 'created') {
+    second = await booker.book({ contact_key: contact.contact_key, event_id: eventId });
+    secondClass = classifyWrite(second);
+    line(
+      'book again (Q6)',
+      `HTTP ${second.status ?? 'n/a'} ${secondClass.outcome}` +
+        (second.bookingId ? ` · booking ${second.bookingId}` : '') +
+        (reasonOf(second) ? ` · "${reasonOf(second)}"` : ''),
+    );
+    await sleep(GAP_MS);
+
+    afterSecond = await count();
+    line('bookings held after the second', String(afterSecond.ours));
+    await sleep(GAP_MS);
+  } else {
+    line('book again (Q6)', 'SKIPPED — the first booking did not land');
+  }
+
+  const duplicate = describeDuplicateBooking({
+    second: secondClass,
+    countBefore: afterFirst.ours,
+    countAfter: afterSecond?.ours ?? null,
+  });
+
+  // Question 7, sent correctly this time: contact_key travels in a form-encoded
+  // body, which is what #50 omitted.
+  const ids = [...new Set([first.bookingId, second?.bookingId].filter(Boolean).map(String))];
+  const cancellations = [];
+
+  for (const id of ids) {
+    const res = await booker.cancel(id);
+    cancellations.push({
+      id,
+      status: res.status ?? null,
+      refused: res.refused ?? null,
+      reason: reasonOf(res),
+    });
+    line(
+      `cancel ${id} (Q7)`,
+      res.refused
+        ? `REFUSED locally: ${res.refused}`
+        : `HTTP ${res.status ?? 'n/a'}` + (reasonOf(res) ? ` · "${reasonOf(res)}"` : ''),
+    );
+    await sleep(GAP_MS);
+  }
+
+  const afterCancel = ids.length ? await count() : null;
+  if (afterCancel) line('bookings held after cancelling', String(afterCancel.ours));
+
+  const reversal = describeCancellation({
+    cancel: cancellations[cancellations.length - 1] ?? null,
+    countBefore: afterSecond?.ours ?? afterFirst.ours,
+    countAfter: afterCancel?.ours ?? null,
+  });
+
+  return {
+    dryRun: false,
+    outcome: firstClass,
+    firstReason: reasonOf(first),
+    first: { status: first.status ?? null, bookingId: first.bookingId ?? null },
+    second: secondClass,
+    counts: {
+      before: before.ours,
+      afterFirst: afterFirst.ours,
+      afterSecond: afterSecond?.ours ?? null,
+      afterCancel: afterCancel?.ours ?? null,
+    },
+    duplicate,
+    cancellations,
+    reversal,
+    leftBehind: (afterCancel?.ours ?? 0) > before.ours,
+  };
+}
+
+function printDryRun() {
+  console.log('--dry-run: no requests issued, nothing written.\n');
+
+  let n = 0;
+  const req = (verb, p, params) =>
+    console.log(`  ${String(++n).padStart(2)}. ${verb.padEnd(6)} /${p}${params ? `?${params}` : ''}`);
+
+  console.log('0. Find the probe contacts — all three status views (#49):');
+  for (const type of CONTACT_TYPES) for (const email of TAG_EMAILS) req('GET', type, `email=${email}`);
+
+  console.log('\n1–2. Resolve the plan by name:');
+  req('GET', 'membership_plans', `page_size=${PAGE_SIZE}`);
+
+  console.log('\n1. School Pass — held already, or assign one:');
+  req('GET', 'memberships', 'contact_key=<probe contact>');
+  req('POST', 'memberships');
+  console.log(`        { contact_key: <probe contact>, membership_plan_id: <"${PLAN_NAME}">, start_date: ${isoDay(0)} }`);
+  console.log('        ⚠️ PERMANENT — memberships have no delete endpoint');
+  req('GET', 'memberships', 'contact_key=<probe contact>');
+
+  console.log('\n4–5. The event:');
+  req('GET', 'events', `event_starts_after=${isoDay(-1)}&event_ends_before=${isoDay(WINDOW_DAYS)}&page_size=${PAGE_SIZE}`);
+
+  if (!EVENT_ID) {
+    console.log('\n3, 6–7. Booking — NOTHING PLANNED. Pass --event=<id>.');
+  } else {
+    console.log(`\n3, 6–7. Booking into event ${EVENT_ID}:`);
+    req('GET', 'bookings', 'contact_key=<probe contact>');
+    req('POST', 'bookings');
+    req('GET', 'bookings', 'contact_key=<probe contact>');
+    req('POST', 'bookings');
+    console.log('        the same again — does it duplicate? (Q6)');
+    req('GET', 'bookings', 'contact_key=<probe contact>');
+    req('DELETE', 'bookings/<id created above>');
+    console.log('        body: account_key=…&contact_key=…  ← what #50 omitted');
+    req('GET', 'bookings', 'contact_key=<probe contact>');
+  }
+
+  console.log(`\n${n} requests, paced at one per ${GAP_MS}ms (~${Math.round(60_000 / GAP_MS)}/min), per #51.`);
+  console.log(
+    'Both writes are searched for first, so a re-run costs nothing permanent.\n' +
+      'No contact is ever created — ACCESS.md §4, that authorisation is spent.',
+  );
+}
+
+async function main() {
+  if (DRY_RUN) {
+    printDryRun();
+    return;
+  }
+
+  const accountKey = loadAccountKey(DEV_VARS);
+  const get = createGetter({ accountKey });
+
+  console.log(
+    WRITE
+      ? 'staff-site#60 probe — WRITES ENABLED, against production Clubworx'
+      : 'staff-site#60 probe — read-only. Pass --event=<id> --write to assign a pass and book.',
+  );
+
+  const record = { probe: 'staff-site#60', ranAt: new Date().toISOString(), write: WRITE };
+
+  const contacts = await findProbeContacts(get);
+  record.contacts = contacts.map(c => ({
+    contact_key: c.contact_key,
+    last_name: c.last_name,
+    status_endpoint: c.status_endpoint,
+  }));
+
+  if (!contacts.length) {
+    rule('Stopped');
+    console.log('  No probe contacts found anywhere. This probe creates none — see ACCESS.md §4.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const subject = contacts[0];
+  line('acting as', `${subject.last_name} · ${subject.status_endpoint} · ${subject.contact_key}`);
+  await sleep(GAP_MS);
+
+  const plan = await resolvePlan(get);
+  record.plan = {
+    name: PLAN_NAME,
+    id: plan.plan?.id ?? null,
+    duration: plan.plan?.membership_duration ?? null,
+    matches: plan.matches,
+    truncated: plan.truncated,
+    count: plan.count,
+  };
+
+  if (!plan.plan) {
+    rule('Stopped');
+    console.log(
+      `  Could not resolve "${PLAN_NAME}" to exactly one plan` +
+        (plan.truncated ? ' — and the page came back full, so the list is truncated.' : '.'),
+    );
+    process.exitCode = 1;
+    return;
+  }
+  await sleep(GAP_MS);
+
+  const assigner = createMembershipAssigner({
+    accountKey,
+    allowedContactKeys: contacts.map(c => c.contact_key),
+    live: WRITE,
+  });
+
+  record.membership = await ensureMembership(get, assigner, {
+    contact: subject,
+    plan: plan.plan,
+    live: WRITE,
+  });
+  await sleep(GAP_MS);
+
+  if (EVENT_ID) {
+    record.event = await inspectEvent(get, EVENT_ID);
+    await sleep(GAP_MS);
+  }
+
+  const booker = createBooker({
+    accountKey,
+    allowedContactKeys: contacts.map(c => c.contact_key),
+    live: WRITE,
+  });
+
+  if (!EVENT_ID) {
+    rule('3, 6–7. Booking — SKIPPED');
+    console.log('  No --event=<id> given. The event is never chosen automatically.');
+  } else {
+    record.booking = await probeBooking(get, booker, {
+      contact: subject,
+      eventId: EVENT_ID,
+      accountKey,
+    });
+  }
+
+  rule('Verdicts');
+  line('Q2  plan resolves by name', `${plan.matches === 1} (id ${plan.plan.id})`);
+  line('Q1  School Pass held', `${record.membership.after.holdsPlan} · active ${record.membership.after.holdsActivePlan}`);
+  if (record.event?.found) {
+    line('Q4  spaces_available', `${record.event.spaces_available} · full ${record.event.event_full}`);
+    line('Q5  lead time', `${record.event.lead.hoursAhead}h ahead` + (record.event.lead.withinLeadTime ? ' — inside the 1-day rule' : ''));
+  }
+  if (record.booking && !record.booking.dryRun) {
+    line('Q3  member with pass books', String(record.booking.outcome.outcome));
+    if (record.booking.firstReason) line('    the server said', `"${record.booking.firstReason}"`);
+    line('Q6  double-booking', record.booking.duplicate.summary);
+    line('Q7  DELETE reverses it', record.booking.reversal.summary);
+  }
+
+  const stranded = record.booking?.leftBehind;
+  if (stranded) {
+    rule('⚠️  Cleanup — could not undo');
+    console.log(`  ${subject.last_name} still holds bookings on event ${EVENT_ID}. Clear them in the Clubworx UI.`);
+  }
+  if (record.membership.assigned && !record.membership.reused && WRITE) {
+    rule('⚠️  Permanent');
+    console.log(`  A ${PLAN_NAME} was assigned to ${subject.last_name}. Memberships have no delete endpoint.`);
+  }
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `60-${record.ranAt.replace(/[:.]/g, '-')}.json`);
+  writeFileSync(file, JSON.stringify(record, null, 2));
+
+  const writes = assigner.assign.writes + booker.book.writes + booker.cancel.writes;
+  console.log(`\n${get.calls} reads, ${writes} writes. Summary written to probes/out/${path.basename(file)}`);
+}
+
+main().catch(err => {
+  console.error(`probe failed: ${err.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Two read-only-then-carefully-write probes against the live Clubworx API, the harness that ran them, and the corrections they forced. **Docs and probe tooling only** — no page, no Worker, no `tools.json`.

Closes the evidence gap that #46 was blocked on. Answers #50 and #60.

## What changed and why

### #50 — a prospect cannot be booked

`probes/50-membership-less-booking.md`. Booking a **prospect** into a session is refused with HTTP 400 `"...no free spaces available"` while the same API reports the class as having 25. The cause is a **prospect allowance** — a per-event limit exposed by *no* endpoint. Anyone meeting that message without this note goes looking at capacity and finds nothing wrong.

That invalidated the prospect-based design #46 was charting, which is why #60 exists.

### #60 — the member + School Pass route works

`probes/60-member-school-pass-booking.md`. Measured against production on 2026-08-18, into a purpose-made School Session:

| Question | Result |
|---|---|
| Q1 `POST /memberships` | 200 — pass active immediately |
| Q3 member with an active pass books | 200 created |
| Q6 booking the same member twice | 400, refused by the server |
| Q7 `DELETE /bookings/:id` | 200, re-read confirms 1 → 0 |
| Q5 same event 20.6h out | 400 `"closed for bookings"` |

**Booking is idempotent.** The server refuses the duplicate itself — *"Woops! You've already booked into this class!"* — and the re-count confirms it, 1 before and 1 after. Judged on the re-count rather than the status, because an accepted-but-silent duplicate is indistinguishable from an idempotent server from the response alone. A partial run can therefore be re-run without double-booking anyone.

**Bookings can be undone; contacts and School Passes cannot.** That is the real undo asymmetry, and it is narrower than #50 feared. Undo can unbook and can never uncreate.

**A School Pass costs nothing** — upfront 0.0, no recurring charge, no billing schedule — which removes the cost question #50 raised about the new route.

## Two traps worth more than the answers

- **`GET /membership_plans` truncates at 50** of UJ's 57 plans, and hid School Pass. A lookup on the default page reports "no such plan" for a plan that plainly exists — silent truncation in the one place where the answer decides whether anything can be booked. `findPlanByName` now treats a full page as truncated and refuses an ambiguous name rather than taking the first.
- **A membership record has no `status` field.** Only `start_date` and `expiration_date`. Code reaching for `status` gets `undefined` and would read a live pass as inactive, so activity is derived from the dates, inclusive at both ends.

## One retraction

`0e04f72` recorded "bookings are not reversible — DELETE is 401". `7036b14` retracts it: the 401 was a malformed request, not a permissions wall. `DELETE` needs `contact_key` alongside `account_key`, form-encoded in the body. ACCESS.md now records deletion as **measured**, not documented.

## Also in here

- `cloudflare-clubworx/probes/lib/booking.mjs`, `membership.mjs` — the third and fourth ways out to Clubworx, guarded like the others: inert unless live, and refusing any contact that did not come from the identity-filtered search. Memberships have no delete endpoint, so assignment is treated as permanent — search first, reuse an active pass rather than stacking another.
- `cloudflare-clubworx/ACCESS.md` — corrected caveats table, four new API limitations.
- `CONTEXT.md` — **School Session** (the event type) and **School Pass** (the 12-week membership) as domain vocabulary, plus *active pass*, *reversible write*, and *prospect allowance*. "School booking" is recorded as a name to avoid: *booking* already means three things.

## Error vocabulary #53 needs

Three distinct refusals now have known text — prospect allowance, lead time, already-booked. All arrive as HTTP 400 with `{"error": "..."}`, so **the message string is the only discriminator** between a retryable problem and a permanent one.

## Still open

Whether `spaces_available` blocks at the cap. It read 25 and the booking succeeded, but only one booking was made against 25 spaces — and #46's picker plans to warn staff from exactly that number. Recorded on #46, not chased here.

## Verification

Tests are run by hand; `pages.yml` runs none.

| Suite | Result |
|---|---|
| `cloudflare-clubworx` | 207 pass |
| `cloudflare-worker` | 81 pass (incl. `secret-hygiene.test.js`) |
| `cloudflare-payments-proxy` | 9 pass |
| `vouchers` | 216 pass, 1 pre-existing environmental failure (`version.test.js` resolves the parent superrepo — unrelated) |

No `hvt/` files touched.

No real student name, DOB or school appears in any probe, fixture or finding — the probe fixtures are purpose-made test records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
