### PR TITLE
Identity module: the matching rule for a school list against Clubworx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,9 @@ school-booking/parse.js - turns a pasted school student list into rows plus the
                           spec. Nothing imports it yet — see #64/#71.
 school-booking/identity.js - the matching rule: surname + DOB narrows, first name
                           breaks ties, variance is surfaced never merged. §5 of
-                          the design spec. Imports write/compare form from
-                          parse.js rather than restating them — two copies of
-                          that table drift, and the drift writes a second
-                          permanent contact in silence. Fetches nothing.
+                          the design spec. Imports the two name forms from
+                          parse.js rather than restating them — the header there
+                          says what a second copy costs. Fetches nothing.
 vouchers/               - voucher management portal (auth = Cloudflare Access)
 vouchers/stats.html     - voucher analytics: revenue, liability, redemption, product mix
 vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and why

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,12 @@ school-booking/parse.js - turns a pasted school student list into rows plus the
                           list-level inferences (layout, column mapping, date
                           orientation). Pure and unit tested; §7 of the design
                           spec. Nothing imports it yet — see #64/#71.
+school-booking/identity.js - the matching rule: surname + DOB narrows, first name
+                          breaks ties, variance is surfaced never merged. §5 of
+                          the design spec. Imports write/compare form from
+                          parse.js rather than restating them — two copies of
+                          that table drift, and the drift writes a second
+                          permanent contact in silence. Fetches nothing.
 vouchers/               - voucher management portal (auth = Cloudflare Access)
 vouchers/stats.html     - voucher analytics: revenue, liability, redemption, product mix
 vouchers/unsubscribes.html - who is not receiving automatic voucher emails, and why

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -502,6 +502,14 @@ Distinct from the **match** states — `new`, `matched`, `name variant`,
 `ambiguous`, `already booked` — which all require a Clubworx read and belong to
 the review table.
 
+`unmatchable` joined the match states on #65: a row missing either half of the
+identity key — **surname or DOB** — concludes nothing, however many candidates
+come back. It is not an error state and not `new`. Calling such a row `new` is
+what creates a permanent contact with no DOB, which then poisons the surname +
+DOB key for every later term; matching a surname-less row picks whichever contact
+happens to share the birthday. The parser holds both shapes at
+`needs-confirmation`, so this is the second line of defence, not the first.
+
 *Avoid*: mixing the two lists. Only the first exists before a single request is
 sent.
 

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -343,6 +343,16 @@ output they cannot be shown, confirmed, or tested.
 `new` / `matched` / `name variant` / `ambiguous` / `already booked` require a
 Clubworx read. §9's table gives each its own column for exactly this reason.
 
+**Amended on #65: `unmatchable` is a sixth match state.** A row missing either
+half of the identity key — surname or DOB — concludes nothing however many
+candidates come back, and the five above have no way to say so. The parser holds
+both shapes at `needs-confirmation` and step 4's gates should stop them, so this
+is the second line of defence; it exists because the first line failing silently
+costs a write that cannot be undone. Calling such a row `new` creates a permanent
+contact with no DOB, which then poisons the surname + DOB key for every later
+term; matching a surname-less row picks whichever contact shares the birthday.
+§9's `CLUBWORX` column must render it.
+
 **P10 — Two normalisations, kept apart.**
 
 | | Rules |

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -29,18 +29,16 @@ import { compareForm } from './parse.js';
 // ---------------------------------------------------------------------------
 // Match states (P2b)
 // ---------------------------------------------------------------------------
-// `new` / `matched` / `name-variant` / `ambiguous` are distinct from the parse
-// states `clean` / `needs-confirmation` / `error` / `ignored`, which exist before
-// any API call. §9's preview table gives each axis its own column for exactly
-// that reason.
+// The match states — `new` / `matched` / `name-variant` / `ambiguous`, and
+// `already booked`, which belongs to the booking pass rather than to this module
+// — are distinct from the parse states `clean` / `needs-confirmation` / `error` /
+// `ignored`, which exist before any API call. §9's preview table gives each axis
+// its own column for exactly that reason.
 //
-// `unmatchable` is a fifth, added here: a row with no DOB has half the identity
-// key missing, and the four states above have no way to say so. See the guard in
+// `unmatchable` is a sixth, added on #65 and recorded in CONTEXT.md § "Parse-time
+// row state": a row missing either half of the identity key can conclude nothing,
+// and the five states above have no way to say so. See the guard in
 // `matchStudent` for why silence is not an option.
-
-function result({ state, reason, contact = null, candidates = [] }) {
-  return { state, reason, contact, candidates };
-}
 
 // An absent DOB and an empty one are the same fact, and both arrive: the parser
 // emits `null` when it could not read a date, Clubworx omits the field on some
