### PR TITLE
feat(school-booking): parser module for a pasted student list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, an
                           what they found. Start with probes/README.md — it carries
                           the rules (no production data recorded, pace under
                           75 req/min) that any new probe has to follow.
+school-booking/parse.js - turns a pasted school student list into rows plus the
+                          list-level inferences (layout, column mapping, date
+                          orientation). Pure and unit tested; §7 of the design
+                          spec. Nothing imports it yet — see #64/#71.
 vouchers/               - voucher management portal (auth = Cloudflare Access)
 vouchers/stats.html     - voucher analytics: revenue, liability, redemption, product mix
 vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and why

--- a/school-booking/.gitignore
+++ b/school-booking/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/school-booking/package.json
+++ b/school-booking/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "uj-school-booking",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.0"
+  }
+}

--- a/school-booking/parse.js
+++ b/school-booking/parse.js
@@ -33,7 +33,13 @@
 // contact no human-typed search will ever match again.
 //
 // The matching rules that consume compare form live in identity.js (#65); what
-// this module owes is that both forms are emitted for every row.
+// this module owes is that both forms are emitted for every row. That module
+// must **import** the two functions below rather than restate their rules: two
+// copies of one normalisation table will drift, and the drift is silent in the
+// worst way. The day compare form disagrees with itself, `O'Brien` stops
+// matching `OBrien`, a student who already has a contact comes back as `new`,
+// and a second permanent contact is written for them — with nothing thrown,
+// because both spellings are individually valid and contacts cannot be deleted.
 
 const ZERO_WIDTH = /[​‌‍⁠﻿]/g;
 const SPACEY = /[    ]/g; // NBSP, figure space, narrow NBSP, thin space

