### PR TITLE
Compare form folds accents on Latin letters

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -463,10 +463,20 @@ zero-width characters and BOM stripped, Unicode NFC. Case is never touched and
 accents are never stripped.
 
 *Compare form* is used only for matching and in-paste dedup: additionally
-case-folded, with apostrophes, hyphens and spaces removed.
+case-folded, with apostrophes, hyphens and spaces removed, and **Latin accents
+folded** — `Fernández` matches `Fernandez` (#80).
 
-The split is load-bearing — it is what lets `O'Brien` match `OBrien` without
-ever *writing* the second spelling into a record that cannot be deleted.
+Accent folding is deliberately limited to Latin combining marks, not all of
+`\p{M}`. In an abugida the vowel signs are marks too, so the wider rule deletes
+letters rather than accents and can collapse two different children onto one
+compare form. A false match is the worse failure: it attaches a pass and bookings
+to the wrong child, where a miss only creates a duplicate contact. A letter
+carrying its stroke inside itself does not decompose and so is not folded —
+`Wałęsa` matches `Wałesa`, not `Walesa`.
+
+The split is load-bearing — it is what lets `O'Brien` match `OBrien`, and
+`Fernandez` match `Fernández`, without ever *writing* the second spelling into a
+record that cannot be deleted.
 
 *Avoid*: "normalised name" unqualified. Which one is meant decides whether a
 permanent record is altered.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -466,13 +466,25 @@ accents are never stripped.
 case-folded, with apostrophes, hyphens and spaces removed, and **Latin accents
 folded** — `Fernández` matches `Fernandez` (#80).
 
-Accent folding is deliberately limited to Latin combining marks, not all of
-`\p{M}`. In an abugida the vowel signs are marks too, so the wider rule deletes
-letters rather than accents and can collapse two different children onto one
-compare form. A false match is the worse failure: it attaches a pass and bookings
-to the wrong child, where a miss only creates a duplicate contact. A letter
-carrying its stroke inside itself does not decompose and so is not folded —
-`Wałęsa` matches `Wałesa`, not `Walesa`.
+Precisely: a combining mark (U+0300–U+036F) is dropped **only when it sits on a
+Latin base letter**. Two narrowings, both because a false match is the worse
+failure — it attaches a pass and bookings to the wrong child, where a miss only
+creates a duplicate contact:
+
+- **Not all of `\p{M}`.** In an abugida the vowel signs are marks too, so the
+  wider rule deletes letters rather than accents — `प्रिया` becomes `परय`.
+- **Not marks on a non-Latin base.** The combining-diacritics block is
+  script-neutral; ungated it folds Cyrillic `й` onto `и` and `ё` onto `е`, which
+  are separate letters of that alphabet. `Андрей` and `Андреи` are two names.
+
+Two limits worth knowing, both deliberate:
+
+- **Vietnamese folds**, because it is Latin script: `Lê`, `Lệ` and `Lễ` share one
+  compare form. Accepted, since this is the case #80 was filed about, and a false
+  match needs the surname, birthday and first name to coincide as well.
+- **A letter carrying its stroke inside itself never folds**, because it does not
+  decompose: `Wałęsa` matches `Wałesa`, not `Walesa`. Reaching those needs a
+  transliteration table, not mark-stripping — #83.
 
 The split is load-bearing — it is what lets `O'Brien` match `OBrien`, and
 `Fernandez` match `Fernández`, without ever *writing* the second spelling into a

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -358,18 +358,30 @@ term; matching a surname-less row picks whichever contact shares the birthday.
 | | Rules |
 |---|---|
 | **Write form** — what is stored | trim; collapse internal whitespace runs; NBSP → space; curly apostrophe and prime → `'`; non-breaking and figure hyphens → `-`; strip zero-width characters and BOM; Unicode NFC. **Never** touch case, **never** strip accents |
-| **Compare form** — matching and in-paste dedup only | write form, additionally case-folded, with apostrophes, hyphens and spaces stripped, and **Latin accents folded** (amended on #80) |
+| **Compare form** — matching and in-paste dedup only | write form, additionally case-folded, with apostrophes, hyphens and spaces stripped, and **accents on Latin letters folded** (amended on #80) |
 
 **Amended on #80: compare form folds accents.** An accent is the same class of
 variance as an apostrophe — one list types it, one contact record does not — and
 in a *surname* the mismatch was silent: the candidate never narrowed, an existing
 student reported `new`, and a second permanent contact was written with nobody
-asked. Folding is limited to **Latin combining marks**, not all of `\p{M}`: in an
-abugida the vowel signs are marks too, so the wider rule deletes letters rather
-than accents and can collapse two different children onto one compare form. A
-false match is the worse failure — it attaches a pass and bookings to the wrong
-child, where a miss only creates a duplicate contact. Write form is unchanged and
-still **never** strips an accent; that half of the split is the point of it.
+asked. Write form is unchanged and still **never** strips an accent; that half of
+the split is the point of it.
+
+The rule is narrower than #80 proposed, in two steps, because a **false** match
+is the worse failure — it attaches a pass and bookings to the wrong child, where
+a miss only creates a duplicate contact. Not all of `\p{M}`: in an abugida the
+vowel signs are marks, so that rule deletes letters (`प्रिया` → `परय`). And only
+marks on a **Latin base letter**: the combining-diacritics block is
+script-neutral, so ungated it folds Cyrillic `й` onto `и`, which are two letters
+rather than two spellings.
+
+**Vietnamese still folds**, since it is Latin script — `Lê`, `Lệ` and `Lễ` share
+one compare form. That is the accepted cost of fixing the reported case, taken
+**without** the contact-database count #80 suggested weighing first: a false match
+additionally requires surname, birthday and first name to coincide, where the miss
+it prevents needs none of that. If that trade is ever revisited, the count is the
+evidence to gather. Letters like `ł` and `ø` do not decompose and so never fold;
+that residue is #83.
 
 One of the real fixtures is a PDF exported from Word, so curly apostrophes and
 non-breaking hyphens are an expected input. A curly apostrophe written verbatim
@@ -496,11 +508,15 @@ generous outer band (roughly 4–21).
 
 **P14 — True duplicates collapse visibly; twins stay as two rows.**
 
-- Same surname + DOB + same **compare-form** first name → collapse to one row,
-  badged *"listed twice"*. Silent collapsing is not acceptable; this happens
-  when a school merges two class exports.
+- Same surname + DOB + same first name → collapse to one row, badged *"listed
+  twice"*. Silent collapsing is not acceptable; this happens when a school merges
+  two class exports.
 - Same surname + DOB, **different** first name → **keep both**, badged *"possible
   siblings"*. That is twins — exactly the case the tie-breaker exists for.
+
+Both names are compared in **compare form**, surname included — so since #80 the
+two class exports need not agree about an accent either. The surviving row keeps
+the spelling the list used first, and write form is what reaches Clubworx.
 
 Collapsing on surname + DOB alone is rejected: it merges twins into one student,
 and nobody discovers the missing child until the session.

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -358,7 +358,18 @@ term; matching a surname-less row picks whichever contact shares the birthday.
 | | Rules |
 |---|---|
 | **Write form** — what is stored | trim; collapse internal whitespace runs; NBSP → space; curly apostrophe and prime → `'`; non-breaking and figure hyphens → `-`; strip zero-width characters and BOM; Unicode NFC. **Never** touch case, **never** strip accents |
-| **Compare form** — matching and in-paste dedup only | write form, additionally case-folded, with apostrophes, hyphens and spaces stripped |
+| **Compare form** — matching and in-paste dedup only | write form, additionally case-folded, with apostrophes, hyphens and spaces stripped, and **Latin accents folded** (amended on #80) |
+
+**Amended on #80: compare form folds accents.** An accent is the same class of
+variance as an apostrophe — one list types it, one contact record does not — and
+in a *surname* the mismatch was silent: the candidate never narrowed, an existing
+student reported `new`, and a second permanent contact was written with nobody
+asked. Folding is limited to **Latin combining marks**, not all of `\p{M}`: in an
+abugida the vowel signs are marks too, so the wider rule deletes letters rather
+than accents and can collapse two different children onto one compare form. A
+false match is the worse failure — it attaches a pass and bookings to the wrong
+child, where a miss only creates a duplicate contact. Write form is unchanged and
+still **never** strips an accent; that half of the split is the point of it.
 
 One of the real fixtures is a PDF exported from Word, so curly apostrophes and
 non-breaking hyphens are an expected input. A curly apostrophe written verbatim

--- a/school-booking/parse.js
+++ b/school-booking/parse.js
@@ -60,9 +60,34 @@ export function writeForm(value) {
     .replace(/\s+/g, ' ');
 }
 
+// Latin combining marks, reachable only after NFD splits a letter from its
+// accent. Deliberately this range and not `\p{M}`: in an abugida the vowel signs
+// are marks too, so the wider rule deletes letters rather than accents —
+// `प्रिया` becomes `परय` — and two different children can collapse onto one
+// compare form. A false match is the worse failure, because it attaches a pass
+// and bookings to the wrong child, where a miss only creates a duplicate contact.
+const LATIN_MARKS = /[̀-ͯ]/g;
+
 // Matching and in-paste dedup only. Never written anywhere.
+//
+// Accents fold here and nowhere else (#80). It is the same class of variance as
+// the apostrophe: one list types it, one contact record does not, and in a
+// surname the mismatch is silent — the candidate never narrows, an existing
+// student reports `new`, and a second permanent contact is written for them.
+//
+// Known limit: a letter carrying its stroke inside itself does not decompose, so
+// no mark-stripping rule reaches it. `Wałęsa` matches `Wałesa`, not `Walesa`.
 export function compareForm(value) {
-  return writeForm(value).toLowerCase().replace(/['\-\s]/g, '');
+  return writeForm(value)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(LATIN_MARKS, '')
+    // Back to NFC, because NFD also splits Hangul syllables into jamo and every
+    // mark this rule deliberately leaves alone stays split without it. Two
+    // strings that look identical would then compare unequal — the exact failure
+    // this function exists to prevent, arrived at from the other direction.
+    .normalize('NFC')
+    .replace(/['\-\s]/g, '');
 }
 
 // ---------------------------------------------------------------------------

--- a/school-booking/parse.js
+++ b/school-booking/parse.js
@@ -60,13 +60,29 @@ export function writeForm(value) {
     .replace(/\s+/g, ' ');
 }
 
-// Latin combining marks, reachable only after NFD splits a letter from its
-// accent. Deliberately this range and not `\p{M}`: in an abugida the vowel signs
-// are marks too, so the wider rule deletes letters rather than accents —
-// `प्रिया` becomes `परय` — and two different children can collapse onto one
-// compare form. A false match is the worse failure, because it attaches a pass
-// and bookings to the wrong child, where a miss only creates a duplicate contact.
-const LATIN_MARKS = /[̀-ͯ]/g;
+// A Latin letter and the combining marks NFD split off it. Written as escapes
+// because raw combining marks reattach to the bracket in editors, diffs and
+// greps — the class either side of this one enumerates its codepoints in a
+// comment for the same reason.
+//
+// Two narrowings, both deliberate, because a **false** match is the worse
+// failure here: it attaches a permanent pass and bookings to the wrong child,
+// where a miss only creates a duplicate contact.
+//
+//   1. Not `\p{M}`. In an abugida the vowel signs are marks too, so the wider
+//      rule deletes letters rather than accents — `प्रिया` becomes `परय`.
+//   2. Only marks sitting on a **Latin base letter**. The combining-diacritics
+//      block is script-neutral: unqualified it folds Cyrillic `й` onto `и` and
+//      `ё` onto `е`, which are separate letters of that alphabet, not accented
+//      spellings of one.
+//
+// What it does **not** narrow, and this is a trade rather than an oversight:
+// Vietnamese is Latin script, so `ệ` and `ễ` fold onto `e` and `Lê`, `Lệ` and
+// `Lễ` share one compare form. That is accepted because it is the case #80 was
+// filed about — a school types `Nguyen`, the contact record says `Nguyễn` — and
+// a false match additionally needs the surname, the birthday and the first name
+// to coincide, where the miss it prevents is routine. Tested both ways below.
+const ACCENTED_LATIN = /(\p{Script=Latin})[\u0300-\u036f]+/gu;
 
 // Matching and in-paste dedup only. Never written anywhere.
 //
@@ -81,7 +97,7 @@ export function compareForm(value) {
   return writeForm(value)
     .toLowerCase()
     .normalize('NFD')
-    .replace(LATIN_MARKS, '')
+    .replace(ACCENTED_LATIN, '$1')
     // Back to NFC, because NFD also splits Hangul syllables into jamo and every
     // mark this rule deliberately leaves alone stays split without it. Two
     // strings that look identical would then compare unequal — the exact failure

--- a/school-booking/test/identity.test.js
+++ b/school-booking/test/identity.test.js
@@ -257,29 +257,26 @@ describe('P10 — the imported normalisation, and what it buys the match', () =>
     expect(compareForm('MacTAVISH')).toBe('mactavish');
   });
 
-  test('compare form does NOT fold accents, and the surname is where that bites', () => {
-    // Pinned deliberately, because it is a gap rather than a decision. P10's table
-    // folds case and removes apostrophes, hyphens and spaces; it says nothing about
-    // accents. Changing that means changing P10 and parse.js, not this module — so
-    // it is #80, and this test changes with whatever #80 decides.
-    expect(compareForm('Zoë')).not.toBe(compareForm('Zoe'));
-    expect(compareForm('Fernández')).not.toBe(compareForm('Fernandez'));
-
-    // In the *first* name the gap is survivable: surname and DOB still narrow, so
-    // it lands in front of a human as a variant.
-    const firstNameAccent = matchStudent(student('Zoe', 'Van Dermeer', '2010-04-23'), [
-      contact('Zoë', 'Van Dermeer', '2010-04-23'),
-    ]);
-    expect(firstNameAccent.state).toBe('name-variant');
-
-    // In the *surname* it is the silent one, and this is the hazard worth filing:
-    // the candidate never narrows, so an existing student reports as `new` and
-    // earns a second permanent contact with nobody asked. Same failure the
-    // O'Brien rule exists to prevent, one character along.
+  test('an accent no longer decides whether a student is found (#80)', () => {
+    // This test previously pinned the opposite, as the record of a known gap.
+    // #80 closed it in compare form only: an accented surname used to stop the
+    // candidate narrowing at all, so an existing student reported `new` and
+    // earned a second permanent contact with nobody asked.
     const surnameAccent = matchStudent(student('Ana', 'Fernandez', '2010-04-23'), [
-      contact('Ana', 'Fernández', '2010-04-23'),
+      contact('Ana', 'Fernández', '2010-04-23', 'k-accent'),
     ]);
-    expect(surnameAccent.state).toBe('new');
+    expect(surnameAccent.state).toBe('matched');
+    expect(surnameAccent.contact.contact_key).toBe('k-accent');
+
+    // Both directions, because either side can be the one carrying the accent.
+    const pasteHasAccent = matchStudent(student('Zoë', 'Van Dermeer', '2010-04-23'), [
+      contact('Zoe', 'Van Dermeer', '2010-04-23'),
+    ]);
+    expect(pasteHasAccent.state).toBe('matched');
+
+    // And the write form is still the school's spelling, untouched — which is the
+    // whole reason the two forms are kept apart.
+    expect(writeForm('Fernández')).toBe('Fernández');
   });
 
   test('a contact stored with a curly apostrophe still matches a straight-typed paste', () => {

--- a/school-booking/test/parse.test.js
+++ b/school-booking/test/parse.test.js
@@ -675,6 +675,66 @@ describe('P10 — write form and compare form, kept apart', () => {
     expect(compareForm('Van Dermeer')).toBe('vandermeer');
   });
 
+  // #80. The accent is the same class of variance as the apostrophe: one list
+  // types it, one contact record does not, and in a *surname* the mismatch is
+  // silent — the candidate never narrows, an existing student reports `new`, and
+  // a second permanent contact is written with nobody asked.
+  test('compare form folds accents, so Fernandez matches Fernández', () => {
+    expect(compareForm('Fernández')).toBe('fernandez');
+    expect(compareForm('Fernandez')).toBe('fernandez');
+    expect(compareForm('Zoë')).toBe('zoe');
+    expect(compareForm('Nguyễn')).toBe('nguyen');
+    // Decomposed and precomposed spellings of one name agree, which is what
+    // makes this safe to apply to input pasted from anywhere.
+    expect(compareForm('Fernández'.normalize('NFD'))).toBe('fernandez');
+  });
+
+  test('write form still never strips an accent — the split is the point', () => {
+    expect(writeForm('Fernández')).toBe('Fernández');
+    expect(writeForm('Zoë')).toBe('Zoë');
+    expect(writeForm('Nguyễn')).toBe('Nguyễn');
+  });
+
+  test('folding is limited to Latin marks, because elsewhere they are letters', () => {
+    // `\p{M}` would have been the obvious rule and is the wrong one: in an
+    // abugida the vowel signs are marks, so stripping them deletes letters and
+    // can collapse two different children onto one compare form. A false match
+    // is worse than a missed one — it attaches a pass and bookings to the wrong
+    // child, where a miss only creates a duplicate contact.
+    expect(compareForm('สมชาย')).toBe('สมชาย');
+    expect(compareForm('प्रिया')).toBe('प्रिया');
+    expect(compareForm('김민준')).toBe('김민준');
+  });
+
+  test('#80 reaches in-paste dedup too: one child spelled two ways collapses', () => {
+    // compare form drives P14 as well as matching, so this is a second consequence
+    // of the same change — and the right one. A school merging two class exports
+    // is exactly how a list gains a duplicate, and the two exports need not agree
+    // about the accent. Before #80 these were two students, and the second would
+    // have earned its own permanent contact.
+    const result = parseStudentList(
+      tsv([
+        ['First name', 'Surname', 'DOB'],
+        ['Ana', 'Fernández', '23/4/2010'],
+        ['Ana', 'Fernandez', '23/4/2010'],
+      ])
+    );
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].flags).toContain('listed-twice');
+    // The surviving row keeps the spelling the school actually typed first.
+    expect(result.records[0].write.lastName).toBe('Fernández');
+    expectReconciled(result);
+  });
+
+  test('a letter that carries its stroke inside itself is not folded', () => {
+    // ł, ø and ß do not decompose, so no mark-stripping rule reaches them. This
+    // is a known limit of #80 rather than an oversight: `Wałęsa` matches
+    // `Wałesa` but not `Walesa`.
+    expect(compareForm('Wałęsa')).toBe('wałesa');
+    expect(compareForm('Sørensen')).toBe('sørensen');
+    expect(compareForm('Straße')).toBe('straße');
+  });
+
   test('every record carries both forms', () => {
     const result = parseStudentList(
       tsv([

--- a/school-booking/test/parse.test.js
+++ b/school-booking/test/parse.test.js
@@ -695,15 +695,40 @@ describe('P10 — write form and compare form, kept apart', () => {
     expect(writeForm('Nguyễn')).toBe('Nguyễn');
   });
 
-  test('folding is limited to Latin marks, because elsewhere they are letters', () => {
-    // `\p{M}` would have been the obvious rule and is the wrong one: in an
-    // abugida the vowel signs are marks, so stripping them deletes letters and
-    // can collapse two different children onto one compare form. A false match
-    // is worse than a missed one — it attaches a pass and bookings to the wrong
-    // child, where a miss only creates a duplicate contact.
+  test('folding reaches only marks on a Latin base letter', () => {
+    // `\p{M}` would have been the obvious rule and is the wrong one: in an abugida
+    // the vowel signs are marks, so stripping them deletes letters —
+    // `प्रिया` becomes `परय` — and can collapse two different children onto one
+    // compare form. A false match is worse than a missed one: it attaches a pass
+    // and bookings to the wrong child, where a miss only creates a duplicate.
     expect(compareForm('สมชาย')).toBe('สมชาย');
     expect(compareForm('प्रिया')).toBe('प्रिया');
     expect(compareForm('김민준')).toBe('김민준');
+  });
+
+  test('Cyrillic is left alone, because there the marks make different letters', () => {
+    // The combining-diacritics block is script-neutral, so an ungated rule folds
+    // `й` onto `и` and `ё` onto `е`. Those are separate letters of the Russian
+    // alphabet, not accented spellings of one — Андрей and Андреи are two names.
+    // This is why the regex requires a Latin base letter rather than trusting the
+    // block to mean "accent".
+    expect(compareForm('Андрей')).not.toBe(compareForm('Андреи'));
+    expect(compareForm('Алёна')).not.toBe(compareForm('Алена'));
+  });
+
+  test('Vietnamese tone marks DO fold — an accepted trade, not an oversight', () => {
+    // Vietnamese is Latin script, so the rule reaches it and `Lê`, `Lệ` and `Lễ`
+    // share one compare form even though they are different names. Pinned here so
+    // the cost is visible rather than discovered.
+    //
+    // Accepted because this is the case #80 was filed about — a school types
+    // `Nguyen`, the contact record says `Nguyễn`, and the student silently gets a
+    // second permanent contact. The false match it risks additionally needs the
+    // surname, the birthday *and* the first name to coincide; the miss it
+    // prevents needs none of that and happens on ordinary lists.
+    expect(compareForm('Nguyễn')).toBe('nguyen');
+    expect(compareForm('Lê')).toBe(compareForm('Lệ'));
+    expect(compareForm('Đặng')).toBe(compareForm('Đăng'));
   });
 
   test('#80 reaches in-paste dedup too: one child spelled two ways collapses', () => {


### PR DESCRIPTION
Closes #80. Compare form now folds accents, so `Fernandez` matches `Fernández`. Write form is untouched and still never strips an accent — that half of the split is the point of it, and `Fernández` reaches Clubworx exactly as the school typed it.

The hazard being closed was silent. In a *surname* an accent mismatch stopped the candidate narrowing at all, so an existing student reported `new` and earned a **second permanent contact**, with nothing thrown and no way to delete the result.

## The rule is narrower than #80 proposed, twice

#80 suggested stripping all of `\p{M}`. Measuring it first is what ruled that out — a false match is the worse failure here, because it attaches a permanent pass and bookings to the *wrong child*, where a miss only creates a duplicate contact.

1. **Not `\p{M}`.** In an abugida the vowel signs are marks too, so that rule deletes letters rather than accents: `प्रिया` → `परय`.
2. **Only marks on a Latin base letter.** The combining-diacritics block is script-neutral. Ungated it folds Cyrillic `й` onto `и` and `ё` onto `е` — separate letters of that alphabet, so `Андрей` and `Андреи` would have become one name.

Both reviews caught (2) independently, in the commit that claimed to have avoided it. `71ef2ef` had the bug; `f6dd46a` fixes it and pins it with tests. Verified either side of the change: `compareForm('Андрей') === compareForm('Андреи')` was true, and is now false.

## What it does and doesn't match

| Matches | Stays distinct |
|---|---|
| `Fernández` ≡ `Fernandez` | `Андрей` ≢ `Андреи` (Cyrillic letters) |
| `Zoë` ≡ `Zoe` | `สมชาย` ≢ `สมชัย` (Thai vowel signs) |
| `Nguyễn` ≡ `Nguyen` | `Wałęsa` ≢ `Walesa` (#83) |
| `İnce` ≡ `Ince` (Turkish dotted capital) | `Müller` ≢ `Mueller` (transliteration, not an accent) |

`compareForm` is idempotent, and precomposed input agrees with decomposed.

## One accepted cost, stated plainly

**Vietnamese folds**, because it is Latin script: `Lê`, `Lệ` and `Lễ` share one compare form even though they are different names. Accepted, because it is exactly the case #80 was filed about — a school types `Nguyen`, the record says `Nguyễn` — and a false match additionally needs the surname, the birthday *and* the first name to coincide, where the miss it prevents needs none of that. Pinned by test so the cost is visible rather than discovered.

Also worth flagging: **#80 argued for counting accented surnames across the ~60k contacts before widening a shared key, and that count was not done.** It is recorded in the spec as accepted-without-evidence, with a note on what to gather if you want to revisit the trade.

## Second consequence, tested

Compare form drives P14's in-paste dedup as well as matching, so one child spelled two ways in a single paste now collapses to a `listed-twice` row instead of two students. A school merging two class exports is exactly how a list gains a duplicate, and the exports need not agree about the accent. P14's own wording is corrected — it qualified only the *first* name as compare-form.

## Left open: #83

`ł`, `ø`, `ß`, `đ`, `æ` do not decompose, so no mark-stripping rule can reach them — `Wałęsa` matches `Wałesa` but not `Walesa`. That is the same silent duplicate-contact failure #80 was filed for, and it needs a transliteration table plus an answer to "should `Müller` match `Mueller`?", so it is its own ticket rather than a follow-up commit.

## Verification

```bash
npx vitest run                      # 601 pass repo-wide (87 in school-booking)
```

`pages.yml` runs none of them (#76), so this is by hand. Reviewed on both axes; `f6dd46a` is what came of it.

> ⚠️ **Merging this repo is deploying it** (`main` → `ujstaff.happyk.au`). Nothing imports these modules yet, so no staff-visible behaviour changes — but the merge is yours to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYGFYNFXj8pM5beoUa75Uo