@@ -58,31 +56,67 @@ function dobOf(value) {
  * caller that writes `if (match.contact) reuse(match.contact)` cannot
  * accidentally accept a variance a human has not looked at.
  *
+ * `reason` is the controlled vocabulary behind whatever the review table ends up
+ * saying, and it stays factual — what happened, not how to word it:
+ *
+ * | `state` | `reason` |
+ * |---|---|
+ * | `unmatchable` | `no-dob`, `no-surname` |
+ * | `new` | `no-candidates` |
+ * | `matched` | `first-name-matches` |
+ * | `name-variant` | `first-name-differs` |
+ * | `ambiguous` | `no-first-name-match`, `duplicate-contacts`, `candidate-dob-unknown` |
+ *
+ * `firstNameIsPreferred` is echoed onto every result rather than folded into
+ * `reason`, because it is a second, independent fact: the reason says the names
+ * disagree, and this says a disagreement was expected. Collapsing them would cost
+ * the difference between twins-with-nicknames and a plain duplicate.
+ *
  * @param {{write: {firstName: string, lastName: string, dob: string|null},
  *          compare: {firstName: string, lastName: string}}} record
  *        A row as `parseStudentList` emits it.
  * @param {Array<{contact_key: string, first_name?: string, last_name?: string, dob?: string}>} candidates
- *        What the Worker's three-view search returned.
- * @param {{firstNameIsPreferred?: boolean}} [options]
- *        `firstNameIsPreferred` comes straight from `parseStudentList`'s
- *        `columns.firstNameIsPreferred` — true when the school's own header
- *        called the column a preferred name. Read it rather than guessing: it is
- *        the only place that distinction survives from the paste.
+ *        What the Worker's three-view search returned. Tolerates a missing list:
+ *        it arrives as a field of a fetch response, not as a local literal.
+ * @param {{firstNameIsPreferred?: boolean}|null} [columns]
+ *        `parseStudentList`'s `columns`, passed straight through — the whole
+ *        object rather than a hand-copied boolean, because the two always travel
+ *        together and a forgotten flag reads a nickname list as a name mismatch.
+ *        `columns` is `null` on the parser's refusal paths, hence the optional
+ *        chaining. Only `firstNameIsPreferred` is read: true when the school's
+ *        own header called the column a preferred name, which is the only place
+ *        that distinction survives from the paste.
  */
-export function matchStudent(record, candidates = [], options = {}) {
-  const firstNameIsPreferred = options?.firstNameIsPreferred === true;
+export function matchStudent(record, candidates = [], columns = null) {
+  const firstNameIsPreferred = columns?.firstNameIsPreferred === true;
   const dob = dobOf(record?.write?.dob);
   const lastName = record?.compare?.lastName ?? '';
   const firstName = record?.compare?.firstName ?? '';
 
-  // Half the identity key is missing, so nothing can be concluded from any
-  // candidate set. Reporting `new` here would create a permanent contact with no
-  // DOB, which then poisons the surname + DOB key for every later term — the same
-  // damage a wrong date orientation does (CONTEXT.md § Date orientation). The
-  // step-4 gates should mean this never arrives; it refuses rather than trusting
-  // them, because the cost of being wrong is a write that cannot be undone.
+  const outcome = ({ state, reason, contact = null, candidates: offered = [] }) => ({
+    state,
+    reason,
+    contact,
+    candidates: offered,
+    firstNameIsPreferred,
+  });
+
+  // Both halves of the identity key are required before anything can be concluded
+  // from any candidate set, and the parser can emit a row missing either: a `null`
+  // dob when no date could be read, an empty surname for an unsplittable
+  // single-token name. It holds both at needs-confirmation, and the step-4 gates
+  // should mean neither arrives here — this refuses rather than trusting them,
+  // because being wrong costs a write that cannot be undone.
+  //
+  // Reporting `new` for a DOB-less row creates a permanent contact with no DOB,
+  // which then poisons the surname + DOB key for every later term — the same
+  // damage a wrong date orientation does (CONTEXT.md § Date orientation).
+  // Matching a surname-less row picks whichever contact shares the birthday.
   if (!dob) {
-    return result({ state: 'unmatchable', reason: 'no-dob' });
+    return outcome({ state: 'unmatchable', reason: 'no-dob' });
+  }
+  if (!lastName) {
+    return outcome({ state: 'unmatchable', reason: 'no-surname' });
   }
 
   // Surname + DOB narrows. Re-checked here rather than trusted from the query:
@@ -94,30 +128,35 @@ export function matchStudent(record, candidates = [], options = {}) {
   const narrowed = bySurname.filter((row) => dobOf(row?.dob) === dob);
 
   if (narrowed.length === 0) {
-    // A contact created by hand often carries no DOB at all, and #49 measured
-    // that the field can come back empty. Such a row cannot be confirmed — but
+    // A contact created by hand often carries no DOB at all, and #49 measured that
+    // the field can come back empty. Such a row cannot be confirmed — but
     // discarding it reports a student who already exists as `new` and writes them
     // a second permanent contact, so a same-name one is surfaced instead of
     // dropped. The first name is required here precisely because surname alone is
     // not an identity: a school list holds siblings.
+    //
+    // Deliberately only when nothing was confirmed. With a DOB-confirmed
+    // candidate in hand this branch would add noise, not safety: the run reuses
+    // the better-identified record and creates nothing, so no second contact can
+    // come of it.
     const dobUnknown = bySurname.filter(
       (row) => !dobOf(row?.dob) && compareForm(row?.first_name) === firstName
     );
     if (dobUnknown.length > 0) {
-      return result({
+      return outcome({
         state: 'ambiguous',
         reason: 'candidate-dob-unknown',
         candidates: dobUnknown,
       });
     }
-    return result({ state: 'new', reason: 'no-candidates' });
+    return outcome({ state: 'new', reason: 'no-candidates' });
   }
 
   // First name breaks ties — twins share both surname and birthday.
   const byFirstName = narrowed.filter((row) => compareForm(row?.first_name) === firstName);
 
   if (byFirstName.length === 1) {
-    return result({
+    return outcome({
       state: 'matched',
       reason: 'first-name-matches',
       contact: byFirstName[0],
@@ -125,36 +164,25 @@ export function matchStudent(record, candidates = [], options = {}) {
     });
   }
 
-  // One candidate, a different first name. Katie/Katherine is a human decision
-  // and so is the `PreferredName` case, where a mismatch is the *correct*
-  // outcome of a correct match — one real list ships a nickname column. The
-  // state is the same either way; what changes is what the operator is told,
-  // because "different name" and "expected nickname" call for different looks.
+  // One candidate, a different first name. Katie/Katherine is a human decision,
+  // and so is the `PreferredName` case, where a mismatch is the *correct* outcome
+  // of a correct match — one real list ships a nickname column. Never merged
+  // either way; `firstNameIsPreferred` on the result is what lets the operator be
+  // told which of the two they are looking at.
   if (narrowed.length === 1) {
-    return result({
-      state: 'name-variant',
-      reason: firstNameIsPreferred ? 'preferred-name-column' : 'first-name-differs',
-      candidates: narrowed,
-    });
+    return outcome({ state: 'name-variant', reason: 'first-name-differs', candidates: narrowed });
   }
 
-  // More than one candidate and the first name settles nothing. Which of the two
-  // ways it failed matters to whoever has to resolve it, so they are not
-  // collapsed into one message.
+  // Two contacts with the same name and birthday. Contacts cannot be deleted
+  // through the API, so a ~60,000-person database holds duplicates; taking the
+  // first would attach a permanent pass to whichever row the search happened to
+  // return first, which is not a decision this module gets to make.
   if (byFirstName.length > 1) {
-    // Two contacts with the same name and birthday. Contacts cannot be deleted
-    // through the API, so a ~60,000-person database holds duplicates; taking the
-    // first would attach a permanent pass to whichever row the search returned
-    // first, which is not a decision this module gets to make.
-    return result({ state: 'ambiguous', reason: 'duplicate-contacts', candidates: narrowed });
+    return outcome({ state: 'ambiguous', reason: 'duplicate-contacts', candidates: narrowed });
   }
 
-  return result({
-    state: 'ambiguous',
-    // Twins already in Clubworx, and the paste's first name matches neither. With
-    // a nickname column that is expected rather than surprising — and it is
-    // exactly where the tie-breaker is weakest, so the reason says so.
-    reason: firstNameIsPreferred ? 'preferred-name-column' : 'no-first-name-match',
-    candidates: narrowed,
-  });
+  // Twins already in Clubworx, and the paste's first name matches neither. Kept
+  // distinct from `duplicate-contacts` because the two need different resolutions:
+  // one is a choice between records, the other a choice between children.
+  return outcome({ state: 'ambiguous', reason: 'no-first-name-match', candidates: narrowed });
 }

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -1,0 +1,160 @@
+// school-booking/identity.js
+//
+// The matching rule: given one parsed student row and the Clubworx contacts a
+// search returned for them, decide whether this student is `new`, `matched`, a
+// `name-variant` or `ambiguous`. Pure on purpose — no DOM, no network, no clock.
+// The page imports this and publishes it as `window.schoolIdentity`, the same
+// seam parse.js, delete-logic.js and unsubscribes-logic.js use.
+//
+// Rules are §5 of docs/superpowers/specs/2026-08-19-school-group-booking-design.md.
+// Vocabulary is CONTEXT.md § "Clubworx school list parsing".
+//
+// **It does not fetch the candidates.** That is the Worker's job — it searches
+// all three disjoint status views (#49) and merges. Keeping this module
+// network-free is what makes the rule testable.
+//
+// ---------------------------------------------------------------------------
+// The two normalisations are imported, never restated
+// ---------------------------------------------------------------------------
+// `writeForm` and `compareForm` live in parse.js, which shipped first: P10
+// requires the parser to emit both forms for every row, and P14's in-paste dedup
+// needs compare form to tell a true duplicate from twins. Two copies of that
+// table would drift, and the drift is silent in the worst way — the day compare
+// form disagrees with itself, `O'Brien` stops matching `OBrien`, a student who
+// already has a contact comes back as `new`, and a second permanent contact is
+// written for them. Nothing throws: both spellings are individually valid, and
+// contacts cannot be deleted.
+import { compareForm } from './parse.js';
+
+// ---------------------------------------------------------------------------
+// Match states (P2b)
+// ---------------------------------------------------------------------------
+// `new` / `matched` / `name-variant` / `ambiguous` are distinct from the parse
+// states `clean` / `needs-confirmation` / `error` / `ignored`, which exist before
+// any API call. §9's preview table gives each axis its own column for exactly
+// that reason.
+//
+// `unmatchable` is a fifth, added here: a row with no DOB has half the identity
+// key missing, and the four states above have no way to say so. See the guard in
+// `matchStudent` for why silence is not an option.
+
+function result({ state, reason, contact = null, candidates = [] }) {
+  return { state, reason, contact, candidates };
+}
+
+// An absent DOB and an empty one are the same fact, and both arrive: the parser
+// emits `null` when it could not read a date, Clubworx omits the field on some
+// rows and returns it blank on others.
+function dobOf(value) {
+  const s = String(value ?? '').trim();
+  return s || null;
+}
+
+/**
+ * Decide the match state for one student row against one candidate set.
+ *
+ * `contact` is populated **only** when the state is `matched`. A `name-variant`
+ * or `ambiguous` row carries its possibilities in `candidates` instead, so a
+ * caller that writes `if (match.contact) reuse(match.contact)` cannot
+ * accidentally accept a variance a human has not looked at.
+ *
+ * @param {{write: {firstName: string, lastName: string, dob: string|null},
+ *          compare: {firstName: string, lastName: string}}} record
+ *        A row as `parseStudentList` emits it.
+ * @param {Array<{contact_key: string, first_name?: string, last_name?: string, dob?: string}>} candidates
+ *        What the Worker's three-view search returned.
+ * @param {{firstNameIsPreferred?: boolean}} [options]
+ *        `firstNameIsPreferred` comes straight from `parseStudentList`'s
+ *        `columns.firstNameIsPreferred` — true when the school's own header
+ *        called the column a preferred name. Read it rather than guessing: it is
+ *        the only place that distinction survives from the paste.
+ */
+export function matchStudent(record, candidates = [], options = {}) {
+  const firstNameIsPreferred = options?.firstNameIsPreferred === true;
+  const dob = dobOf(record?.write?.dob);
+  const lastName = record?.compare?.lastName ?? '';
+  const firstName = record?.compare?.firstName ?? '';
+
+  // Half the identity key is missing, so nothing can be concluded from any
+  // candidate set. Reporting `new` here would create a permanent contact with no
+  // DOB, which then poisons the surname + DOB key for every later term — the same
+  // damage a wrong date orientation does (CONTEXT.md § Date orientation). The
+  // step-4 gates should mean this never arrives; it refuses rather than trusting
+  // them, because the cost of being wrong is a write that cannot be undone.
+  if (!dob) {
+    return result({ state: 'unmatchable', reason: 'no-dob' });
+  }
+
+  // Surname + DOB narrows. Re-checked here rather than trusted from the query:
+  // whether Clubworx honours a `dob` filter server-side is unmeasured, and a
+  // candidate that slipped through must not be matched on surname alone.
+  const bySurname = (Array.isArray(candidates) ? candidates : []).filter(
+    (row) => compareForm(row?.last_name) === lastName
+  );
+  const narrowed = bySurname.filter((row) => dobOf(row?.dob) === dob);
+
+  if (narrowed.length === 0) {
+    // A contact created by hand often carries no DOB at all, and #49 measured
+    // that the field can come back empty. Such a row cannot be confirmed — but
+    // discarding it reports a student who already exists as `new` and writes them
+    // a second permanent contact, so a same-name one is surfaced instead of
+    // dropped. The first name is required here precisely because surname alone is
+    // not an identity: a school list holds siblings.
+    const dobUnknown = bySurname.filter(
+      (row) => !dobOf(row?.dob) && compareForm(row?.first_name) === firstName
+    );
+    if (dobUnknown.length > 0) {
+      return result({
+        state: 'ambiguous',
+        reason: 'candidate-dob-unknown',
+        candidates: dobUnknown,
+      });
+    }
+    return result({ state: 'new', reason: 'no-candidates' });
+  }
+
+  // First name breaks ties — twins share both surname and birthday.
+  const byFirstName = narrowed.filter((row) => compareForm(row?.first_name) === firstName);
+
+  if (byFirstName.length === 1) {
+    return result({
+      state: 'matched',
+      reason: 'first-name-matches',
+      contact: byFirstName[0],
+      candidates: narrowed,
+    });
+  }
+
+  // One candidate, a different first name. Katie/Katherine is a human decision
+  // and so is the `PreferredName` case, where a mismatch is the *correct*
+  // outcome of a correct match — one real list ships a nickname column. The
+  // state is the same either way; what changes is what the operator is told,
+  // because "different name" and "expected nickname" call for different looks.
+  if (narrowed.length === 1) {
+    return result({
+      state: 'name-variant',
+      reason: firstNameIsPreferred ? 'preferred-name-column' : 'first-name-differs',
+      candidates: narrowed,
+    });
+  }
+
+  // More than one candidate and the first name settles nothing. Which of the two
+  // ways it failed matters to whoever has to resolve it, so they are not
+  // collapsed into one message.
+  if (byFirstName.length > 1) {
+    // Two contacts with the same name and birthday. Contacts cannot be deleted
+    // through the API, so a ~60,000-person database holds duplicates; taking the
+    // first would attach a permanent pass to whichever row the search returned
+    // first, which is not a decision this module gets to make.
+    return result({ state: 'ambiguous', reason: 'duplicate-contacts', candidates: narrowed });
+  }
+
+  return result({
+    state: 'ambiguous',
+    // Twins already in Clubworx, and the paste's first name matches neither. With
+    // a nickname column that is expected rather than surprising — and it is
+    // exactly where the tie-breaker is weakest, so the reason says so.
+    reason: firstNameIsPreferred ? 'preferred-name-column' : 'no-first-name-match',
+    candidates: narrowed,
+  });
+}

--- a/school-booking/test/identity.test.js
+++ b/school-booking/test/identity.test.js
@@ -1,0 +1,298 @@
+// The matching rule (#65): surname + DOB narrows, first name breaks ties, and
+// first-name variance is surfaced rather than merged.
+//
+// Rules are §5 of docs/superpowers/specs/2026-08-19-school-group-booking-design.md.
+// Every candidate set below is invented — no real student name, DOB or school
+// name belongs in this repo (§16).
+
+import { describe, expect, test } from 'vitest';
+import { compareForm, parseStudentList, writeForm } from '../parse.js';
+import { matchStudent } from '../identity.js';
+
+// A student row in the shape `parseStudentList` emits, so these tests speak the
+// same vocabulary as the parser's output rather than a convenient invention.
+const student = (firstName, lastName, dob) => ({
+  write: { firstName, lastName, dob },
+  compare: { firstName: compareForm(firstName), lastName: compareForm(lastName) },
+});
+
+// A Clubworx contact in the shape the three status endpoints return — the field
+// names are the schema measured in probes/49-plus-addressed-duplicates.md.
+const contact = (first_name, last_name, dob, contact_key = `k-${last_name}-${first_name}`) => ({
+  contact_key,
+  first_name,
+  last_name,
+  dob,
+  status: 'Prospect',
+});
+
+describe('a student nobody has a contact for is new', () => {
+  test('an empty candidate set is `new`', () => {
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), []);
+    expect(match.state).toBe('new');
+    expect(match.contact).toBe(null);
+  });
+
+  test('candidates that share neither surname nor birthday are still `new`', () => {
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Katie', 'Quarrey', '2010-04-23'),
+      contact('Katie', 'Fernsby', '2011-04-23'),
+    ]);
+    expect(match.state).toBe('new');
+    expect(match.candidates).toHaveLength(0);
+  });
+});
+
+describe('surname + DOB narrows, first name confirms', () => {
+  test('one candidate with the same first name is `matched`, and carries the contact', () => {
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Katie', 'Fernsby', '2010-04-23', 'k-1'),
+    ]);
+    expect(match.state).toBe('matched');
+    expect(match.contact.contact_key).toBe('k-1');
+  });
+
+  test("matching runs on compare form: O'Brien matches OBrien, without writing OBrien", () => {
+    const match = matchStudent(student("Bea", "O'Brien", '2010-04-23'), [
+      contact('bea', 'OBrien', '2010-04-23', 'k-2'),
+    ]);
+    expect(match.state).toBe('matched');
+    expect(match.contact.contact_key).toBe('k-2');
+    // The write form the run would send is untouched by the match.
+    expect(writeForm("O'Brien")).toBe("O'Brien");
+  });
+});
+
+describe('first-name variance is surfaced, never auto-merged', () => {
+  test('one candidate with a different first name is a `name-variant`, not a match', () => {
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Katherine', 'Fernsby', '2010-04-23', 'k-3'),
+    ]);
+    expect(match.state).toBe('name-variant');
+    // Deliberately withheld: a caller reusing `match.contact` cannot accept a
+    // variance no human has looked at.
+    expect(match.contact).toBe(null);
+    expect(match.candidates.map((c) => c.contact_key)).toEqual(['k-3']);
+  });
+
+  test('a preferred-name column changes why it is a variant, never whether', () => {
+    const row = student('Katie', 'Fernsby', '2010-04-23');
+    const candidates = [contact('Katherine', 'Fernsby', '2010-04-23')];
+
+    const plain = matchStudent(row, candidates);
+    const preferred = matchStudent(row, candidates, { firstNameIsPreferred: true });
+
+    expect(preferred.state).toBe('name-variant');
+    expect(plain.reason).toBe('first-name-differs');
+    // The school's own header called the column a preferred name, so a mismatch
+    // here is the expected outcome of a correct match — the operator should be
+    // told that rather than shown a bare "different name".
+    expect(preferred.reason).toBe('preferred-name-column');
+  });
+});
+
+describe('twins: the case the first-name tie-breaker exists for', () => {
+  test('two contacts sharing surname and birthday resolve to one each, never merged', () => {
+    const inClubworx = [
+      contact('Katherine', 'Fernsby', '2010-04-23', 'k-twin-a'),
+      contact('Jessica', 'Fernsby', '2010-04-23', 'k-twin-b'),
+    ];
+
+    const one = matchStudent(student('Katherine', 'Fernsby', '2010-04-23'), inClubworx);
+    const two = matchStudent(student('Jessica', 'Fernsby', '2010-04-23'), inClubworx);
+
+    expect(one.state).toBe('matched');
+    expect(two.state).toBe('matched');
+    expect(one.contact.contact_key).toBe('k-twin-a');
+    expect(two.contact.contact_key).toBe('k-twin-b');
+  });
+
+  test('twins whose paste names match neither contact are `ambiguous`, with both offered', () => {
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Katherine', 'Fernsby', '2010-04-23', 'k-twin-a'),
+      contact('Jessica', 'Fernsby', '2010-04-23', 'k-twin-b'),
+    ]);
+    expect(match.state).toBe('ambiguous');
+    expect(match.reason).toBe('no-first-name-match');
+    expect(match.contact).toBe(null);
+    expect(match.candidates).toHaveLength(2);
+  });
+
+  test('a nickname column against twins says the tie-breaker was the weak one', () => {
+    const match = matchStudent(
+      student('Katie', 'Fernsby', '2010-04-23'),
+      [
+        contact('Katherine', 'Fernsby', '2010-04-23'),
+        contact('Jessica', 'Fernsby', '2010-04-23'),
+      ],
+      { firstNameIsPreferred: true }
+    );
+    expect(match.state).toBe('ambiguous');
+    expect(match.reason).toBe('preferred-name-column');
+  });
+});
+
+describe('duplicate contacts already in Clubworx', () => {
+  test('two contacts with the same name and birthday are `ambiguous`, never picked for us', () => {
+    // Contacts cannot be deleted through the API (ACCESS.md §4), so a database
+    // of ~60,000 people holds duplicates. Silently taking the first would attach
+    // a pass and bookings to whichever row the search happened to return first.
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Katie', 'Fernsby', '2010-04-23', 'k-dup-a'),
+      contact('katie', 'Fernsby', '2010-04-23', 'k-dup-b'),
+    ]);
+    expect(match.state).toBe('ambiguous');
+    expect(match.reason).toBe('duplicate-contacts');
+    expect(match.contact).toBe(null);
+    expect(match.candidates.map((c) => c.contact_key)).toEqual(['k-dup-a', 'k-dup-b']);
+  });
+});
+
+describe('the DOB gaps, both of which would otherwise end in a duplicate contact', () => {
+  test('a row whose DOB never parsed is `unmatchable`, never `new`', () => {
+    // Half the identity key is missing, so nothing can be concluded. Calling it
+    // `new` would create a permanent contact with no DOB, which then poisons the
+    // surname + DOB key for every later term.
+    const match = matchStudent(student('Katie', 'Fernsby', null), [
+      contact('Katie', 'Fernsby', '2010-04-23'),
+    ]);
+    expect(match.state).toBe('unmatchable');
+    expect(match.reason).toBe('no-dob');
+    expect(match.contact).toBe(null);
+  });
+
+  test('a same-name candidate with no DOB recorded is `ambiguous`, never `new`', () => {
+    // Contacts created by hand often carry no DOB, and a list response is not
+    // guaranteed to fill it (probes/lib/identity.mjs). Discarding the row would
+    // report a student who already exists as `new` and create a second contact
+    // for them.
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Katie', 'Fernsby', null, 'k-nodob'),
+    ]);
+    expect(match.state).toBe('ambiguous');
+    expect(match.reason).toBe('candidate-dob-unknown');
+    expect(match.candidates.map((c) => c.contact_key)).toEqual(['k-nodob']);
+  });
+
+  test('a DOB-less candidate with a different first name is not a candidate at all', () => {
+    // Surname alone is not an identity: a school list holds siblings, and this
+    // would otherwise make every sibling ambiguous forever.
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Jessica', 'Fernsby', null),
+    ]);
+    expect(match.state).toBe('new');
+  });
+});
+
+describe('the candidate set is re-checked, not trusted', () => {
+  test('a matching first name and DOB under another surname is discarded', () => {
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Katie', 'Quarrey', '2010-04-23'),
+    ]);
+    expect(match.state).toBe('new');
+  });
+});
+
+// P10's two forms are asserted in parse.test.js as well. Re-asserting them here
+// against the *imported* functions is the point: a test that fails the moment
+// this module stops sharing one normalisation table is exactly the alarm the
+// boundary needs, because the drift itself throws nothing.
+describe('P10 — the imported normalisation, and what it buys the match', () => {
+  test("O'Brien, OBrien and o'brien are one compare form and three write forms", () => {
+    expect(compareForm("O'Brien")).toBe('obrien');
+    expect(compareForm('OBrien')).toBe('obrien');
+    expect(compareForm("o’brien")).toBe('obrien');
+
+    expect(writeForm("O'Brien")).toBe("O'Brien");
+    expect(writeForm('OBrien')).toBe('OBrien');
+    expect(writeForm("o’brien")).toBe("o'brien");
+  });
+
+  test('write form keeps case and accents, and repairs what a Word export brings', () => {
+    expect(writeForm('MacTAVISH')).toBe('MacTAVISH');
+    expect(writeForm('Zoë')).toBe('Zoë');
+    // NBSP, zero-width joiner, BOM, curly apostrophe, non-breaking hyphen.
+    expect(writeForm('Zoë O’Brien')).toBe("Zoë O'Brien");
+    expect(writeForm('Fern​sby﻿')).toBe('Fernsby');
+    expect(writeForm('Quarrey‑Blake')).toBe('Quarrey-Blake');
+    // Folded only in compare form, never on the way to a permanent record.
+    expect(compareForm('MacTAVISH')).toBe('mactavish');
+  });
+
+  test('a contact stored with a curly apostrophe still matches a straight-typed paste', () => {
+    // The write path can never produce this, but ~60,000 existing contacts were
+    // not all created by this tool.
+    const match = matchStudent(student('Bea', "O'Brien", '2010-04-23'), [
+      contact('Bea', 'O’Brien', '2010-04-23', 'k-curly'),
+    ]);
+    expect(match.state).toBe('matched');
+    expect(match.contact.contact_key).toBe('k-curly');
+  });
+
+  test('a hyphenated surname matches whichever hyphen the record holds', () => {
+    const match = matchStudent(student('Nils', 'Quarrey-Blake', '2010-08-19'), [
+      contact('Nils', 'Quarrey‑Blake', '2010-08-19', 'k-hyphen'),
+    ]);
+    expect(match.state).toBe('matched');
+  });
+});
+
+// P14 — whether a pair of rows is a true duplicate or twins is already decided in
+// parse.js, on compare-form first name. This module consumes those rows; it does
+// not re-decide them.
+describe('the handoff from the parser', () => {
+  const tsv = (rows) => rows.map((row) => row.join('\t')).join('\n');
+
+  test('a collapsed duplicate arrives as one row and matches one contact', () => {
+    const parsed = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Katie', 'Fernsby', '23/4/2010'],
+        ['Katie', 'Fernsby', '23/4/2010'],
+      ])
+    );
+    expect(parsed.records).toHaveLength(1);
+    expect(parsed.records[0].flags).toContain('listed-twice');
+
+    const match = matchStudent(parsed.records[0], [
+      contact('Katie', 'Fernsby', '2010-04-23', 'k-once'),
+    ]);
+    expect(match.state).toBe('matched');
+    expect(match.contact.contact_key).toBe('k-once');
+  });
+
+  test('twins arrive as two rows and take one contact each', () => {
+    const parsed = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Katherine', 'Fernsby', '23/4/2010'],
+        ['Jessica', 'Fernsby', '23/4/2010'],
+      ])
+    );
+    expect(parsed.records).toHaveLength(2);
+    expect(parsed.records[0].flags).toContain('possible-siblings');
+
+    const inClubworx = [
+      contact('Katherine', 'Fernsby', '2010-04-23', 'k-a'),
+      contact('Jessica', 'Fernsby', '2010-04-23', 'k-b'),
+    ];
+    const keys = parsed.records.map((row) => matchStudent(row, inClubworx).contact?.contact_key);
+    expect(keys).toEqual(['k-a', 'k-b']);
+  });
+
+  test("the list's preferred-name column reaches the match through columns", () => {
+    const parsed = parseStudentList(
+      tsv([
+        ['Preferred name', 'Surname', 'DOB'],
+        ['Katie', 'Fernsby', '23/4/2010'],
+      ])
+    );
+    expect(parsed.columns.firstNameIsPreferred).toBe(true);
+
+    const match = matchStudent(parsed.records[0], [contact('Katherine', 'Fernsby', '2010-04-23')], {
+      firstNameIsPreferred: parsed.columns.firstNameIsPreferred,
+    });
+    expect(match.state).toBe('name-variant');
+    expect(match.reason).toBe('preferred-name-column');
+  });
+});