--- a/school-booking/parse.js
+++ b/school-booking/parse.js
@@ -1,0 +1,872 @@
+// school-booking/parse.js
+//
+// Turns a pasted school student list into rows, per-row parse state, and the
+// list-level inferences that go with them. Pure on purpose — no DOM, no
+// network, no clock — so every rule below is unit-testable. The page imports
+// this and publishes it as `window.schoolListParser`, the same seam
+// delete-logic.js, unsubscribes-logic.js and image-pipeline.js use.
+//
+// Rules are §7 of docs/superpowers/specs/2026-08-19-school-group-booking-design.md,
+// settled on #52 against the three real lists catalogued in #48. Vocabulary is
+// CONTEXT.md § "Clubworx school list parsing".
+//
+// Why none of this is cosmetic: under the member + School Pass route a student
+// is three writes and only the last is reversible, so a parsing misread creates
+// a permanent wrong contact carrying a permanent membership.
+//
+// The two rules everything else leans on:
+//
+//   P1 — never drop a line, only classify it. Every input line lands in exactly
+//        one bucket, and `counts.accounted === counts.lines` is checked here
+//        rather than left to the caller.
+//   P4 — the DOB is the anchor. Layout and column mapping are both validated by
+//        finding the date by the *shape of its values*, never by position or
+//        header text. Neither holding is a refusal, not a guess.
+
+// ---------------------------------------------------------------------------
+// P10 — two normalisations, kept apart
+// ---------------------------------------------------------------------------
+// The split is load-bearing: it is what lets `O'Brien` match `OBrien` without
+// ever *writing* the second spelling into a record that cannot be deleted. One
+// of the three real lists is a PDF exported from Word, so curly apostrophes and
+// non-breaking hyphens are expected input — written verbatim they produce a
+// contact no human-typed search will ever match again.
+//
+// The matching rules that consume compare form live in identity.js (#65); what
+// this module owes is that both forms are emitted for every row.
+
+const ZERO_WIDTH = /[​‌‍⁠﻿]/g;
+const SPACEY = /[    ]/g; // NBSP, figure space, narrow NBSP, thin space
+const APOSTROPHES = /[‘’ʼʹ′]/g; // curly quotes, modifier letter, prime
+const HYPHENS = /[‐‑‒–−]/g; // hyphen, non-breaking, figure dash, en dash, minus
+
+// Case is never touched and accents are never stripped. Both are deliberate:
+// this string is written into a permanent record.
+export function writeForm(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(ZERO_WIDTH, '')
+    .replace(SPACEY, ' ')
+    .replace(APOSTROPHES, "'")
+    .replace(HYPHENS, '-')
+    .normalize('NFC')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+// Matching and in-paste dedup only. Never written anywhere.
+export function compareForm(value) {
+  return writeForm(value).toLowerCase().replace(/['\-\s]/g, '');
+}
+
+// ---------------------------------------------------------------------------
+// Date shapes — the anchor (P4), the orientation (P11), the serials (P12)
+// ---------------------------------------------------------------------------
+
+const ISO = /^(\d{4})-(\d{2})-(\d{2})$/;
+const PARTED = /^(\d{1,4})[/.-](\d{1,2})[/.-](\d{2,4})$/;
+const SERIAL = /^\d{5}$/;
+
+// Excel's 1900 system, using the 1899-12-30 base that absorbs its leap-year bug
+// for every serial above 60. The window is 1900–2100: a five-digit integer is
+// the weakest date shape there is, and bounding it keeps a column of student
+// IDs from reading as dates. It is also why serials are only consulted when no
+// unambiguous date shape exists anywhere (see `dateColumns`).
+const SERIAL_EPOCH_UTC = Date.UTC(1899, 11, 30);
+const SERIAL_MIN = 1;
+const SERIAL_MAX = 73415; // 2100-12-31
+
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function isLeap(year) {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+function validDate(year, month, day) {
+  if (month < 1 || month > 12 || day < 1) return false;
+  const last = month === 2 && isLeap(year) ? 29 : DAYS_IN_MONTH[month - 1];
+  return day <= last;
+}
+
+const iso = (year, month, day) =>
+  `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+// `strict` excludes bare five-digit serials. Detection runs strict first so a
+// list that has a real date column is never anchored on an integer column.
+export function isDateShaped(value, { strict = false } = {}) {
+  const s = String(value ?? '').trim();
+  if (!s) return false;
+  if (ISO.test(s)) return true;
+  if (PARTED.test(s)) return true;
+  if (!strict && SERIAL.test(s)) {
+    const n = Number(s);
+    return n >= SERIAL_MIN && n <= SERIAL_MAX;
+  }
+  return false;
+}
+
+// Which orientation a single value *proves*, if any. Only a field above 12 is
+// proof; everything else — self-identifying, serial, or two fields both under
+// 13 — returns null and contributes nothing. P11 is emphatic that this is a
+// property of the whole list, so no caller may read a date without one.
+export function orientationEvidence(value) {
+  const s = String(value ?? '').trim();
+  const m = PARTED.exec(s);
+  if (!m) return null;
+  const [, a, b] = m;
+  if (a.length === 4) return null; // yyyy-m-d, self-identifying
+  const first = Number(a);
+  const second = Number(b);
+  if (first > 12 && second <= 12) return 'dmy';
+  if (second > 12 && first <= 12) return 'mdy';
+  return null; // both above 12 is invalid, both under 13 is ambiguous
+}
+
+// `{ iso, kind }` on success, `{ error }` on a date-shaped value that is not a
+// date. `orientation` may be null, in which case an ambiguous parted date is
+// reported as needing it rather than guessed.
+export function readDate(value, orientation) {
+  const s = String(value ?? '').trim();
+  if (!s) return { error: 'empty' };
+
+  const isoMatch = ISO.exec(s);
+  if (isoMatch) {
+    const [, y, m, d] = isoMatch.map(Number);
+    return validDate(y, m, d) ? { iso: iso(y, m, d), kind: 'iso' } : { error: 'invalid-date' };
+  }
+
+  if (SERIAL.test(s)) {
+    const n = Number(s);
+    if (n < SERIAL_MIN || n > SERIAL_MAX) return { error: 'invalid-date' };
+    // Not unambiguous — 1900 and 1904 are 1462 days apart, so a bare 40365 is
+    // either 2010-07-06 or 2014-07-07, both plausible school ages. Which system
+    // a workbook uses is unanswerable, so P12 confirms the resulting *dates*
+    // instead, which is a question staff can actually answer.
+    const date = new Date(SERIAL_EPOCH_UTC + n * 86400000);
+    return {
+      iso: date.toISOString().slice(0, 10),
+      kind: 'serial',
+    };
+  }
+
+  const parted = PARTED.exec(s);
+  if (!parted) return { error: 'not-a-date' };
+  const [, a, b, c] = parted;
+
+  if (a.length === 4) {
+    const [y, m, d] = [Number(a), Number(b), Number(c)];
+    return validDate(y, m, d) ? { iso: iso(y, m, d), kind: 'iso' } : { error: 'invalid-date' };
+  }
+
+  // The century constraint: students are all born this century, so a two-digit
+  // year is 20xx. (This does not resolve 1900-vs-1904 — both readings land
+  // after 2000 — it only fixes the century of a typed year.)
+  const year = c.length <= 2 ? 2000 + Number(c) : Number(c);
+  const first = Number(a);
+  const second = Number(b);
+
+  if (!orientation) {
+    if (first > 12 && second > 12) return { error: 'invalid-date' };
+    if (first <= 12 && second <= 12) return { error: 'needs-orientation' };
+    // A value that proves its own orientation can be read without one.
+    const proven = first > 12 ? 'dmy' : 'mdy';
+    return readParted(first, second, year, proven);
+  }
+
+  return readParted(first, second, year, orientation);
+}
+
+function readParted(first, second, year, orientation) {
+  const day = orientation === 'dmy' ? first : second;
+  const month = orientation === 'dmy' ? second : first;
+  if (!validDate(year, month, day)) return { error: 'invalid-date' };
+  return { iso: iso(year, month, day), kind: 'parted' };
+}
+
+// ---------------------------------------------------------------------------
+// P13 — age band, against the event date, in Australia/Perth
+// ---------------------------------------------------------------------------
+// Generous on purpose: a hard block would refuse the legitimate senior student
+// or an 18-year-old on a leadership day, so an implausible age is
+// needs-confirmation and never a refusal. Perth has never observed daylight
+// saving, so calendar arithmetic on the two ISO dates is exact.
+
+export const MIN_PLAUSIBLE_AGE = 4;
+export const MAX_PLAUSIBLE_AGE = 21;
+
+export function ageOn(dobIso, onIso) {
+  if (!ISO.test(String(dobIso)) || !ISO.test(String(onIso))) return null;
+  const [by, bm, bd] = dobIso.split('-').map(Number);
+  const [ey, em, ed] = onIso.split('-').map(Number);
+  let age = ey - by;
+  if (em < bm || (em === bm && ed < bd)) age -= 1;
+  return age;
+}
+
+// ---------------------------------------------------------------------------
+// Lines and fields
+// ---------------------------------------------------------------------------
+
+function splitLines(text) {
+  const body = String(text ?? '').replace(/^﻿/, '');
+  const lines = body.split(/\r\n|\r|\n/);
+  // A trailing newline is a terminator, not an empty final line. Every other
+  // blank line is real input and is classified like any other (P1).
+  if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
+  return lines.map((raw, i) => ({ n: i + 1, raw }));
+}
+
+// A pasted list is not necessarily tab-separated — one of the three real lists
+// contains no tab and no comma at all. Commas are deliberately *not* a
+// delimiter: a comma inside a name field means `Surname, Given` (P8), and a
+// parser that split on it would tear that field in half.
+function detectDelimiter(lines) {
+  const filled = lines.filter((l) => l.raw.trim() !== '');
+  if (filled.some((l) => l.raw.includes('\t'))) return 'tab';
+  // Two or more spaces, never single whitespace: list 3's columns are aligned
+  // with runs of 2–8 spaces, and both a first name and a surname containing a
+  // single space appear in the real lists.
+  if (filled.some((l) => /\S {2,}\S/.test(l.raw.trim()))) return 'spaces';
+  return 'none';
+}
+
+function splitFields(raw, delimiter) {
+  const trimmed = raw.trim();
+  if (trimmed === '') return [];
+  let fields;
+  if (delimiter === 'tab') fields = raw.split('\t').map((f) => f.trim());
+  else if (delimiter === 'spaces') fields = trimmed.split(/\s{2,}/).map((f) => f.trim());
+  else fields = [trimmed];
+  // Phantom trailing columns: styled but empty cells arrive as trailing tabs
+  // and turn "this list has 3 columns" into "6 columns, three of them blank".
+  // Interior blanks are left alone — those are missing values, not padding.
+  while (fields.length > 1 && fields[fields.length - 1] === '') fields.pop();
+  return fields;
+}
+
+function modalCount(counts) {
+  let best = 0;
+  let bestN = 0;
+  for (const [size, n] of counts) {
+    if (n > bestN || (n === bestN && Number(size) > best)) {
+      best = Number(size);
+      bestN = n;
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// P4 — layout, detected then validated against content
+// ---------------------------------------------------------------------------
+// The divisibility rule as first written on #48 is superseded and deliberately
+// not implemented: all three fixtures are CRLF and the vertical one opens with
+// a blank line, so its 37 lines are not a multiple of 6 while its 36 non-blank
+// lines are — and almost any line count divides by 2 or 3 anyway.
+//
+// What holds instead is the DOB anchor. In a genuine vertical list exactly one
+// position within the repeating block is date-shaped in *every* block, which
+// shows up as a constant gap between date-shaped lines. That gap is the block
+// size, and it is a measurement rather than a guess.
+
+function detectVertical(seq, strict) {
+  const dateAt = seq.map((cell) => isDateShaped(cell.value, { strict }));
+  const hits = [];
+  dateAt.forEach((isDate, i) => {
+    if (isDate) hits.push(i);
+  });
+  // One date cannot establish a stride, and zero cannot establish anything.
+  if (hits.length < 2) return null;
+
+  const gap = hits[1] - hits[0];
+  if (gap < 2 || gap > 40) return null;
+  for (let i = 2; i < hits.length; i++) {
+    if (hits[i] - hits[i - 1] !== gap) return null; // two date positions, or a broken list
+  }
+
+  const firstHit = hits[0];
+  let start = null;
+  for (let p = 0; p <= Math.min(gap - 1, firstHit); p++) {
+    const s = firstHit - p;
+    if ((seq.length - s) % gap === 0) {
+      start = s;
+      break;
+    }
+  }
+  // No offset leaves whole blocks to the end — a truncated paste. Keep as many
+  // complete blocks as the anchor supports and let the remainder be errors;
+  // the count gate (P5) is what catches the truncation itself.
+  if (start === null) start = firstHit - Math.min(firstHit, gap - 1);
+
+  const blocks = Math.floor((seq.length - start) / gap);
+  if (blocks < 1) return null;
+  return { blockSize: gap, start, blocks, dobPos: firstHit - start };
+}
+
+// ---------------------------------------------------------------------------
+// P6 — columns mapped content-first
+// ---------------------------------------------------------------------------
+// Fixed column order is rejected outright: the first school that reorders its
+// export would produce wrong permanent contacts with no error at all. A header,
+// where present, does one job — naming the two *name* columns. It never finds
+// the date, and it never decides which columns are ignored.
+
+const NAME_SHAPED = /^[\p{L}][\p{L}\p{M}'\-. ]*$/u;
+
+function isNameShaped(value) {
+  const s = String(value ?? '').trim();
+  if (!s) return false;
+  if (s.includes('@') || /\d/.test(s)) return false;
+  return NAME_SHAPED.test(s);
+}
+
+const label = (text) => String(text ?? '').toLowerCase().replace(/[^a-z]/g, '');
+const FIRST_WORDS = ['first', 'given', 'preferred', 'forename', 'christian'];
+const LAST_WORDS = ['last', 'surname', 'family'];
+const COMBINED_LABELS = ['name', 'studentname', 'fullname', 'student', 'pupil'];
+
+function mapColumns(dataRows, width, dobCol, header) {
+  const others = [];
+  for (let c = 0; c < width; c++) if (c !== dobCol) others.push(c);
+
+  const nameShaped = others.filter((c) =>
+    dataRows.every((row) => isNameShaped(row.fields[c]))
+  );
+
+  if (header) {
+    const first = others.find((c) => FIRST_WORDS.some((w) => label(header[c]).includes(w)));
+    const last = others.find((c) => LAST_WORDS.some((w) => label(header[c]).includes(w)));
+    if (first !== undefined && last !== undefined && first !== last) {
+      return { firstName: first, lastName: last, combined: null, nameOrderKnown: true };
+    }
+    const combined = others.find((c) => COMBINED_LABELS.includes(label(header[c])));
+    if (combined !== undefined) {
+      return { firstName: null, lastName: null, combined, nameOrderKnown: false };
+    }
+  }
+
+  // Content fallback. Order is not inferable: hyphenated and apostrophe names
+  // appear in *both* fields in the real lists, so any content rule for which is
+  // which would be a guess dressed as inference. P7 asks instead.
+  if (nameShaped.length >= 2) {
+    return {
+      firstName: nameShaped[0],
+      lastName: nameShaped[1],
+      combined: null,
+      nameOrderKnown: false,
+    };
+  }
+  if (nameShaped.length === 1) {
+    return { firstName: null, lastName: null, combined: nameShaped[0], nameOrderKnown: false };
+  }
+  return null;
+}
+
+function columnLabel(header, index) {
+  const named = header && String(header[index] ?? '').trim();
+  return named || `Column ${index + 1}`;
+}
+
+// ---------------------------------------------------------------------------
+// P8 — a combined name column, with graded confirmation
+// ---------------------------------------------------------------------------
+// No particle list (van, der, de, mac, o') is maintained: every such name has
+// three or more tokens anyway, so the token rule catches them without a list
+// that is culturally incomplete by nature and silently wrong when it misses.
+
+function splitCombinedName(value, nameOrder) {
+  const name = writeForm(value);
+  if (!name) return { firstName: '', lastName: '', needs: null, flag: 'empty-name' };
+
+  if (name.includes(',')) {
+    // `Surname, Given` — the only reading a comma has in a name field.
+    // Confirmed once for the list, not once per row.
+    const [surname, ...rest] = name.split(',');
+    return {
+      firstName: writeForm(rest.join(',')),
+      lastName: writeForm(surname),
+      needs: null,
+      flag: 'comma-split',
+    };
+  }
+
+  const tokens = name.split(' ');
+  if (tokens.length === 2) {
+    // Auto-split: no other reading exists. Which way round is P7's problem.
+    const [a, b] = tokens;
+    return nameOrder === 'last-first'
+      ? { firstName: b, lastName: a, needs: null, flag: null }
+      : { firstName: a, lastName: b, needs: null, flag: null };
+  }
+
+  if (tokens.length === 1) {
+    return {
+      firstName: '',
+      lastName: tokens[0],
+      needs: { kind: 'name-split', tokens, splitPoints: [], suggested: null },
+      flag: 'single-token-name',
+    };
+  }
+
+  // Three or more tokens: per-row confirmation, offering the split points as
+  // clickable positions with a suggested default. The fixtures overturned the
+  // original recommendation to refuse a combined column — only 3 of 63 first
+  // names and 1 of 63 surnames contain an internal space, so the largest real
+  // list needs about four confirmations, not sixty-three.
+  const splitPoints = tokens.map((_, i) => i).slice(1);
+  const suggested = nameOrder === 'last-first' ? 1 : tokens.length - 1;
+  const applied =
+    nameOrder === 'last-first'
+      ? { firstName: tokens.slice(1).join(' '), lastName: tokens[0] }
+      : { firstName: tokens.slice(0, -1).join(' '), lastName: tokens[tokens.length - 1] };
+  return {
+    ...applied,
+    needs: { kind: 'name-split', tokens, splitPoints, suggested },
+    flag: 'name-split',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The parse
+// ---------------------------------------------------------------------------
+
+const REFUSALS = {
+  'layout-not-held': 'The layout could not be established from the dates in this list.',
+  'no-dob-column': 'No column holds a date in every row, so the date of birth cannot be identified.',
+  'dob-column-ambiguous': 'More than one column holds a date in every row, so the date of birth is ambiguous.',
+  'no-name-columns': 'No column holds names in every row.',
+  'date-orientation-contradiction':
+    'This list contains dates that prove both day/month and month/day, so it cannot be read safely.',
+};
+
+const refusal = (code, extra = {}) => ({ code, message: REFUSALS[code], ...extra });
+
+/**
+ * @param {string} text            the pasted list
+ * @param {object} [options]
+ * @param {'dmy'|'mdy'} [options.dateOrientation]  answer to the P11 question
+ * @param {'first-last'|'last-first'} [options.nameOrder]  answer to the P7 question
+ * @param {string} [options.eventDate]  ISO date, enables the P13 age band
+ */
+export function parseStudentList(text, options = {}) {
+  const nameOrder = options.nameOrder === 'last-first' ? 'last-first' : 'first-last';
+  const lines = splitLines(text);
+  const delimiter = detectDelimiter(lines);
+
+  const ignored = [];
+  const errors = [];
+
+  const cells = lines.map((line) => ({ ...line, fields: splitFields(line.raw, delimiter) }));
+  for (const cell of cells) {
+    if (cell.fields.length === 0) {
+      ignored.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'blank' });
+    }
+  }
+  const filled = cells.filter((c) => c.fields.length > 0);
+
+  // A refusal re-buckets from scratch: every non-blank line becomes an error,
+  // because nothing about the list was established. It cannot reuse `ignored`,
+  // which by this point may already hold header lines that are also in
+  // `filled` — counting those twice would break P1 on exactly the path where
+  // the reconciliation matters most.
+  const bail = (code, extra) =>
+    finish({
+      lines,
+      layout: null,
+      records: [],
+      ignored: cells
+        .filter((c) => c.fields.length === 0)
+        .map((c) => ({ lineNumbers: [c.n], text: c.raw, reason: 'blank' })),
+      errors: filled.map((c) => ({
+        lineNumbers: [c.n],
+        text: c.raw,
+        reason: code,
+      })),
+      refusalValue: refusal(code, extra),
+      extras: {},
+    });
+
+  if (filled.length === 0) {
+    return finish({ lines, layout: null, records: [], ignored, errors, refusalValue: null, extras: {} });
+  }
+
+  // --- layout ------------------------------------------------------------
+  const vertical = delimiter === 'none';
+  let rows; // { fields, lineNumbers }
+  let header = null;
+  let width;
+  let blockSize = null;
+
+  if (vertical) {
+    const seq = filled.map((c) => ({ value: c.fields[0], n: c.n }));
+    const shape = detectVertical(seq, true) || detectVertical(seq, false);
+    if (!shape) return bail('layout-not-held');
+
+    blockSize = shape.blockSize;
+    width = blockSize;
+    rows = [];
+    for (let b = 0; b < shape.blocks; b++) {
+      const at = shape.start + b * blockSize;
+      const block = seq.slice(at, at + blockSize);
+      rows.push({ fields: block.map((c) => c.value), lineNumbers: block.map((c) => c.n) });
+    }
+    // Everything before the first block is header or junk; both are ignored,
+    // and both are before the first record, so P9 never has to choose.
+    const lead = seq.slice(0, shape.start);
+    if (lead.length === blockSize) header = lead.map((c) => c.value);
+    for (const cell of lead) {
+      ignored.push({
+        lineNumbers: [cell.n],
+        text: cell.value,
+        reason: header ? 'header' : 'junk',
+      });
+    }
+    // A truncated final block cannot be a student; it is after the first good
+    // record, so it is unparseable rather than junk.
+    for (const cell of seq.slice(shape.start + shape.blocks * blockSize)) {
+      errors.push({ lineNumbers: [cell.n], text: cell.value, reason: 'incomplete-block' });
+    }
+  } else {
+    const counts = new Map();
+    for (const c of filled) counts.set(c.fields.length, (counts.get(c.fields.length) ?? 0) + 1);
+    width = modalCount([...counts.entries()]);
+    rows = filled
+      .filter((c) => c.fields.length === width)
+      .map((c) => ({ fields: c.fields, lineNumbers: [c.n], raw: c.raw }));
+  }
+
+  // --- the DOB anchor ----------------------------------------------------
+  // Strict first, so a list that has a real date column is never anchored on a
+  // five-digit integer column that happens to look like Excel serials.
+  const dateBearing = (strict) =>
+    rows.filter((row) => row.fields.some((f) => isDateShaped(f, { strict })));
+
+  let strict = true;
+  let dataRows = dateBearing(true);
+  if (dataRows.length === 0) {
+    strict = false;
+    dataRows = dateBearing(false);
+  }
+  if (dataRows.length === 0) return bail('no-dob-column');
+
+  const dateCols = [];
+  for (let c = 0; c < width; c++) {
+    if (dataRows.every((row) => isDateShaped(row.fields[c], { strict }))) dateCols.push(c);
+  }
+  if (dateCols.length === 0) return bail('no-dob-column');
+  if (dateCols.length > 1) return bail('dob-column-ambiguous', { columns: dateCols });
+  const dobCol = dateCols[0];
+
+  // --- non-data lines, classified by position (P9) ------------------------
+  if (!vertical) {
+    const firstRecordLine = dataRows[0].lineNumbers[0];
+    const dataLines = new Set(dataRows.map((r) => r.lineNumbers[0]));
+    for (const cell of filled) {
+      if (dataLines.has(cell.n)) continue;
+      const before = cell.n < firstRecordLine;
+      const hasDate = cell.fields.some((f) => isDateShaped(f, { strict }));
+      if (before && !hasDate && cell.fields.length === width && header === null) {
+        // A modal-width, date-free line before the first record names the
+        // columns. It is not junk by P9's definition — its field count matches
+        // — and it is the only line whose text this parser reads for meaning.
+        header = cell.fields;
+        ignored.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'header' });
+      } else if (before && !hasDate && cell.fields.length !== width) {
+        // Junk is defined by position: no date, a field count unlike the modal
+        // one, and before the first good record. The school title line and the
+        // stray prose sentence both collapse to a single field; data rows do not.
+        ignored.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'junk' });
+      } else if (before && !hasDate) {
+        ignored.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'junk' });
+      } else {
+        // After the first good record, a line that does not parse is
+        // unparseable, not junk. That is where a real student hides — it blocks
+        // Apply until corrected or explicitly dismissed (P15).
+        errors.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'unparseable' });
+      }
+    }
+  }
+
+  // --- column mapping (P6) ------------------------------------------------
+  const mapping = mapColumns(dataRows, width, dobCol, header);
+  if (!mapping) return bail('no-name-columns');
+
+  const usedCols = new Set(
+    [dobCol, mapping.firstName, mapping.lastName, mapping.combined].filter((c) => c !== null && c !== undefined)
+  );
+  const ignoredColumns = [];
+  for (let c = 0; c < width; c++) {
+    if (!usedCols.has(c)) ignoredColumns.push({ index: c, label: columnLabel(header, c) });
+  }
+
+  // --- date orientation, once for the whole list (P11) --------------------
+  const evidence = new Map();
+  for (const row of dataRows) {
+    const verdict = orientationEvidence(row.fields[dobCol]);
+    if (verdict && !evidence.has(verdict)) evidence.set(verdict, row);
+  }
+
+  let orientation = null;
+  let orientationBasis;
+  let orientationSample = null;
+  let orientationRefusal = null;
+
+  if (evidence.size > 1) {
+    // Contradictory evidence refuses the whole paste, showing the two rows.
+    orientationBasis = 'contradicted';
+    orientationRefusal = refusal('date-orientation-contradiction', {
+      rows: [...evidence.entries()].map(([reading, row]) => ({
+        reading,
+        value: row.fields[dobCol],
+        lineNumbers: row.lineNumbers,
+      })),
+    });
+  } else if (evidence.size === 1) {
+    orientation = [...evidence.keys()][0];
+    orientationBasis = 'proved'; // a field above 12 is a proof, not a heuristic
+  } else if (options.dateOrientation === 'dmy' || options.dateOrientation === 'mdy') {
+    orientation = options.dateOrientation;
+    orientationBasis = 'supplied';
+  } else {
+    const ambiguous = dataRows.find(
+      (row) => readDate(row.fields[dobCol], null).error === 'needs-orientation'
+    );
+    if (ambiguous) {
+      // Never default silently. A wrong orientation does not error — it turns
+      // March into May, reports the student not-found, and creates a permanent
+      // contact with a wrong DOB that poisons the identity key for every later
+      // term. So ask, showing a real date from the paste read both ways.
+      orientationBasis = 'ask';
+      const value = ambiguous.fields[dobCol];
+      orientationSample = {
+        value,
+        lineNumbers: ambiguous.lineNumbers,
+        dmy: readDate(value, 'dmy').iso ?? null,
+        mdy: readDate(value, 'mdy').iso ?? null,
+      };
+    } else {
+      orientationBasis = 'self-identifying'; // every date is ISO or a serial
+    }
+  }
+
+  // --- rows ---------------------------------------------------------------
+  const listNeeds = [];
+  if (!mapping.nameOrderKnown && !options.nameOrder) {
+    const samples = dataRows.slice(0, 2).map((row) => ({
+      values: mapping.combined === null
+        ? [writeForm(row.fields[mapping.firstName]), writeForm(row.fields[mapping.lastName])]
+        : [writeForm(row.fields[mapping.combined])],
+      lineNumbers: row.lineNumbers,
+    }));
+    listNeeds.push({ kind: 'name-order', default: 'first-last', samples });
+  }
+  if (orientationBasis === 'ask') {
+    listNeeds.push({ kind: 'date-orientation', sample: orientationSample });
+  }
+
+  let records = [];
+  let sawComma = false;
+  let sawSerial = false;
+
+  for (const row of dataRows) {
+    const rawDob = row.fields[dobCol];
+    let rawFirst;
+    let rawLast;
+    let names;
+
+    if (mapping.combined !== null) {
+      names = splitCombinedName(row.fields[mapping.combined], nameOrder);
+      rawFirst = row.fields[mapping.combined];
+      rawLast = row.fields[mapping.combined];
+      if (names.flag === 'comma-split') sawComma = true;
+    } else {
+      rawFirst = row.fields[mapping.firstName];
+      rawLast = row.fields[mapping.lastName];
+      names = {
+        firstName: writeForm(rawFirst),
+        lastName: writeForm(rawLast),
+        needs: null,
+        flag: null,
+      };
+      if (nameOrder === 'last-first') {
+        names = { ...names, firstName: names.lastName, lastName: names.firstName };
+      }
+    }
+
+    const read = readDate(rawDob, orientation);
+    if (read.error && read.error !== 'needs-orientation') {
+      errors.push({ lineNumbers: row.lineNumbers, text: rawDob, reason: read.error });
+      continue;
+    }
+
+    const flags = [];
+    const needs = [];
+    if (names.flag && names.flag !== 'comma-split') flags.push(names.flag);
+    if (names.needs) needs.push(names.needs);
+    if (read.kind === 'serial') {
+      sawSerial = true;
+      flags.push('excel-serial'); // P12 surfaces the resulting date for a sanity check
+    }
+    if (read.error === 'needs-orientation') needs.push({ kind: 'date-orientation' });
+
+    const dob = read.iso ?? null;
+    if (dob && Number(dob.slice(0, 4)) < 2000) {
+      // Students are all born this century. A sharper teacher-row detector than
+      // guessing at names — and a flag, not a block.
+      flags.push('not-a-student');
+    } else if (dob && options.eventDate) {
+      const age = ageOn(dob, options.eventDate);
+      if (age !== null && (age < MIN_PLAUSIBLE_AGE || age > MAX_PLAUSIBLE_AGE)) {
+        flags.push('implausible-age');
+      }
+    }
+
+    records.push({
+      lineNumbers: [...row.lineNumbers],
+      raw: { firstName: rawFirst, lastName: rawLast, dob: rawDob },
+      write: { firstName: names.firstName, lastName: names.lastName, dob },
+      compare: { firstName: compareForm(names.firstName), lastName: compareForm(names.lastName) },
+      flags,
+      needs,
+      state: 'clean', // set below, once dedup has had its say
+    });
+  }
+
+  if (sawComma) {
+    // Confirmed once for the list, not per row.
+    listNeeds.push({ kind: 'combined-name-comma' });
+  }
+  if (sawSerial) {
+    listNeeds.push({ kind: 'excel-serial-dates' });
+  }
+
+  records = collapseDuplicates(records);
+  for (const record of records) {
+    record.state = record.needs.length > 0 || record.flags.length > 0 ? 'needs-confirmation' : 'clean';
+  }
+
+  const students = records.length;
+  const verdict = vertical
+    ? `read as ${blockSize} fields per student — ${students} student${students === 1 ? '' : 's'} found`
+    : `read as one student per line, ${width} column${width === 1 ? '' : 's'} — ${students} student${students === 1 ? '' : 's'} found`;
+
+  return finish({
+    lines,
+    layout: vertical ? 'vertical' : 'horizontal',
+    records,
+    ignored,
+    errors,
+    refusalValue: orientationRefusal,
+    extras: {
+      blockSize,
+      fieldCount: width,
+      header,
+      verdict,
+      columns: {
+        dob: dobCol,
+        firstName: mapping.firstName,
+        lastName: mapping.lastName,
+        combined: mapping.combined,
+      },
+      ignoredColumns,
+      dateOrientation: {
+        value: orientation,
+        basis: orientationBasis,
+        sample: orientationSample,
+      },
+      nameOrder,
+      needs: listNeeds,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// P14 — true duplicates collapse visibly; twins stay as two rows
+// ---------------------------------------------------------------------------
+// Collapsing on surname + DOB alone is rejected: it merges twins into one
+// student, and nobody discovers the missing child until the session. Silent
+// collapsing is not acceptable either — a school merging two class exports is
+// exactly how a list gains a duplicate, and the badge is what makes it visible.
+
+function collapseDuplicates(records) {
+  const groups = new Map();
+  for (const record of records) {
+    if (!record.write.dob) continue;
+    const key = `${record.compare.lastName}|${record.write.dob}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(record);
+  }
+
+  const dropped = new Set();
+  for (const group of groups.values()) {
+    const byFirst = new Map();
+    for (const record of group) {
+      const first = record.compare.firstName;
+      if (!byFirst.has(first)) byFirst.set(first, []);
+      byFirst.get(first).push(record);
+    }
+    for (const same of byFirst.values()) {
+      if (same.length < 2) continue;
+      const [keep, ...rest] = same;
+      for (const extra of rest) {
+        keep.lineNumbers.push(...extra.lineNumbers);
+        dropped.add(extra);
+      }
+      keep.lineNumbers.sort((a, b) => a - b);
+      keep.flags.push('listed-twice');
+      keep.duplicateCount = same.length;
+    }
+    if (byFirst.size > 1) {
+      // Same surname and birthday, different first name: twins, and exactly the
+      // case the first-name tie-breaker exists for. Both rows survive.
+      for (const record of group) {
+        if (!dropped.has(record)) record.flags.push('possible-siblings');
+      }
+    }
+  }
+
+  return records.filter((record) => !dropped.has(record));
+}
+
+// ---------------------------------------------------------------------------
+// P1 — the reconciliation, checked here rather than left to the caller
+// ---------------------------------------------------------------------------
+
+function finish({ lines, layout, records, ignored, errors, refusalValue, extras }) {
+  const recordLines = records.reduce((n, r) => n + r.lineNumbers.length, 0);
+  const ignoredLines = ignored.reduce((n, e) => n + e.lineNumbers.length, 0);
+  const errorLines = errors.reduce((n, e) => n + e.lineNumbers.length, 0);
+  const accounted = recordLines + ignoredLines + errorLines;
+
+  ignored.sort((a, b) => a.lineNumbers[0] - b.lineNumbers[0]);
+  errors.sort((a, b) => a.lineNumbers[0] - b.lineNumbers[0]);
+
+  return {
+    layout,
+    blockSize: null,
+    fieldCount: null,
+    header: null,
+    verdict: '',
+    columns: null,
+    ignoredColumns: [],
+    dateOrientation: null,
+    nameOrder: 'first-last',
+    needs: [],
+    ...extras,
+    records,
+    ignored,
+    errors,
+    refusal: refusalValue ?? null,
+    counts: {
+      lines: lines.length,
+      records: records.length,
+      recordLines,
+      ignored: ignored.length,
+      ignoredLines,
+      errors: errors.length,
+      errorLines,
+      accounted,
+      reconciled: accounted === lines.length,
+    },
+  };
+}

--- a/school-booking/parse.js
+++ b/school-booking/parse.js
@@ -71,7 +71,7 @@ const SERIAL = /^\d{5}$/;
 // for every serial above 60. The window is 1900–2100: a five-digit integer is
 // the weakest date shape there is, and bounding it keeps a column of student
 // IDs from reading as dates. It is also why serials are only consulted when no
-// unambiguous date shape exists anywhere (see `dateColumns`).
+// unambiguous date shape exists anywhere (see `dateBearing`).
 const SERIAL_EPOCH_UTC = Date.UTC(1899, 11, 30);
 const SERIAL_MIN = 1;
 const SERIAL_MAX = 73415; // 2100-12-31
@@ -88,8 +88,8 @@ function validDate(year, month, day) {
   return day <= last;
 }
 
-const iso = (year, month, day) =>
-  `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+const pad = (n, width) => String(n).padStart(width, '0');
+const iso = (year, month, day) => `${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`;
 
 // `strict` excludes bare five-digit serials. Detection runs strict first so a
 // list that has a real date column is never anchored on an integer column.
@@ -237,6 +237,10 @@ function splitFields(raw, delimiter) {
   if (delimiter === 'tab') fields = raw.split('\t').map((f) => f.trim());
   else if (delimiter === 'spaces') fields = trimmed.split(/\s{2,}/).map((f) => f.trim());
   else fields = [trimmed];
+  // A line of nothing but delimiters carries no data, so it is blank — not a
+  // one-field row. Appending phantom tabs to a trailing empty line is exactly
+  // how this arises, and counting it as content would invent a junk line.
+  if (fields.every((f) => f === '')) return [];
   // Phantom trailing columns: styled but empty cells arrive as trailing tabs
   // and turn "this list has 3 columns" into "6 columns, three of them blank".
   // Interior blanks are left alone — those are missing values, not padding.
@@ -321,9 +325,18 @@ function isNameShaped(value) {
 }
 
 const label = (text) => String(text ?? '').toLowerCase().replace(/[^a-z]/g, '');
-const FIRST_WORDS = ['first', 'given', 'preferred', 'forename', 'christian'];
+const FIRST_WORDS = ['first', 'given', 'preferred', 'forename', 'christian', 'nickname'];
 const LAST_WORDS = ['last', 'surname', 'family'];
 const COMBINED_LABELS = ['name', 'studentname', 'fullname', 'student', 'pupil'];
+
+// A preferred name is a nickname, not the legal name, and the two must stay
+// tellable apart: a first-name mismatch against Clubworx is then an *expected*
+// outcome of a correct match, which weakens the first-name tie-breaker exactly
+// where identity.js (#65) needs it — for twins. One of the three real lists
+// ships a column headed `PreferredName`, so this is not hypothetical.
+const PREFERRED_WORDS = ['preferred', 'nickname', 'knownas'];
+
+const isPreferredLabel = (text) => PREFERRED_WORDS.some((w) => label(text).includes(w));
 
 function mapColumns(dataRows, width, dobCol, header) {
   const others = [];
@@ -337,11 +350,23 @@ function mapColumns(dataRows, width, dobCol, header) {
     const first = others.find((c) => FIRST_WORDS.some((w) => label(header[c]).includes(w)));
     const last = others.find((c) => LAST_WORDS.some((w) => label(header[c]).includes(w)));
     if (first !== undefined && last !== undefined && first !== last) {
-      return { firstName: first, lastName: last, combined: null, nameOrderKnown: true };
+      return {
+        firstName: first,
+        lastName: last,
+        combined: null,
+        nameOrderKnown: true,
+        firstNameIsPreferred: isPreferredLabel(header[first]),
+      };
     }
     const combined = others.find((c) => COMBINED_LABELS.includes(label(header[c])));
     if (combined !== undefined) {
-      return { firstName: null, lastName: null, combined, nameOrderKnown: false };
+      return {
+        firstName: null,
+        lastName: null,
+        combined,
+        nameOrderKnown: false,
+        firstNameIsPreferred: false,
+      };
     }
   }
 
@@ -354,10 +379,19 @@ function mapColumns(dataRows, width, dobCol, header) {
       lastName: nameShaped[1],
       combined: null,
       nameOrderKnown: false,
+      // Without a header there is nothing that could say so either way, and
+      // guessing "legal" would be the silent half of the mistake.
+      firstNameIsPreferred: false,
     };
   }
   if (nameShaped.length === 1) {
-    return { firstName: null, lastName: null, combined: nameShaped[0], nameOrderKnown: false };
+    return {
+      firstName: null,
+      lastName: null,
+      combined: nameShaped[0],
+      nameOrderKnown: false,
+      firstNameIsPreferred: false,
+    };
   }
   return null;
 }
@@ -374,12 +408,21 @@ function columnLabel(header, index) {
 // three or more tokens anyway, so the token rule catches them without a list
 // that is culturally incomplete by nature and silently wrong when it misses.
 
-function splitCombinedName(value, nameOrder) {
+// Which half of a document-order split is the given name is P7's question, not
+// this function's, so every split routes through here rather than restating the
+// nameOrder test at each site.
+const ordered = (left, right, nameOrder) =>
+  nameOrder === 'last-first'
+    ? { firstName: right, lastName: left }
+    : { firstName: left, lastName: right };
+
+function splitCombinedName(value, nameOrder, chosenSplit) {
   const name = writeForm(value);
   if (!name) return { firstName: '', lastName: '', needs: null, flag: 'empty-name' };
 
   if (name.includes(',')) {
-    // `Surname, Given` — the only reading a comma has in a name field.
+    // `Surname, Given` — the only reading a comma has in a name field, and it
+    // is explicit about which half is which, so nameOrder does not apply.
     // Confirmed once for the list, not once per row.
     const [surname, ...rest] = name.split(',');
     return {
@@ -393,19 +436,14 @@ function splitCombinedName(value, nameOrder) {
   const tokens = name.split(' ');
   if (tokens.length === 2) {
     // Auto-split: no other reading exists. Which way round is P7's problem.
-    const [a, b] = tokens;
-    return nameOrder === 'last-first'
-      ? { firstName: b, lastName: a, needs: null, flag: null }
-      : { firstName: a, lastName: b, needs: null, flag: null };
+    return { ...ordered(tokens[0], tokens[1], nameOrder), needs: null, flag: null };
   }
 
   if (tokens.length === 1) {
-    return {
-      firstName: '',
-      lastName: tokens[0],
-      needs: { kind: 'name-split', tokens, splitPoints: [], suggested: null },
-      flag: 'single-token-name',
-    };
+    // One token cannot be split, so there is no split to confirm and P8's table
+    // has no row for it. It is surfaced as a flag — which is enough to hold the
+    // row at needs-confirmation — rather than as a question with no answers.
+    return { firstName: '', lastName: tokens[0], needs: null, flag: 'single-token-name' };
   }
 
   // Three or more tokens: per-row confirmation, offering the split points as
@@ -415,12 +453,17 @@ function splitCombinedName(value, nameOrder) {
   // list needs about four confirmations, not sixty-three.
   const splitPoints = tokens.map((_, i) => i).slice(1);
   const suggested = nameOrder === 'last-first' ? 1 : tokens.length - 1;
-  const applied =
-    nameOrder === 'last-first'
-      ? { firstName: tokens.slice(1).join(' '), lastName: tokens[0] }
-      : { firstName: tokens.slice(0, -1).join(' '), lastName: tokens[tokens.length - 1] };
+  const at = (k) => ordered(tokens.slice(0, k).join(' '), tokens.slice(k).join(' '), nameOrder);
+
+  // An answered split is a settled row: this is the only channel by which the
+  // question below can come back, so without it #71 would have to re-implement
+  // the splitting the module already emits split points for.
+  if (splitPoints.includes(chosenSplit)) {
+    return { ...at(chosenSplit), needs: null, flag: null };
+  }
+
   return {
-    ...applied,
+    ...at(suggested),
     needs: { kind: 'name-split', tokens, splitPoints, suggested },
     flag: 'name-split',
   };
@@ -432,11 +475,14 @@ function splitCombinedName(value, nameOrder) {
 
 const REFUSALS = {
   'layout-not-held': 'The layout could not be established from the dates in this list.',
-  'no-dob-column': 'No column holds a date in every row, so the date of birth cannot be identified.',
-  'dob-column-ambiguous': 'More than one column holds a date in every row, so the date of birth is ambiguous.',
+  'no-dob-column':
+    'No column holds a date in every row, so the date of birth cannot be identified.',
+  'dob-column-ambiguous':
+    'More than one column holds a date in every row, so the date of birth is ambiguous.',
   'no-name-columns': 'No column holds names in every row.',
   'date-orientation-contradiction':
-    'This list contains dates that prove both day/month and month/day, so it cannot be read safely.',
+    'This list contains dates that prove both day/month and month/day, so it cannot be read '
+    + 'safely.',
 };
 
 const refusal = (code, extra = {}) => ({ code, message: REFUSALS[code], ...extra });
@@ -446,10 +492,17 @@ const refusal = (code, extra = {}) => ({ code, message: REFUSALS[code], ...extra
  * @param {object} [options]
  * @param {'dmy'|'mdy'} [options.dateOrientation]  answer to the P11 question
  * @param {'first-last'|'last-first'} [options.nameOrder]  answer to the P7 question
+ * @param {Object<number, number>} [options.nameSplits]  answers to the P8
+ *        per-row question: first source line number → chosen split point
  * @param {string} [options.eventDate]  ISO date, enables the P13 age band
+ *
+ * Every question this module raises in `needs` has an option above that answers
+ * it. Layout and column overrides deliberately do not: those are inferences
+ * with a UI affordance rather than questions, and their shape belongs to #71.
  */
 export function parseStudentList(text, options = {}) {
   const nameOrder = options.nameOrder === 'last-first' ? 'last-first' : 'first-last';
+  const nameSplits = options.nameSplits ?? {};
   const lines = splitLines(text);
   const delimiter = detectDelimiter(lines);
 
@@ -487,17 +540,36 @@ export function parseStudentList(text, options = {}) {
     });
 
   if (filled.length === 0) {
-    return finish({ lines, layout: null, records: [], ignored, errors, refusalValue: null, extras: {} });
+    return finish({
+      lines,
+      layout: null,
+      records: [],
+      ignored,
+      errors,
+      refusalValue: null,
+      extras: {},
+    });
   }
 
   // --- layout ------------------------------------------------------------
-  const vertical = delimiter === 'none';
+  // The delimiter narrows the hypothesis; the modal field count decides it. A
+  // list whose rows hold one field each cannot be one record per line whatever
+  // its delimiter, so a vertical list carrying a single stray double-space is
+  // still read as vertical rather than refused for having no name columns.
+  const counts = new Map();
+  for (const c of filled) counts.set(c.fields.length, (counts.get(c.fields.length) ?? 0) + 1);
+  const modalWidth = modalCount([...counts.entries()]);
+  const vertical = modalWidth === 1;
+
   let rows; // { fields, lineNumbers }
   let header = null;
   let width;
   let blockSize = null;
 
   if (vertical) {
+    // Every line contributes its first field: in a vertical list that is the
+    // whole line, and where a stray delimiter split one, the remainder is not
+    // part of the repeating block.
     const seq = filled.map((c) => ({ value: c.fields[0], n: c.n }));
     const shape = detectVertical(seq, true) || detectVertical(seq, false);
     if (!shape) return bail('layout-not-held');
@@ -527,9 +599,7 @@ export function parseStudentList(text, options = {}) {
       errors.push({ lineNumbers: [cell.n], text: cell.value, reason: 'incomplete-block' });
     }
   } else {
-    const counts = new Map();
-    for (const c of filled) counts.set(c.fields.length, (counts.get(c.fields.length) ?? 0) + 1);
-    width = modalCount([...counts.entries()]);
+    width = modalWidth;
     rows = filled
       .filter((c) => c.fields.length === width)
       .map((c) => ({ fields: c.fields, lineNumbers: [c.n], raw: c.raw }));
@@ -571,12 +641,17 @@ export function parseStudentList(text, options = {}) {
         // — and it is the only line whose text this parser reads for meaning.
         header = cell.fields;
         ignored.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'header' });
-      } else if (before && !hasDate && cell.fields.length !== width) {
-        // Junk is defined by position: no date, a field count unlike the modal
-        // one, and before the first good record. The school title line and the
-        // stray prose sentence both collapse to a single field; data rows do not.
-        ignored.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'junk' });
       } else if (before && !hasDate) {
+        // Junk is defined by position: no date, and before the first good
+        // record. The school title line and the stray prose sentence both
+        // collapse to a single field; data rows do not.
+        //
+        // P9 also names a field count unlike the modal one, but that clause is
+        // what separates junk from the *header* — which is caught above and
+        // ignored under its own reason. Once the header is taken, a further
+        // modal-width date-free line before the first record (a second header
+        // from a merged export) is junk too: P9's protection is positional, and
+        // nothing before the first good record can be a hidden student.
         ignored.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'junk' });
       } else {
         // After the first good record, a line that does not parse is
@@ -592,7 +667,9 @@ export function parseStudentList(text, options = {}) {
   if (!mapping) return bail('no-name-columns');
 
   const usedCols = new Set(
-    [dobCol, mapping.firstName, mapping.lastName, mapping.combined].filter((c) => c !== null && c !== undefined)
+    [dobCol, mapping.firstName, mapping.lastName, mapping.combined].filter(
+      (c) => c !== null && c !== undefined
+    )
   );
   const ignoredColumns = [];
   for (let c = 0; c < width; c++) {
@@ -609,19 +686,23 @@ export function parseStudentList(text, options = {}) {
   let orientation = null;
   let orientationBasis;
   let orientationSample = null;
-  let orientationRefusal = null;
 
   if (evidence.size > 1) {
-    // Contradictory evidence refuses the whole paste, showing the two rows.
-    orientationBasis = 'contradicted';
-    orientationRefusal = refusal('date-orientation-contradiction', {
+    // Contradictory evidence refuses the whole *paste*, and refusing has to
+    // mean no rows. Falling through to the row loop here would let each
+    // self-proving date be read on its own orientation — the row-by-row
+    // decision P11 exists to forbid — and would hand the caller apply-ready
+    // rows for a list the spec says cannot be read at all.
+    return bail('date-orientation-contradiction', {
       rows: [...evidence.entries()].map(([reading, row]) => ({
         reading,
         value: row.fields[dobCol],
         lineNumbers: row.lineNumbers,
       })),
     });
-  } else if (evidence.size === 1) {
+  }
+
+  if (evidence.size === 1) {
     orientation = [...evidence.keys()][0];
     orientationBasis = 'proved'; // a field above 12 is a proof, not a heuristic
   } else if (options.dateOrientation === 'dmy' || options.dateOrientation === 'mdy') {
@@ -675,7 +756,13 @@ export function parseStudentList(text, options = {}) {
     let names;
 
     if (mapping.combined !== null) {
-      names = splitCombinedName(row.fields[mapping.combined], nameOrder);
+      // Splits are answered per row, keyed by the row's first source line —
+      // the one identifier that survives a re-parse of the same paste.
+      names = splitCombinedName(
+        row.fields[mapping.combined],
+        nameOrder,
+        nameSplits[row.lineNumbers[0]]
+      );
       rawFirst = row.fields[mapping.combined];
       rawLast = row.fields[mapping.combined];
       if (names.flag === 'comma-split') sawComma = true;
@@ -683,14 +770,10 @@ export function parseStudentList(text, options = {}) {
       rawFirst = row.fields[mapping.firstName];
       rawLast = row.fields[mapping.lastName];
       names = {
-        firstName: writeForm(rawFirst),
-        lastName: writeForm(rawLast),
+        ...ordered(writeForm(rawFirst), writeForm(rawLast), nameOrder),
         needs: null,
         flag: null,
       };
-      if (nameOrder === 'last-first') {
-        names = { ...names, firstName: names.lastName, lastName: names.firstName };
-      }
     }
 
     const read = readDate(rawDob, orientation);
@@ -728,6 +811,7 @@ export function parseStudentList(text, options = {}) {
       compare: { firstName: compareForm(names.firstName), lastName: compareForm(names.lastName) },
       flags,
       needs,
+      duplicateCount: 1, // raised by collapseDuplicates when a row absorbs another
       state: 'clean', // set below, once dedup has had its say
     });
   }
@@ -742,13 +826,16 @@ export function parseStudentList(text, options = {}) {
 
   records = collapseDuplicates(records);
   for (const record of records) {
-    record.state = record.needs.length > 0 || record.flags.length > 0 ? 'needs-confirmation' : 'clean';
+    const unsettled = record.needs.length > 0 || record.flags.length > 0;
+    record.state = unsettled ? 'needs-confirmation' : 'clean';
   }
 
   const students = records.length;
-  const verdict = vertical
-    ? `read as ${blockSize} fields per student — ${students} student${students === 1 ? '' : 's'} found`
-    : `read as one student per line, ${width} column${width === 1 ? '' : 's'} — ${students} student${students === 1 ? '' : 's'} found`;
+  const plural = (n, noun) => `${n} ${noun}${n === 1 ? '' : 's'}`;
+  const shape = vertical
+    ? `read as ${blockSize} fields per student`
+    : `read as one student per line, ${plural(width, 'column')}`;
+  const verdict = `${shape} — ${plural(students, 'student')} found`;
 
   return finish({
     lines,
@@ -756,7 +843,7 @@ export function parseStudentList(text, options = {}) {
     records,
     ignored,
     errors,
-    refusalValue: orientationRefusal,
+    refusalValue: null, // every refusal returns through bail() above
     extras: {
       blockSize,
       fieldCount: width,
@@ -767,6 +854,9 @@ export function parseStudentList(text, options = {}) {
         firstName: mapping.firstName,
         lastName: mapping.lastName,
         combined: mapping.combined,
+        // Emitted so identity.js can weaken the first-name tie-breaker rather
+        // than read a nickname mismatch as a wrong match.
+        firstNameIsPreferred: mapping.firstNameIsPreferred,
       },
       ignoredColumns,
       dateOrientation: {

--- a/school-booking/test/parse.test.js
+++ b/school-booking/test/parse.test.js
@@ -1,0 +1,599 @@
+// The acceptance bar from #64 and §14: all three committed fixtures parse to
+// their exact expected record counts, plus a synthesised phantom-trailing-column
+// variant and a CRLF / leading-blank variant.
+//
+// The fixtures reproduce the *shape* of three real lists with invented data, at
+// reduced size — the real lists hold 21, 63 and 18 students (docs/school-lists/
+// README.md). Where a count below differs from the number quoted on the ticket,
+// it is because the committed fixture is the smaller reproduction; the vertical
+// case is additionally tested at its real 21 students, because "21, not 126" is
+// the specific failure this module exists to prevent.
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { ageOn, compareForm, parseStudentList, writeForm } from '../parse.js';
+
+const fixture = (name) =>
+  readFileSync(new URL(`../../docs/school-lists/${name}`, import.meta.url), 'utf8');
+
+const VERTICAL = fixture('fixture-1-vertical.txt');
+const SPREADSHEET = fixture('fixture-2-spreadsheet.tsv');
+const WORD_TABLE = fixture('fixture-3-word-table.txt');
+
+// P1 is the assertion the rest of the rules lean on, so it is checked on every
+// parse in this file rather than once: every input line lands in exactly one
+// bucket, and a record in a vertical list accounts for all of its lines.
+const expectReconciled = (result) => {
+  expect(result.counts.reconciled).toBe(true);
+  expect(result.counts.accounted).toBe(result.counts.lines);
+};
+
+describe('the three committed fixtures', () => {
+  test('fixture 1 is a vertical list: 5 students, not 30', () => {
+    const result = parseStudentList(VERTICAL);
+    expect(result.layout).toBe('vertical');
+    expect(result.blockSize).toBe(6);
+    expect(result.records).toHaveLength(5);
+    expectReconciled(result);
+  });
+
+  test('fixture 2 is a 3-column spreadsheet paste: 6 students', () => {
+    const result = parseStudentList(SPREADSHEET);
+    expect(result.layout).toBe('horizontal');
+    expect(result.fieldCount).toBe(3);
+    expect(result.records).toHaveLength(6);
+    expectReconciled(result);
+  });
+
+  test('fixture 3 is a space-aligned Word table: 8 students', () => {
+    const result = parseStudentList(WORD_TABLE);
+    expect(result.layout).toBe('horizontal');
+    expect(result.fieldCount).toBe(3);
+    expect(result.records).toHaveLength(8);
+    expectReconciled(result);
+  });
+});
+
+describe('the failure this module exists to prevent', () => {
+  // Built at the real list's size rather than the fixture's, because "21, not
+  // 126" is the number on the ticket and 5-vs-30 does not read as the same bug.
+  const HEADER = ['PreferredName', 'LastName', 'Dob', 'FormGroup', 'YearLevel', 'Email'];
+  const student = (n) => [
+    `First${n}`,
+    `Surname${n}`,
+    `${(n % 28) + 1}/${(n % 12) + 1}/2010`,
+    'HARLOW',
+    '10',
+    `first${n}.surname${n}@example.edu.au`,
+  ];
+  const twentyOne = ['', ...HEADER, ...Array.from({ length: 21 }, (_, i) => student(i + 1)).flat()];
+
+  test('a 21-student vertical list reads as 21 students, not 126', () => {
+    const result = parseStudentList(twentyOne.join('\n'));
+    expect(result.layout).toBe('vertical');
+    expect(result.records).toHaveLength(21);
+    expectReconciled(result);
+  });
+});
+
+describe('variants the committed files cannot carry', () => {
+  // Trailing empty fields do not survive being committed and reviewed, so the
+  // phantom-column case (styled but empty cells at columns J and W in the real
+  // list 2) has to be built here. It is what turns "this list has 3 columns"
+  // into "6 columns, three of them blank".
+  test('phantom trailing columns do not change the record count', () => {
+    const withPhantoms = SPREADSHEET.split('\n')
+      .map((line) => (line === '' ? line : `${line}\t\t\t`))
+      .join('\n');
+    const result = parseStudentList(withPhantoms);
+    expect(result.fieldCount).toBe(3);
+    expect(result.records).toHaveLength(6);
+    expectReconciled(result);
+  });
+
+  test('CRLF line endings and a leading blank line do not change the counts', () => {
+    for (const [name, text, expected] of [
+      ['vertical', VERTICAL, 5],
+      ['spreadsheet', SPREADSHEET, 6],
+      ['word table', WORD_TABLE, 8],
+    ]) {
+      const crlf = `\r\n${text.replace(/\n/g, '\r\n')}`;
+      const result = parseStudentList(crlf);
+      expect(result.records, name).toHaveLength(expected);
+      expectReconciled(result);
+    }
+  });
+
+  test('a BOM on the first line is stripped rather than joining the first field', () => {
+    const result = parseStudentList(`﻿${SPREADSHEET}`);
+    expect(result.records).toHaveLength(6);
+    expectReconciled(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+const tsv = (rows) => rows.map((r) => (Array.isArray(r) ? r.join('\t') : r)).join('\n');
+
+describe('P2 — the list-level inferences are emitted, not just the rows', () => {
+  // The dangerous decisions here are list-level, not row-level. What is not
+  // emitted cannot be shown, confirmed, or tested.
+  test('the vertical fixture reports its layout, mapping and orientation', () => {
+    const result = parseStudentList(VERTICAL);
+    expect(result.header).toEqual([
+      'PreferredName',
+      'LastName',
+      'Dob',
+      'FormGroup',
+      'YearLevel',
+      'Email',
+    ]);
+    expect(result.columns).toEqual({ dob: 2, firstName: 0, lastName: 1, combined: null });
+    expect(result.dateOrientation.value).toBe('dmy');
+    expect(result.dateOrientation.basis).toBe('proved');
+    expect(result.verdict).toBe('read as 6 fields per student — 5 students found');
+  });
+
+  test('ignored columns are named, which is the tell that the mapping went wrong', () => {
+    const result = parseStudentList(VERTICAL);
+    expect(result.ignoredColumns.map((c) => c.label)).toEqual([
+      'FormGroup',
+      'YearLevel',
+      'Email',
+    ]);
+  });
+
+  test('the header block of a vertical list is ignored, not read as a student', () => {
+    const result = parseStudentList(VERTICAL);
+    expect(result.ignored.filter((e) => e.reason === 'header')).toHaveLength(6);
+    expect(result.ignored.filter((e) => e.reason === 'blank')).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe('P4 — the DOB anchor, and what happens when it does not hold', () => {
+  test('a vertical list is anchored by a constant gap between date-shaped lines', () => {
+    const result = parseStudentList(VERTICAL);
+    expect(result.blockSize).toBe(6);
+    expect(result.columns.dob).toBe(2);
+  });
+
+  test('two date positions per block is not a stride, so the paste is refused', () => {
+    // Gaps of 1 and 2 alternating: nothing here establishes a block size, and
+    // guessing one is how 21 students become 126.
+    const result = parseStudentList(
+      ['Katie', '23/4/2010', '1/1/2020', 'Tomas', '7/11/2010', '2/2/2020'].join('\n')
+    );
+    expect(result.refusal.code).toBe('layout-not-held');
+    expect(result.records).toHaveLength(0);
+    expectReconciled(result);
+  });
+
+  test('a single date cannot establish a stride, so it is refused rather than guessed', () => {
+    const result = parseStudentList(['Name', 'DOB', 'Katie', '23/4/2010'].join('\n'));
+    expect(result.refusal.code).toBe('layout-not-held');
+    expectReconciled(result);
+  });
+
+  test('no date-shaped column at all is a refusal, not an empty result', () => {
+    const result = parseStudentList(
+      tsv([
+        ['Katie', 'Fernsby', 'HARLOW'],
+        ['Tomas', 'Oakhill', 'BRIGGS'],
+      ])
+    );
+    expect(result.refusal.code).toBe('no-dob-column');
+    expectReconciled(result);
+  });
+
+  test('two date-shaped columns is a refusal, because the DOB is then ambiguous', () => {
+    const result = parseStudentList(
+      tsv([
+        ['Katie', 'Fernsby', '23/4/2010', '1/1/2020'],
+        ['Tomas', 'Oakhill', '7/11/2010', '2/2/2020'],
+      ])
+    );
+    expect(result.refusal.code).toBe('dob-column-ambiguous');
+    expectReconciled(result);
+  });
+});
+
+describe('P6 — columns are mapped content-first, never by position', () => {
+  test('a five-digit ID column does not steal the anchor from a real date column', () => {
+    // The strict-first pass is what makes this hold: a bare five-digit integer
+    // is the weakest date shape there is, and a list carrying real dates must
+    // never be anchored on one.
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'Student ID', 'DOB'],
+        ['Katie', 'Fernsby', '40365', '23/4/2010'],
+        ['Tomas', 'Oakhill', '40731', '7/11/2010'],
+      ])
+    );
+    expect(result.columns).toEqual({ dob: 3, firstName: 0, lastName: 1, combined: null });
+    expect(result.ignoredColumns.map((c) => c.label)).toEqual(['Student ID']);
+    expect(result.records[0].write.dob).toBe('2010-04-23');
+  });
+
+  test('reordering the columns changes the mapping, not the result', () => {
+    // Fixed column order is rejected outright: the first school that reorders
+    // its export would otherwise produce wrong permanent contacts, silently.
+    const result = parseStudentList(
+      tsv([
+        ['DOB', 'Surname', 'First name'],
+        ['23/4/2010', 'Fernsby', 'Katie'],
+        ['7/11/2010', 'Oakhill', 'Tomas'],
+      ])
+    );
+    expect(result.columns).toEqual({ dob: 0, firstName: 2, lastName: 1, combined: null });
+    expect(result.records[0].write).toEqual({
+      firstName: 'Katie',
+      lastName: 'Fernsby',
+      dob: '2010-04-23',
+    });
+  });
+});
+
+describe('P7 — a headerless list asks which way round the names are', () => {
+  const headerless = tsv([
+    ['Katie', 'Fernsby', '23/4/2010'],
+    ['Tomas', 'Oakhill', '7/11/2010'],
+  ]);
+
+  test('the order is asked, defaulted to first-then-last, with real sample rows', () => {
+    const result = parseStudentList(headerless);
+    const ask = result.needs.find((n) => n.kind === 'name-order');
+    expect(ask.default).toBe('first-last');
+    expect(ask.samples).toHaveLength(2);
+    expect(ask.samples[0].values).toEqual(['Katie', 'Fernsby']);
+    expect(result.records[0].write.firstName).toBe('Katie');
+  });
+
+  test('answering it swaps the fields and retires the question', () => {
+    const result = parseStudentList(headerless, { nameOrder: 'last-first' });
+    expect(result.records[0].write).toEqual({
+      firstName: 'Fernsby',
+      lastName: 'Katie',
+      dob: '2010-04-23',
+    });
+    expect(result.needs.some((n) => n.kind === 'name-order')).toBe(false);
+  });
+
+  test('a header names the columns, so nothing is asked', () => {
+    expect(parseStudentList(SPREADSHEET).needs.some((n) => n.kind === 'name-order')).toBe(false);
+  });
+});
+
+describe('P8 — a combined name column, with graded confirmation', () => {
+  const combined = tsv([
+    ['Name', 'DOB'],
+    ['Katie Fernsby', '23/4/2010'],
+    ['Mary Jane Oakhill', '7/11/2010'],
+    ["O'Brien, Sean", '19/8/2010'],
+  ]);
+
+  test('two tokens auto-split, because no other reading exists', () => {
+    const result = parseStudentList(combined);
+    expect(result.columns.combined).toBe(0);
+    expect(result.records[0].write.firstName).toBe('Katie');
+    expect(result.records[0].write.lastName).toBe('Fernsby');
+    expect(result.records[0].state).toBe('clean');
+  });
+
+  test('three or more tokens ask per row, with the split points offered', () => {
+    const result = parseStudentList(combined);
+    const row = result.records[1];
+    expect(row.state).toBe('needs-confirmation');
+    expect(row.flags).toContain('name-split');
+    const ask = row.needs.find((n) => n.kind === 'name-split');
+    expect(ask.tokens).toEqual(['Mary', 'Jane', 'Oakhill']);
+    expect(ask.splitPoints).toEqual([1, 2]);
+    expect(ask.suggested).toBe(2);
+    // A default is applied so the row is showable; the state is what stops it
+    // being written before someone agrees.
+    expect(row.write).toMatchObject({ firstName: 'Mary Jane', lastName: 'Oakhill' });
+  });
+
+  test('a comma auto-splits as Surname, Given and is confirmed once for the list', () => {
+    const result = parseStudentList(combined);
+    const row = result.records[2];
+    expect(row.write.lastName).toBe("O'Brien");
+    expect(row.write.firstName).toBe('Sean');
+    expect(row.state).toBe('clean');
+    expect(result.needs.filter((n) => n.kind === 'combined-name-comma')).toHaveLength(1);
+  });
+
+  test('no particle list is consulted — van/der/de fall out of the token rule', () => {
+    const result = parseStudentList(
+      tsv([
+        ['Name', 'DOB'],
+        ['Priya van der Meer', '23/4/2010'],
+      ])
+    );
+    const ask = result.records[0].needs.find((n) => n.kind === 'name-split');
+    expect(ask.tokens).toEqual(['Priya', 'van', 'der', 'Meer']);
+    expect(ask.splitPoints).toEqual([1, 2, 3]);
+  });
+});
+
+describe('P9 — junk is defined by position', () => {
+  test('the title line and the prose sentence are junk; the header is a header', () => {
+    const result = parseStudentList(WORD_TABLE);
+    const reasons = result.ignored.map((e) => e.reason);
+    expect(reasons.filter((r) => r === 'junk')).toHaveLength(2);
+    expect(reasons.filter((r) => r === 'header')).toHaveLength(1);
+    expect(reasons.filter((r) => r === 'blank')).toHaveLength(3);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('the same line is junk before the first record and unparseable after it', () => {
+    const stray = 'Please add Otto to the list if there is room.';
+    const lines = WORD_TABLE.trimEnd().split('\n');
+
+    const before = parseStudentList([...lines.slice(0, 4), stray, ...lines.slice(4)].join('\n'));
+    expect(before.ignored.filter((e) => e.reason === 'junk')).toHaveLength(3);
+    expect(before.errors).toHaveLength(0);
+    expect(before.records).toHaveLength(8);
+    expectReconciled(before);
+
+    // After the first good record the same text is where a real student hides,
+    // so it blocks Apply (P15) rather than being quietly dropped.
+    const after = parseStudentList([...lines, stray].join('\n'));
+    expect(after.errors).toHaveLength(1);
+    expect(after.errors[0].reason).toBe('unparseable');
+    expect(after.ignored.filter((e) => e.reason === 'junk')).toHaveLength(2);
+    expect(after.records).toHaveLength(8);
+    expectReconciled(after);
+  });
+});
+
+describe('P11 — date orientation is a property of the whole list', () => {
+  test('one field above 12 fixes the whole list — a proof, not a heuristic', () => {
+    const result = parseStudentList(SPREADSHEET);
+    expect(result.dateOrientation).toMatchObject({ value: 'dmy', basis: 'proved' });
+    // 7/11 is individually ambiguous and is read by the list's orientation.
+    expect(result.records[1].write.dob).toBe('2010-11-07');
+  });
+
+  test('a proof overrides an answer, because arithmetic outranks a click', () => {
+    const result = parseStudentList(SPREADSHEET, { dateOrientation: 'mdy' });
+    expect(result.dateOrientation).toMatchObject({ value: 'dmy', basis: 'proved' });
+  });
+
+  test('evidence for both orientations refuses the whole paste, naming the two rows', () => {
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Katie', 'Fernsby', '23/4/2010'],
+        ['Tomas', 'Oakhill', '7/25/2010'],
+      ])
+    );
+    expect(result.refusal.code).toBe('date-orientation-contradiction');
+    expect(result.refusal.rows.map((r) => r.reading).sort()).toEqual(['dmy', 'mdy']);
+    expect(result.refusal.rows.map((r) => r.value)).toEqual(['23/4/2010', '7/25/2010']);
+    expectReconciled(result);
+  });
+
+  test('a wholly ambiguous list asks, showing a real date read both ways', () => {
+    const ambiguous = tsv([
+      ['First name', 'Surname', 'DOB'],
+      ['Katie', 'Fernsby', '3/4/2010'],
+      ['Tomas', 'Oakhill', '5/6/2011'],
+    ]);
+    const result = parseStudentList(ambiguous);
+    expect(result.dateOrientation.basis).toBe('ask');
+    expect(result.dateOrientation.sample).toMatchObject({
+      value: '3/4/2010',
+      dmy: '2010-04-03',
+      mdy: '2010-03-04',
+    });
+    // Never defaulted silently: no row carries a date until the question is
+    // answered, and every row says so.
+    expect(result.records.map((r) => r.write.dob)).toEqual([null, null]);
+    expect(result.records.every((r) => r.state === 'needs-confirmation')).toBe(true);
+    expect(result.needs.some((n) => n.kind === 'date-orientation')).toBe(true);
+
+    const answered = parseStudentList(ambiguous, { dateOrientation: 'mdy' });
+    expect(answered.dateOrientation.basis).toBe('supplied');
+    expect(answered.records.map((r) => r.write.dob)).toEqual(['2010-03-04', '2011-05-06']);
+  });
+
+  test('an ISO list is self-identifying and asks nothing', () => {
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Katie', 'Fernsby', '2010-04-23'],
+        ['Tomas', 'Oakhill', '2010-11-07'],
+      ])
+    );
+    expect(result.dateOrientation.basis).toBe('self-identifying');
+    expect(result.records.map((r) => r.write.dob)).toEqual(['2010-04-23', '2010-11-07']);
+    expect(result.needs.some((n) => n.kind === 'date-orientation')).toBe(false);
+  });
+});
+
+describe('P12 — the century constraint, and Excel serials', () => {
+  test('a two-digit year is 20xx', () => {
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Katie', 'Fernsby', '23/4/10'],
+        ['Tomas', 'Oakhill', '7/11/11'],
+      ])
+    );
+    expect(result.records.map((r) => r.write.dob)).toEqual(['2010-04-23', '2011-11-07']);
+  });
+
+  test('a DOB before 2000 is flagged not-a-student — sharper than guessing at names', () => {
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Katie', 'Fernsby', '23/4/2010'],
+        ['Alison', 'Thornbury', '14/6/1978'],
+      ])
+    );
+    expect(result.records).toHaveLength(2); // flagged, never dropped
+    expect(result.records[0].flags).toEqual([]);
+    expect(result.records[1].flags).toContain('not-a-student');
+    expect(result.records[1].state).toBe('needs-confirmation');
+  });
+
+  test('serials convert on the 1900 epoch, and the resulting dates are surfaced', () => {
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'Birth date'],
+        ['Katie', 'Fernsby', '40365'],
+        ['Tomas', 'Oakhill', '40731'],
+      ])
+    );
+    // The range the real list 2 actually holds: 2010-07-06 to 2011-07-07.
+    expect(result.records.map((r) => r.write.dob)).toEqual(['2010-07-06', '2011-07-07']);
+    // Not unambiguous — 1900 and 1904 are 1462 days apart — so the confirmation
+    // is on the resulting dates, which staff can check against expected ages.
+    expect(result.records.every((r) => r.flags.includes('excel-serial'))).toBe(true);
+    expect(result.records.every((r) => r.state === 'needs-confirmation')).toBe(true);
+    expect(result.needs.some((n) => n.kind === 'excel-serial-dates')).toBe(true);
+  });
+
+  test('an impossible date is an error, not a silently shifted one', () => {
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Katie', 'Fernsby', '23/4/2010'],
+        ['Tomas', 'Oakhill', '31/2/2010'],
+      ])
+    );
+    expect(result.records).toHaveLength(1);
+    expect(result.errors[0].reason).toBe('invalid-date');
+    expectReconciled(result);
+  });
+});
+
+describe('P13 — an implausible age is needs-confirmation, not a block', () => {
+  const list = tsv([
+    ['First name', 'Surname', 'DOB'],
+    ['Katie', 'Fernsby', '23/4/2010'],
+    ['Tiny', 'Tot', '23/4/2024'],
+  ]);
+
+  test('age is measured against the event date, and the run is not refused', () => {
+    const result = parseStudentList(list, { eventDate: '2026-09-02' });
+    expect(result.records).toHaveLength(2);
+    expect(result.records[0].flags).toEqual([]);
+    expect(result.records[1].flags).toContain('implausible-age');
+    expect(result.records[1].state).toBe('needs-confirmation');
+    expect(result.refusal).toBeNull();
+  });
+
+  test('without an event date there is nothing to measure against, so nothing is flagged', () => {
+    const result = parseStudentList(list);
+    expect(result.records[1].flags).toEqual([]);
+  });
+
+  test('ageOn does not credit a birthday that has not happened yet', () => {
+    expect(ageOn('2010-09-10', '2026-09-02')).toBe(15);
+    expect(ageOn('2010-09-02', '2026-09-02')).toBe(16);
+  });
+});
+
+describe('P14 — duplicates collapse visibly, twins stay as two rows', () => {
+  const list = tsv([
+    ['First name', 'Surname', 'DOB'],
+    ['Katie', 'Fernsby', '23/4/2010'],
+    ['KATIE', 'Fernsby', '23/4/2010'],
+    ['Nils', 'Quarrey', '19/8/2010'],
+    ['Bea', 'Quarrey', '19/8/2010'],
+  ]);
+
+  test('the same student listed twice collapses to one badged row', () => {
+    const result = parseStudentList(list);
+    const katie = result.records.find((r) => r.compare.firstName === 'katie');
+    expect(katie.flags).toContain('listed-twice');
+    expect(katie.duplicateCount).toBe(2);
+    // Both source lines stay attached to the survivor, which is what keeps the
+    // reconciliation honest through a collapse.
+    expect(katie.lineNumbers).toEqual([2, 3]);
+    // Case is never touched on the write form, so the first spelling survives.
+    expect(katie.write.firstName).toBe('Katie');
+  });
+
+  test('same surname and birthday, different first name, stays as two rows', () => {
+    const result = parseStudentList(list);
+    const quarreys = result.records.filter((r) => r.compare.lastName === 'quarrey');
+    expect(quarreys).toHaveLength(2);
+    expect(quarreys.every((r) => r.flags.includes('possible-siblings'))).toBe(true);
+    // Collapsing on surname + DOB alone would merge twins into one student, and
+    // nobody discovers the missing child until the session.
+    expect(quarreys.map((r) => r.write.firstName).sort()).toEqual(['Bea', 'Nils']);
+  });
+
+  test('a collapse never breaks the line reconciliation', () => {
+    const result = parseStudentList(list);
+    expect(result.records).toHaveLength(3);
+    expectReconciled(result);
+  });
+});
+
+describe('P10 — write form and compare form, kept apart', () => {
+  test('write form repairs the characters a Word export brings, and nothing else', () => {
+    expect(writeForm('  Zoë   O’Brien  ')).toBe("Zoë O'Brien");
+    expect(writeForm('Quarrey‑Blake')).toBe('Quarrey-Blake');
+    expect(writeForm('Van Dermeer')).toBe('Van Dermeer');
+    expect(writeForm('Fern​sby﻿')).toBe('Fernsby');
+    // Case is never touched and accents are never stripped: this string is
+    // written into a record that cannot be deleted.
+    expect(writeForm('MacTAVISH')).toBe('MacTAVISH');
+    expect(writeForm('Ferná́ndez'.normalize('NFD'))).toBe('Ferná́ndez'.normalize('NFC'));
+  });
+
+  test("compare form is what lets O'Brien match OBrien without ever writing OBrien", () => {
+    expect(compareForm("O'Brien")).toBe('obrien');
+    expect(compareForm('OBrien')).toBe('obrien');
+    expect(compareForm("o’brien")).toBe('obrien');
+    expect(compareForm('Quarrey-Blake')).toBe('quarreyblake');
+    expect(compareForm('Van Dermeer')).toBe('vandermeer');
+  });
+
+  test('every record carries both forms', () => {
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Bea', "O’Lindhardt", '23/4/2010'],
+      ])
+    );
+    expect(result.records[0].write.lastName).toBe("O'Lindhardt");
+    expect(result.records[0].compare.lastName).toBe('olindhardt');
+    expect(result.records[0].raw.lastName).toBe('O’Lindhardt');
+  });
+});
+
+describe('P1 — the reconciliation holds through the messy cases', () => {
+  test('junk, a header, blanks, a duplicate and an unparseable row all add up', () => {
+    const messy = [
+      'Example Grammar College Somewhere',
+      '',
+      'List of students attending weekly Rock Climbing.',
+      '',
+      ['First name', 'Surname', 'DOB'].join('\t'),
+      '',
+      ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+      ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+      ['Nils', 'Quarrey', '19/8/2010'].join('\t'),
+      'and Otto if there is room',
+      ['Bea', 'Lindhardt', '1/2/2011'].join('\t'),
+    ].join('\n');
+
+    const result = parseStudentList(messy);
+    expect(result.records).toHaveLength(3);
+    expect(result.errors).toHaveLength(1);
+    expect(result.counts.lines).toBe(11);
+    expect(result.counts.recordLines).toBe(4); // three records, one holding two lines
+    expectReconciled(result);
+  });
+
+  test('an empty paste reconciles too', () => {
+    const result = parseStudentList('');
+    expect(result.records).toHaveLength(0);
+    expectReconciled(result);
+  });
+});

--- a/school-booking/test/parse.test.js
+++ b/school-booking/test/parse.test.js
@@ -82,12 +82,21 @@ describe('variants the committed files cannot carry', () => {
   // list 2) has to be built here. It is what turns "this list has 3 columns"
   // into "6 columns, three of them blank".
   test('phantom trailing columns do not change the record count', () => {
+    // The README's own snippet, unmodified — including what it does to the
+    // trailing empty line, which becomes a row of nothing but tabs.
     const withPhantoms = SPREADSHEET.split('\n')
-      .map((line) => (line === '' ? line : `${line}\t\t\t`))
+      .map((l) => l + '\t\t\t')
       .join('\n');
     const result = parseStudentList(withPhantoms);
     expect(result.fieldCount).toBe(3);
     expect(result.records).toHaveLength(6);
+    expectReconciled(result);
+  });
+
+  test('a line of nothing but delimiters is blank, not a one-field junk row', () => {
+    const result = parseStudentList(`${SPREADSHEET}\t\t\t`);
+    expect(result.records).toHaveLength(6);
+    expect(result.ignored.filter((e) => e.reason === 'junk')).toHaveLength(0);
     expectReconciled(result);
   });
 
@@ -128,7 +137,13 @@ describe('P2 — the list-level inferences are emitted, not just the rows', () =
       'YearLevel',
       'Email',
     ]);
-    expect(result.columns).toEqual({ dob: 2, firstName: 0, lastName: 1, combined: null });
+    expect(result.columns).toEqual({
+      dob: 2,
+      firstName: 0,
+      lastName: 1,
+      combined: null,
+      firstNameIsPreferred: true,
+    });
     expect(result.dateOrientation.value).toBe('dmy');
     expect(result.dateOrientation.basis).toBe('proved');
     expect(result.verdict).toBe('read as 6 fields per student — 5 students found');
@@ -210,7 +225,13 @@ describe('P6 — columns are mapped content-first, never by position', () => {
         ['Tomas', 'Oakhill', '40731', '7/11/2010'],
       ])
     );
-    expect(result.columns).toEqual({ dob: 3, firstName: 0, lastName: 1, combined: null });
+    expect(result.columns).toEqual({
+      dob: 3,
+      firstName: 0,
+      lastName: 1,
+      combined: null,
+      firstNameIsPreferred: false,
+    });
     expect(result.ignoredColumns.map((c) => c.label)).toEqual(['Student ID']);
     expect(result.records[0].write.dob).toBe('2010-04-23');
   });
@@ -225,12 +246,45 @@ describe('P6 — columns are mapped content-first, never by position', () => {
         ['7/11/2010', 'Oakhill', 'Tomas'],
       ])
     );
-    expect(result.columns).toEqual({ dob: 0, firstName: 2, lastName: 1, combined: null });
+    expect(result.columns).toEqual({
+      dob: 0,
+      firstName: 2,
+      lastName: 1,
+      combined: null,
+      firstNameIsPreferred: false,
+    });
     expect(result.records[0].write).toEqual({
       firstName: 'Katie',
       lastName: 'Fernsby',
       dob: '2010-04-23',
     });
+  });
+});
+
+describe('a preferred name stays tellable apart from a legal first name', () => {
+  // CONTEXT.md § "Preferred name": *Avoid: treating it as the first name. The
+  // tie-breaker depends on telling them apart.* A first-name mismatch against
+  // Clubworx is an expected outcome of a *correct* match when the school ships
+  // a nickname column, which weakens the tie-breaker exactly where identity.js
+  // needs it — for twins.
+  test('a PreferredName column is mapped as the first name but marked as preferred', () => {
+    const result = parseStudentList(VERTICAL);
+    expect(result.columns.firstName).toBe(0);
+    expect(result.columns.firstNameIsPreferred).toBe(true);
+  });
+
+  test('an ordinary first-name column is not marked', () => {
+    expect(parseStudentList(SPREADSHEET).columns.firstNameIsPreferred).toBe(false);
+  });
+
+  test('with no header there is nothing that could say either way, so it is not claimed', () => {
+    const result = parseStudentList(
+      tsv([
+        ['Katie', 'Fernsby', '23/4/2010'],
+        ['Tomas', 'Oakhill', '7/11/2010'],
+      ])
+    );
+    expect(result.columns.firstNameIsPreferred).toBe(false);
   });
 });
 
@@ -303,6 +357,35 @@ describe('P8 — a combined name column, with graded confirmation', () => {
     expect(result.needs.filter((n) => n.kind === 'combined-name-comma')).toHaveLength(1);
   });
 
+  test('an answered split settles the row, so the UI never re-implements splitting', () => {
+    // Every question the module raises has an option that answers it; this is
+    // the channel for the per-row one. Row 2 of the paste starts at line 3.
+    const result = parseStudentList(combined, { nameSplits: { 3: 1 } });
+    const row = result.records[1];
+    expect(row.write).toMatchObject({ firstName: 'Mary', lastName: 'Jane Oakhill' });
+    expect(row.needs).toEqual([]);
+    expect(row.flags).toEqual([]);
+    expect(row.state).toBe('clean');
+  });
+
+  test('a split point that is not on offer is ignored rather than applied', () => {
+    const result = parseStudentList(combined, { nameSplits: { 3: 99 } });
+    expect(result.records[1].state).toBe('needs-confirmation');
+  });
+
+  test('a single token offers no split, because there is none to confirm', () => {
+    const result = parseStudentList(
+      tsv([
+        ['Name', 'DOB'],
+        ['Prince', '23/4/2010'],
+      ])
+    );
+    const row = result.records[0];
+    expect(row.flags).toContain('single-token-name');
+    expect(row.needs).toEqual([]); // not a question with no answers
+    expect(row.state).toBe('needs-confirmation');
+  });
+
   test('no particle list is consulted — van/der/de fall out of the token rule', () => {
     const result = parseStudentList(
       tsv([
@@ -326,6 +409,24 @@ describe('P9 — junk is defined by position', () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  test('a second header row from a merged export is junk, not a student', () => {
+    // P9 names three conditions, but the field-count one is what separates junk
+    // from the header — which is caught under its own reason. A further
+    // modal-width date-free line before the first record has nowhere else to go,
+    // and cannot be a hidden student, because position is P9's whole protection.
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['First name', 'Surname', 'DOB'],
+        ['Katie', 'Fernsby', '23/4/2010'],
+      ])
+    );
+    expect(result.records).toHaveLength(1);
+    expect(result.ignored.map((e) => e.reason)).toEqual(['header', 'junk']);
+    expect(result.errors).toHaveLength(0);
+    expectReconciled(result);
+  });
+
   test('the same line is junk before the first record and unparseable after it', () => {
     const stray = 'Please add Otto to the list if there is room.';
     const lines = WORD_TABLE.trimEnd().split('\n');
@@ -344,6 +445,21 @@ describe('P9 — junk is defined by position', () => {
     expect(after.ignored.filter((e) => e.reason === 'junk')).toHaveLength(2);
     expect(after.records).toHaveLength(8);
     expectReconciled(after);
+  });
+});
+
+describe('the layout hypothesis is decided by content, not by the delimiter', () => {
+  test('a vertical list survives one stray double-space inside a value', () => {
+    // Delimiter-first detection would call this horizontal, find one column,
+    // and refuse it for having no name columns — a misleading message for what
+    // is really a whole-list layout question.
+    const lines = VERTICAL.split('\n');
+    const nudged = lines.map((l) => (l === 'Katie' ? 'Katie  Fernsby' : l)).join('\n');
+    const result = parseStudentList(nudged);
+    expect(result.layout).toBe('vertical');
+    expect(result.blockSize).toBe(6);
+    expect(result.records).toHaveLength(5);
+    expectReconciled(result);
   });
 });
 
@@ -371,6 +487,11 @@ describe('P11 — date orientation is a property of the whole list', () => {
     expect(result.refusal.code).toBe('date-orientation-contradiction');
     expect(result.refusal.rows.map((r) => r.reading).sort()).toEqual(['dmy', 'mdy']);
     expect(result.refusal.rows.map((r) => r.value)).toEqual(['23/4/2010', '7/25/2010']);
+    // Refusing the *paste* has to mean no rows. Reading each self-proving date
+    // on its own orientation would be the row-by-row decision P11 forbids, and
+    // would hand a caller apply-ready rows for a list that cannot be read.
+    expect(result.records).toHaveLength(0);
+    expect(result.dateOrientation).toBeNull();
     expectReconciled(result);
   });
 


### PR DESCRIPTION
Implements #64 — a pure parser turning a pasted school student list into rows plus the list-level inferences that go with them. §7 of `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`.

**Nothing imports this.** It is inert in production, which is why §17 puts pure modules first: merging it changes no behaviour on the live hub.

## Acceptance

| | |
|---|---|
| Three committed fixtures at their exact counts | ✅ 5 / 6 / 8, each reconciled |
| Phantom-trailing-column variant | ✅ using the README's snippet unmodified |
| CRLF / leading-blank variant | ✅ all three, plus a BOM case |
| Vertical list reads as 21, not 126 | ✅ committed fixture is a 5-student reproduction, so the test asserts that *and* builds a full 21-student list |

55 tests. `pages.yml` runs none of them (#76) — `cd school-booking && npx vitest run`.

## The rules that carry the weight

- **P1** — every input line lands in exactly one bucket, checked inside the module rather than left to the caller. Holds through six-line vertical records, collapsed duplicates, refusals and the empty paste.
- **P4** — layout is anchored on the DOB, found by the shape of its values. A vertical list shows up as a *constant gap* between date-shaped lines, and that gap is the block size. The #48 divisibility rule is **not** implemented, as the ticket instructed.
- **P6** — columns mapped content-first; a header only names the two name columns, never finds the date. Serials are consulted only when no unambiguous date shape exists anywhere, so a five-digit student-ID column cannot steal the anchor.
- **P11** — orientation inferred once per list. A field above 12 is a proof and outranks a supplied answer; contradiction refuses the whole paste; a wholly ambiguous list asks with a real date read both ways.
- **P14** — true duplicates collapse badged; twins stay as two rows.

## Reviewed before merge

A two-axis review (standards + spec) found two things worth the pass:

- **The P11 contradiction refusal still emitted apply-ready rows**, each read on its *own* orientation — the row-by-row decision P11 exists to forbid. Now refuses like every other refusal.
- **`PreferredName` was folded into first name with no marker**, against `CONTEXT.md`'s explicit *"Avoid: treating it as the first name."* `columns.firstNameIsPreferred` now carries it, which is what lets #65 weaken the tie-breaker where it is weakest — twins.

Verified by mutation rather than the green tick alone: disabling vertical detection, merging twins on surname + DOB, silently defaulting the orientation, removing P9's position rule, dropping a line, suppressing the preferred-name marker and reverting to delimiter-first layout each fail the suite.

## Follow-ups

- #65 must **import** `writeForm` / `compareForm` from here, never restate them — recorded on that ticket and in the module header.
- #71 can now branch from `main` once this lands.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYGFYNFXj8pM5beoUa75Uo