--- a/school-booking/test/identity.test.js
+++ b/school-booking/test/identity.test.js
@@ -75,19 +75,23 @@ describe('first-name variance is surfaced, never auto-merged', () => {
     expect(match.candidates.map((c) => c.contact_key)).toEqual(['k-3']);
   });
 
-  test('a preferred-name column changes why it is a variant, never whether', () => {
+  test('a preferred-name column says the mismatch was expected, never that it is fine', () => {
     const row = student('Katie', 'Fernsby', '2010-04-23');
     const candidates = [contact('Katherine', 'Fernsby', '2010-04-23')];
 
     const plain = matchStudent(row, candidates);
     const preferred = matchStudent(row, candidates, { firstNameIsPreferred: true });
 
+    // Same state and same reason: what happened is identical, and it is still not
+    // accepted for anyone.
     expect(preferred.state).toBe('name-variant');
-    expect(plain.reason).toBe('first-name-differs');
+    expect(preferred.reason).toBe('first-name-differs');
+    expect(preferred.contact).toBe(null);
     // The school's own header called the column a preferred name, so a mismatch
-    // here is the expected outcome of a correct match — the operator should be
-    // told that rather than shown a bare "different name".
-    expect(preferred.reason).toBe('preferred-name-column');
+    // here is the expected outcome of a correct match. That is a second fact, not
+    // a different reason — the operator needs both to word the decision.
+    expect(plain.firstNameIsPreferred).toBe(false);
+    expect(preferred.firstNameIsPreferred).toBe(true);
   });
 });
 
@@ -118,7 +122,9 @@ describe('twins: the case the first-name tie-breaker exists for', () => {
     expect(match.candidates).toHaveLength(2);
   });
 
-  test('a nickname column against twins says the tie-breaker was the weak one', () => {
+  test('a nickname column against twins keeps both facts: no name match, and expected', () => {
+    // This is where the tie-breaker is weakest — two children, and the only field
+    // that separates them is the one the school replaced with a nickname.
     const match = matchStudent(
       student('Katie', 'Fernsby', '2010-04-23'),
       [
@@ -128,7 +134,8 @@ describe('twins: the case the first-name tie-breaker exists for', () => {
       { firstNameIsPreferred: true }
     );
     expect(match.state).toBe('ambiguous');
-    expect(match.reason).toBe('preferred-name-column');
+    expect(match.reason).toBe('no-first-name-match');
+    expect(match.firstNameIsPreferred).toBe(true);
   });
 });
 
@@ -161,6 +168,17 @@ describe('the DOB gaps, both of which would otherwise end in a duplicate contact
     expect(match.contact).toBe(null);
   });
 
+  test('a row with no surname is `unmatchable` too — DOB alone is not an identity', () => {
+    // `parse.js` emits an empty surname for an unsplittable single-token name and
+    // holds the row at needs-confirmation. If one ever reaches here, matching on
+    // the birthday alone would pick whichever contact shares it.
+    const match = matchStudent(student('Otto', '', '2010-04-23'), [
+      contact('Otto', '', '2010-04-23'),
+    ]);
+    expect(match.state).toBe('unmatchable');
+    expect(match.reason).toBe('no-surname');
+  });
+
   test('a same-name candidate with no DOB recorded is `ambiguous`, never `new`', () => {
     // Contacts created by hand often carry no DOB, and a list response is not
     // guaranteed to fill it (probes/lib/identity.mjs). Discarding the row would
@@ -172,6 +190,19 @@ describe('the DOB gaps, both of which would otherwise end in a duplicate contact
     expect(match.state).toBe('ambiguous');
     expect(match.reason).toBe('candidate-dob-unknown');
     expect(match.candidates.map((c) => c.contact_key)).toEqual(['k-nodob']);
+  });
+
+  test('a confirmed candidate beside a DOB-less twin of itself still matches', () => {
+    // The asymmetry is deliberate: the blank-DOB rule exists to stop this tool
+    // creating a second contact, and here it creates nothing. Reusing the
+    // better-identified record is the safe outcome, so this stays a match rather
+    // than becoming a question the operator cannot usefully answer.
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [
+      contact('Katie', 'Fernsby', '2010-04-23', 'k-with-dob'),
+      contact('Katie', 'Fernsby', null, 'k-without-dob'),
+    ]);
+    expect(match.state).toBe('matched');
+    expect(match.contact.contact_key).toBe('k-with-dob');
   });
 
   test('a DOB-less candidate with a different first name is not a candidate at all', () => {
@@ -211,12 +242,44 @@ describe('P10 — the imported normalisation, and what it buys the match', () =>
   test('write form keeps case and accents, and repairs what a Word export brings', () => {
     expect(writeForm('MacTAVISH')).toBe('MacTAVISH');
     expect(writeForm('Zoë')).toBe('Zoë');
-    // NBSP, zero-width joiner, BOM, curly apostrophe, non-breaking hyphen.
-    expect(writeForm('Zoë O’Brien')).toBe("Zoë O'Brien");
+    // The invisible ones are written as escapes on purpose. A literal U+00A0 in
+    // this file is indistinguishable from a plain space on screen, and an editor
+    // that helpfully normalises it leaves a test that asserts nothing while its
+    // comment still claims NBSP coverage.
+    expect(writeForm('Zoë Van Dermeer')).toBe('Zoë Van Dermeer');
     expect(writeForm('Fern​sby﻿')).toBe('Fernsby');
+    expect(writeForm('﻿Katie')).toBe('Katie');
+    // These two are legible as themselves: U+2019 curly apostrophe, U+2011
+    // non-breaking hyphen — both expected input from the Word-exported list.
+    expect(writeForm('Zoë O’Brien')).toBe("Zoë O'Brien");
     expect(writeForm('Quarrey‑Blake')).toBe('Quarrey-Blake');
-    // Folded only in compare form, never on the way to a permanent record.
+    // Case is folded only in compare form, never on the way to a permanent record.
     expect(compareForm('MacTAVISH')).toBe('mactavish');
+  });
+
+  test('compare form does NOT fold accents, and the surname is where that bites', () => {
+    // Pinned deliberately, because it is a gap rather than a decision. P10's table
+    // folds case and removes apostrophes, hyphens and spaces; it says nothing about
+    // accents. Changing that means changing P10 and parse.js, not this module — so
+    // it is #80, and this test changes with whatever #80 decides.
+    expect(compareForm('Zoë')).not.toBe(compareForm('Zoe'));
+    expect(compareForm('Fernández')).not.toBe(compareForm('Fernandez'));
+
+    // In the *first* name the gap is survivable: surname and DOB still narrow, so
+    // it lands in front of a human as a variant.
+    const firstNameAccent = matchStudent(student('Zoe', 'Van Dermeer', '2010-04-23'), [
+      contact('Zoë', 'Van Dermeer', '2010-04-23'),
+    ]);
+    expect(firstNameAccent.state).toBe('name-variant');
+
+    // In the *surname* it is the silent one, and this is the hazard worth filing:
+    // the candidate never narrows, so an existing student reports as `new` and
+    // earns a second permanent contact with nobody asked. Same failure the
+    // O'Brien rule exists to prevent, one character along.
+    const surnameAccent = matchStudent(student('Ana', 'Fernandez', '2010-04-23'), [
+      contact('Ana', 'Fernández', '2010-04-23'),
+    ]);
+    expect(surnameAccent.state).toBe('new');
   });
 
   test('a contact stored with a curly apostrophe still matches a straight-typed paste', () => {
@@ -289,10 +352,20 @@ describe('the handoff from the parser', () => {
     );
     expect(parsed.columns.firstNameIsPreferred).toBe(true);
 
-    const match = matchStudent(parsed.records[0], [contact('Katherine', 'Fernsby', '2010-04-23')], {
-      firstNameIsPreferred: parsed.columns.firstNameIsPreferred,
-    });
+    // The parser's whole `columns` object goes through, so there is no boolean to
+    // forget copying.
+    const match = matchStudent(
+      parsed.records[0],
+      [contact('Katherine', 'Fernsby', '2010-04-23')],
+      parsed.columns
+    );
     expect(match.state).toBe('name-variant');
-    expect(match.reason).toBe('preferred-name-column');
+    expect(match.firstNameIsPreferred).toBe(true);
+  });
+
+  test('a parser refusal path hands over a null columns object without throwing', () => {
+    const match = matchStudent(student('Katie', 'Fernsby', '2010-04-23'), [], null);
+    expect(match.state).toBe('new');
+    expect(match.firstNameIsPreferred).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #65. §5 of `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`.

`matchStudent(record, candidates, columns)` takes one parsed student row and the contacts a search returned for them, and returns `{ state, reason, contact, candidates, firstNameIsPreferred }`. Pure — no DOM, no network, no clock. It **fetches nothing**: the three-view search is the Worker's job, and staying network-free is what makes the rule testable.

`writeForm` and `compareForm` are **imported from `parse.js`**, never restated. I checked that boundary actually holds by mutating it: dropping in a plausible local lowercase-only compare form fails two tests, then reverted.

## The rule

| Situation | State |
|---|---|
| No candidate shares surname **and** DOB | `new` |
| Exactly one shares the compare-form first name | `matched` |
| One candidate, different first name | `name-variant` |
| Several candidates, none matching by first name | `ambiguous` (`no-first-name-match`) |
| Several sharing the same first name | `ambiguous` (`duplicate-contacts`) |
| Row missing surname or DOB | `unmatchable` |

`contact` is populated **only** on `matched`. A variance carries its possibilities in `candidates` instead, so `if (match.contact) reuse(match.contact)` cannot accept something no human has looked at.

`firstNameIsPreferred` is echoed onto the result rather than folded into `reason`: the reason says the names disagree, that says a disagreement was expected. Katie/Katherine stays a human decision either way.

## Three decisions #65 did not spell out

All three taken conservatively, because the alternative is a permanent write.

1. **`unmatchable` is a sixth match state.** A row missing either half of the identity key concludes nothing. Calling it `new` creates a permanent contact with no DOB, which poisons the surname + DOB key for every later term. The surname half caught a real hole — before the guard, a surname-less row returned `matched` against any contact sharing the birthday. P2b and `CONTEXT.md` are amended, so **§9's `CLUBWORX` column needs to render it** (#72).
2. **A same-name candidate whose Clubworx DOB is blank is `ambiguous`, not discarded.** #49 measured that the field comes back empty. Dropping such a row reports an existing student as `new`. The first name is required there, because surname alone is not an identity — a school list holds siblings.
3. **That rule is deliberately asymmetric.** With a DOB-confirmed candidate in hand, a blank-DOB near-duplicate beside it still `matched`s: the rule exists to stop this tool *creating* a second contact, and there it creates nothing. Commented and tested rather than implicit.

Each is easy to reverse if you disagree — one guard, one filter, one test apiece.

## Found on the way out: #80

Compare form folds case but not combining marks, so `Fernandez` never matches `Fernández`. The position decides whether anyone finds out: in a first name, surname + DOB still narrow so it surfaces as `name-variant`; in a **surname** the candidate never narrows, the student reports `new`, and a second permanent contact is written silently. Same failure the `O'Brien` rule prevents, one character along.

Not fixed here — it belongs to P10 and `parse.js`, and patching it in `identity.js` is exactly the drift the import boundary exists to prevent. Both behaviours are pinned by test, so #80 changes that test with it.

## Verification

```bash
cd school-booking && npx vitest run    # 80 pass (55 parse, 25 identity)
npx vitest run                         # 594 pass repo-wide, from the repo root
```

`pages.yml` runs none of them (#76), so this is by hand.

Reviewed on both axes before commit; `4f2d092` is what came of it, including one finding I pushed back on with reasons rather than implementing.

> ⚠️ Nothing imports this module yet, so merging publishes no behaviour change — but **merging this repo is deploying it** (`main` → `ujstaff.happyk.au`), so the merge is yours to make, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYGFYNFXj8pM5beoUa75Uo
