### PR TITLE
feat(clubworx): the Worker skeleton, the Access gate, and the pace (#66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,16 @@ tools.json              - source of truth for hub entries
 roster.html             - daily staff roster, pulled from Deputy via Cloudflare Worker
 cloudflare-worker/      - Worker for roster API and tools.json editor API
 cloudflare-payments-proxy/ - Worker bridging vouchers/ to uj-payments with the Access JWT
-cloudflare-clubworx/    - Clubworx API access for the school-group booking tool (#46).
-                          ACCESS.md is the answer to #47: where the key comes from,
-                          where it lives, and what is still owed. No Worker code yet.
+cloudflare-clubworx/    - uj-clubworx-api, the Worker for the school-group booking
+                          tool (#46). Deploys separately from Pages. Start with its
+                          README.md; ACCESS.md is the answer to #47 (where the key
+                          comes from and where it lives). Verifies the Access JWT
+                          rather than trusting the header, paces at 75 req/min, and
+                          stores nothing — no student name or DOB in any store or
+                          log line. Only GET /api/clubworx/health so far (#66); the
+                          working routes arrive with #67/#68/#70.
+cloudflare-clubworx/src/ - the Worker. request.js and errors.js were moved here
+                          from probes/lib/ by #66 and the probes import them back.
 cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, and
                           what they found. Start with probes/README.md — it carries
                           the rules (no production data recorded, pace under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,13 +312,17 @@ Access, so an unauthenticated request returns **HTTP 200 carrying the Access
 login page**, not the file you asked for — a success status and a body that
 never contains your change. Verifying content needs a real browser session.
 
-The two Workers deploy separately; a Pages publish does not touch them.
+The three Workers deploy separately; a Pages publish does not touch them.
 
 ```bash
 cd cloudflare-worker          # roster + tools.json API
 npx wrangler deploy
 
 cd cloudflare-payments-proxy  # voucher portal → uj-payments; happyk account
+npx wrangler deploy
+
+cd cloudflare-clubworx        # school-group booking → Clubworx; happyk account
+npx wrangler secret put CLUBWORX_ACCOUNT_KEY   # once per environment, not in git
 npx wrangler deploy
 ```
 

--- a/cloudflare-clubworx/.dev.vars.example
+++ b/cloudflare-clubworx/.dev.vars.example
@@ -11,7 +11,11 @@
 # The gym's Clubworx API key. Clubworx admin UI -> Settings -> API.
 # Sent as the account_key query parameter on every api/v2 request.
 #
-# This is the only variable staff-site#47 settles. The Worker's own auth is a
-# separate decision — the #46 map calls for it to be Access-gated — so nothing
-# is pre-declared for it here. Add what that ticket decides, when it decides it.
+# This is the only variable staff-site#47 settles, and staff-site#66 has since
+# confirmed it is still the only one that belongs in this file. The Worker's
+# auth is Cloudflare Access, and its two settings — ACCESS_TEAM_DOMAIN and
+# ACCESS_AUD — are [vars] in the committed wrangler.toml rather than secrets:
+# neither is private (the AUD tag travels in every JWT the browser already
+# holds), and committing them is what makes a fresh deploy fail closed instead
+# of silently refusing everything until somebody sets them by hand.
 CLUBWORX_ACCOUNT_KEY=

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -1,0 +1,139 @@
+# `uj-clubworx-api` — the staff site's Clubworx Worker
+
+staff-site[#66](https://github.com/urbanjungleirc/staff-site/issues/66), part of
+the school group booking map ([#46](https://github.com/urbanjungleirc/staff-site/issues/46)).
+Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §6.
+
+This ticket ships the **skeleton**: the Worker, the Access gate, the pacer and
+the request layer. The routes that do the work — `events`, `plan`, `schools`,
+`contacts`, `student`, `unbook` — arrive with #67, #68 and #70. Until then the
+only route is `GET /api/clubworx/health`.
+
+`ACCESS.md` in this directory is the answer to #47: where the key comes from,
+where it lives, and what is still owed. Read it first.
+
+## Layout
+
+```text
+src/index.js     the Worker: routing, the Access gate, the log line
+src/access.js    Cloudflare Access JWT verification against the team JWKS
+src/clubworx.js  the only path to Clubworx: paced, redacted, measured shapes
+src/pace.js      75 req/min, one in flight — the constant #51 measured
+src/request.js   buildUrl + redact                (promoted from probes/lib)
+src/errors.js    errorMessageOf                   (promoted from probes/lib)
+test/            vitest, run by hand — this repo runs no tests in CI
+probes/          the read-only probes, and what they found
+```
+
+`src/request.js` and `src/errors.js` were **moved** out of `probes/lib/`, not
+copied. The probes import them from here now. They were written against measured
+Clubworx behaviour and carry their own test files; a second copy would re-derive
+their bugs, and the two would drift on the first fix that only landed in one.
+
+## Auth
+
+**Cloudflare Access.** Access fronts `ujstaff.happyk.au` and injects a signed
+`Cf-Access-Jwt-Assertion` header. The Worker **verifies the signature** against
+the `happyk.cloudflareaccess.com` JWKS and **fails closed** — it does not trust
+the header's presence, and a present-but-invalid token is a rejection rather
+than a fallback.
+
+Everything below is a 401, and the client is told only `unauthorized` — the
+reason goes to the log, because told apart these reasons describe the gate to
+whoever is rattling it:
+
+| Reason | What it was |
+|---|---|
+| `no-token` | no assertion at all |
+| `malformed` | not three decodable segments |
+| `unsupported-alg` | anything but `RS256` — `none` and `HS256` are the classic bypasses |
+| `unknown-kid` | signed by a key this team does not publish |
+| `bad-signature` | forged, or edited after signing |
+| `expired` / `not-yet-valid` | outside the token's window, ±30 s of skew |
+| `wrong-issuer` | minted by a different Access team |
+| `wrong-audience` | minted for a different app **on this team** — every app on `happyk.au` is signed by the same keys |
+| `no-email` | valid, but with nobody to attribute a write to |
+| `jwks-unavailable` | the key set could not be fetched — a rejection, never a skip |
+| `not-configured` | `ACCESS_TEAM_DOMAIN` or `ACCESS_AUD` unset |
+
+`workers_dev = false` in `wrangler.toml` is part of this: a `*.workers.dev`
+address is not fronted by Access, so leaving it on would publish an
+unauthenticated door beside the guarded one.
+
+## What this Worker stores
+
+**Nothing.** No student name or date of birth reaches any Cloudflare store, KV,
+D1, or log (§6, D10). There is no run store and no persistence of any kind.
+
+The log line is one JSON object per request carrying the worker name, the
+**route path**, the method, the status, the operator email and the elapsed ms —
+and on a rejection, the reason.
+
+- **Never the query string.** `GET /contacts?last_name=&dob=` is a route this
+  design calls for, so logging a path with its query would put a student's
+  surname and date of birth into Cloudflare's log store.
+- **Never a body.** One debugging `console.log(body)` is all it would take.
+
+`test/worker.test.js` asserts both directly, because a rule of this shape fails
+silently.
+
+## Pacing
+
+**75 requests per minute, one in flight.** #51 measured ~50 fast requests
+followed by ~18 s of `429`, and Clubworx advertises **no rate-limit headers at
+all** — not even while throttling — so the pace is a design constant rather than
+an adaptive one. Concurrency is the wrong lever: the ceiling is on requests, so
+running two at once only reaches it sooner.
+
+The allowance is **gym-wide** — the roster Worker and n8n spend from the same
+key (#47) — so being under the ceiling alone is not the same as being under it.
+
+## Deploying
+
+`main` is production on this repo, but a Pages publish does **not** touch this
+Worker. It deploys on its own:
+
+```bash
+cd cloudflare-clubworx
+npm install
+npx wrangler secret put CLUBWORX_ACCOUNT_KEY   # once, per environment
+npx wrangler deploy
+```
+
+Then check the gate from a browser already signed in to the staff hub:
+
+```text
+https://ujstaff.happyk.au/api/clubworx/health
+```
+
+A healthy answer names the operator Access authenticated, which is what proves
+the gate ran rather than proving the Worker is awake:
+
+```json
+{
+  "ok": true,
+  "worker": "uj-clubworx-api",
+  "email": "you@urbanjungleirc.com",
+  "clubworxKey": "configured",
+  "time": "2026-08-19T14:00:00.000Z"
+}
+```
+
+`"clubworxKey": "missing"` means the secret was never put. The health route
+makes no Clubworx call, so it answers `200` either way — it reports the fact
+rather than hiding it.
+
+## Tests
+
+```bash
+cd cloudflare-clubworx
+npm test
+```
+
+Run `cloudflare-worker/test/secret-hygiene.test.js` too — it asserts the
+repo-wide secret rule for Worker directories *including ones that did not exist
+when it was written*, which is this one.
+
+Nothing runs either automatically: `pages.yml` is this repo's only workflow and
+it runs no tests. Wiring vitest into CI is `ACCESS.md`'s open recommendation and
+is still open.

--- a/cloudflare-clubworx/package-lock.json
+++ b/cloudflare-clubworx/package-lock.json
@@ -1,12 +1,148 @@
 {
-  "name": "uj-clubworx-probes",
+  "name": "uj-clubworx",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "uj-clubworx-probes",
+      "name": "uj-clubworx",
       "devDependencies": {
-        "vitest": "^2.1.0"
+        "vitest": "^2.1.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260815.1.tgz",
+      "integrity": "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260815.1.tgz",
+      "integrity": "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260815.1.tgz",
+      "integrity": "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -298,6 +434,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -315,6 +468,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -330,6 +500,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -400,12 +587,560 @@
         "node": ">=12"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
@@ -415,9 +1150,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -426,6 +1158,35 @@
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
       }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.4",
@@ -519,9 +1280,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -536,9 +1294,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -553,9 +1308,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,9 +1322,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,9 +1336,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -604,9 +1350,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,9 +1364,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -638,9 +1378,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -655,9 +1392,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -672,9 +1406,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,9 +1420,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,9 +1434,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,9 +1448,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -815,6 +1537,26 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -946,6 +1688,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -983,6 +1732,20 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1009,6 +1772,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1092,6 +1875,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -1107,6 +1900,24 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260815.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260815.0-alpha.tgz",
+      "integrity": "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260815.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/ms": {
@@ -1134,6 +1945,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -1234,6 +2052,64 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1264,6 +2140,19 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1308,6 +2197,41 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -1473,6 +2397,543 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260815.1.tgz",
+      "integrity": "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260815.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260815.1",
+        "@cloudflare/workerd-linux-64": "1.20260815.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260815.1",
+        "@cloudflare/workerd-windows-64": "1.20260815.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.124.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
+      "integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260815.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260815.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260815.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     }
   }

--- a/cloudflare-clubworx/package.json
+++ b/cloudflare-clubworx/package.json
@@ -1,13 +1,17 @@
 {
-  "name": "uj-clubworx-probes",
+  "name": "uj-clubworx",
   "private": true,
   "type": "module",
   "scripts": {
     "test": "vitest run",
+    "check": "node --check src/index.js",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
     "probe:51": "node probes/run-51.mjs",
     "probe:49": "node probes/run-49.mjs"
   },
   "devDependencies": {
-    "vitest": "^2.1.0"
+    "vitest": "^2.1.0",
+    "wrangler": "^4.0.0"
   }
 }

--- a/cloudflare-clubworx/package.json
+++ b/cloudflare-clubworx/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "uj-clubworx",
+  "name": "uj-clubworx-api",
   "private": true,
   "type": "module",
   "scripts": {

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -132,7 +132,8 @@ Every one of them is a consequence of *production, public repo, no sandbox*.
 ## Layout
 
 ```
-lib/request.mjs   URL building and redaction        (unit tested)
+../src/request.js URL building and redaction        (unit tested)
+../src/errors.js  a refusal, read safely            (unit tested)
 lib/report.mjs    response → publishable summary    (unit tested)
 lib/key.mjs       where the live key comes from     (unit tested)
 lib/http.mjs      the read path to Clubworx: GET    (unit tested)
@@ -148,6 +149,13 @@ run-49.mjs        the #49 probe itself — writes
 run-50.mjs        the #50 probe itself — writes and deletes
 run-60.mjs        the #60 probe itself — writes and deletes
 ```
+
+The two `../src/` entries are not probe files any more. staff-site#66 promoted
+them into the Worker's own module, because the Worker needs exactly the same URL
+construction, the same redaction and the same way of reading a refusal — and a
+second copy would re-derive their bugs and then drift on the first fix that
+landed in only one of them. The probes import them from there; their tests moved
+with them, to `../test/`.
 
 The libraries are tested and the runner is not. That split is deliberate: the
 runner's job is to talk to a live API, which a unit test cannot do, so

--- a/cloudflare-clubworx/probes/lib/booking.mjs
+++ b/cloudflare-clubworx/probes/lib/booking.mjs
@@ -23,7 +23,7 @@
  * arbitrary id.
  */
 
-import { buildUrl, redact } from './request.mjs';
+import { buildUrl, redact } from '../../src/request.js';
 import { rateLimitHeaders } from './report.mjs';
 
 /** Fields that exist for the write-up, not for Clubworx. */

--- a/cloudflare-clubworx/probes/lib/http.mjs
+++ b/cloudflare-clubworx/probes/lib/http.mjs
@@ -7,7 +7,7 @@
  * promise in a comment.
  */
 
-import { buildUrl, redact } from './request.mjs';
+import { buildUrl, redact } from '../../src/request.js';
 import { rateLimitHeaders } from './report.mjs';
 
 /**

--- a/cloudflare-clubworx/probes/lib/membership.mjs
+++ b/cloudflare-clubworx/probes/lib/membership.mjs
@@ -22,7 +22,7 @@
  * code that looks like something else entirely.
  */
 
-import { buildUrl, redact } from './request.mjs';
+import { buildUrl, redact } from '../../src/request.js';
 import { rateLimitHeaders } from './report.mjs';
 
 /**

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -350,44 +350,6 @@ export function summariseBookings(body, ourKeys = []) {
 }
 
 /**
- * The error message out of a rejected write.
- *
- * A deliberate, bounded exception to *never record a row of production data*.
- * The rule exists because probe responses are drawn from a 60,000-person
- * database — but this reads the server's complaint about **the probe's own
- * request**, which is the only place the reason for a rejection is written
- * down. Discarding it leaves staff-site#50 with "HTTP 400" and no answer to
- * what a booking actually requires, which is the question the ticket is for.
- *
- * Bounded three ways: only the `error`-shaped fields are read, never the whole
- * body; the result is truncated; and the caller redacts before it is printed or
- * written.
- *
- * @param {unknown} body
- * @param {{limit?: number}} [opts]
- * @returns {string|null}
- */
-export function errorMessageOf(body, { limit = 300 } = {}) {
-  if (body === null || typeof body !== 'object') return null;
-
-  const raw = body.error ?? body.errors ?? body.message ?? null;
-  if (raw === null || raw === undefined) return null;
-
-  // Rails-shaped APIs answer with either a string, a list, or field → messages.
-  const text = Array.isArray(raw)
-    ? raw.map(String).join('; ')
-    : typeof raw === 'object'
-      ? Object.entries(raw)
-          .map(([field, messages]) => `${field}: ${[].concat(messages).map(String).join(', ')}`)
-          .join('; ')
-      : String(raw);
-
-  const trimmed = text.trim();
-  if (!trimmed) return null;
-  return trimmed.length > limit ? `${trimmed.slice(0, limit)}…` : trimmed;
-}
-
-/**
  * Question 2: what does a booking actually require?
  *
  * staff-site#50 asks this only if question 1 fails, and names the candidate

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -12,7 +12,6 @@ import {
   classifyWrite,
   schemeCollapses,
   summariseBookings,
-  errorMessageOf,
   describeBookingRequirement,
   describeDuplicateBooking,
   describeCancellation,
@@ -461,39 +460,6 @@ describe('summariseBookings', () => {
   it('survives a non-array body', () => {
     expect(summariseBookings(null).notAnArray).toBe(true);
     expect(summariseBookings('<html>').count).toBe(0);
-  });
-});
-
-describe('errorMessageOf', () => {
-  it('reads a plain string error — the shape Clubworx actually answers with', () => {
-    expect(errorMessageOf({ error: 'Contact has no active membership' })).toBe(
-      'Contact has no active membership',
-    );
-  });
-
-  it('joins a list of errors', () => {
-    expect(errorMessageOf({ errors: ['too late', 'no spaces'] })).toBe('too late; no spaces');
-  });
-
-  it('flattens field → messages, the Rails shape', () => {
-    expect(errorMessageOf({ errors: { base: ['not permitted'], event: 'is full' } })).toBe(
-      'base: not permitted; event: is full',
-    );
-  });
-
-  it('truncates rather than recording an unbounded body', () => {
-    const v = errorMessageOf({ error: 'x'.repeat(500) }, { limit: 20 });
-    expect(v).toHaveLength(21); // 20 + the ellipsis
-    expect(v.endsWith('…')).toBe(true);
-  });
-
-  it('returns null when there is no error to read', () => {
-    // It must never fall back to serialising the whole body — that is how a row
-    // of production data would end up in probes/out/.
-    expect(errorMessageOf({ booking_id: 'bk-1', contact_key: 'ck-real' })).toBeNull();
-    expect(errorMessageOf(null)).toBeNull();
-    expect(errorMessageOf('<html>')).toBeNull();
-    expect(errorMessageOf({ error: '   ' })).toBeNull();
   });
 });
 

--- a/cloudflare-clubworx/probes/lib/write.mjs
+++ b/cloudflare-clubworx/probes/lib/write.mjs
@@ -16,7 +16,7 @@
  *      resembling a real person is refused before the network is touched.
  */
 
-import { buildUrl, redact } from './request.mjs';
+import { buildUrl, redact } from '../../src/request.js';
 import { rateLimitHeaders } from './report.mjs';
 import { assertProbeIdentity } from './identity.mjs';
 

--- a/cloudflare-clubworx/probes/run-50.mjs
+++ b/cloudflare-clubworx/probes/run-50.mjs
@@ -87,9 +87,9 @@ import {
   describeDuplicateBooking,
   describeCancellation,
   pickBookableEvents,
-  errorMessageOf,
 } from './lib/report.mjs';
-import { redact } from './lib/request.mjs';
+import { errorMessageOf } from '../src/errors.js';
+import { redact } from '../src/request.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(HERE, 'out');

--- a/cloudflare-clubworx/src/access.js
+++ b/cloudflare-clubworx/src/access.js
@@ -1,0 +1,196 @@
+/**
+ * Cloudflare Access JWT verification — this Worker's only gate.
+ *
+ * Access sits in front of `ujstaff.happyk.au` and injects a signed
+ * `Cf-Access-Jwt-Assertion` header on every request it lets through. The
+ * temptation is to read the header's presence and get on with it. staff-site#66
+ * rules that out, for a reason worth restating: **the header is only a proof if
+ * its signature is checked.** A request that reaches this Worker by any path
+ * Access does not front — a route added later, a `workers.dev` subdomain left
+ * on, a service binding — carries whatever header its sender chose to write.
+ *
+ * So: the signature is verified against the team's published JWKS, and every
+ * failure is a rejection. **There is no fallback branch in this file.** A
+ * present-but-invalid token is further from acceptable than an absent one, not
+ * closer, and unset configuration rejects everything rather than degrading into
+ * "any token from this team".
+ *
+ * The verified email is what the Worker logs against each write (§6). A token
+ * that carries no email is therefore not good enough to act on: there would be
+ * nothing to attribute the write to, which is the one control standing in for
+ * the per-integration attribution Clubworx cannot give (#47).
+ */
+
+/** Clock skew tolerated on `exp` and `nbf`, in seconds. */
+const SKEW_S = 30;
+
+/** How long a fetched key set is trusted before it is fetched again. */
+const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * The floor between two key-set fetches provoked by an unknown `kid`.
+ *
+ * Access rotates keys, so an unknown kid can legitimately mean "the cache is
+ * stale" and one refetch is right. Refetching on *every* unknown kid is not:
+ * a caller sending garbage kids would turn each rejected request into an
+ * outbound request of ours.
+ */
+const UNKNOWN_KID_REFETCH_FLOOR_MS = 5 * 60 * 1000;
+
+/**
+ * Where a team publishes its Access signing keys.
+ *
+ * @param {string} teamDomain e.g. `happyk.cloudflareaccess.com`
+ * @returns {string}
+ */
+export function certsUrl(teamDomain) {
+  const host = String(teamDomain)
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/+$/, '');
+  return `https://${host}/cdn-cgi/access/certs`;
+}
+
+const reject = reason => ({ ok: false, reason, email: null, sub: null });
+
+const decodeSegment = segment => {
+  const b64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
+
+const decodeJson = segment => JSON.parse(new TextDecoder().decode(decodeSegment(segment)));
+
+/**
+ * Build a verifier bound to one Access team and one application.
+ *
+ * @param {object} opts
+ * @param {string} opts.teamDomain    `happyk.cloudflareaccess.com`
+ * @param {string} opts.aud           The Access application's AUD tag
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {() => number} [opts.now]
+ * @param {number} [opts.cacheTtlMs]
+ * @returns {(token: string|null) => Promise<{ok: boolean, reason?: string, email: string|null, sub: string|null}>}
+ */
+export function createAccessVerifier({
+  teamDomain,
+  aud,
+  fetchImpl = fetch,
+  now = Date.now,
+  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+}) {
+  /** @type {{keys: any[], fetchedAt: number} | null} */
+  let cache = null;
+  /** kid → imported CryptoKey, so a hot path does not re-import on every call. */
+  let imported = new Map();
+  let lastFetchAttemptAt = -Infinity;
+
+  const loadKeys = async () => {
+    lastFetchAttemptAt = now();
+    const res = await fetchImpl(certsUrl(teamDomain));
+    if (!res || !res.ok) throw new Error(`jwks ${res ? res.status : 'no response'}`);
+    const body = await res.json();
+    const keys = Array.isArray(body?.keys) ? body.keys : [];
+    if (keys.length === 0) throw new Error('jwks empty');
+    cache = { keys, fetchedAt: now() };
+    imported = new Map();
+    return cache;
+  };
+
+  const keyFor = async kid => {
+    if (!cache || now() - cache.fetchedAt > cacheTtlMs) await loadKeys();
+
+    let jwk = cache.keys.find(k => k.kid === kid);
+    if (!jwk && now() - lastFetchAttemptAt > UNKNOWN_KID_REFETCH_FLOOR_MS) {
+      // Access rotated mid-cache, most likely. One refetch, then take the answer.
+      await loadKeys();
+      jwk = cache.keys.find(k => k.kid === kid);
+    }
+    if (!jwk) return null;
+
+    if (!imported.has(kid)) {
+      imported.set(
+        kid,
+        await crypto.subtle.importKey(
+          'jwk',
+          { kty: jwk.kty, n: jwk.n, e: jwk.e, alg: 'RS256', ext: true },
+          { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+          false,
+          ['verify'],
+        ),
+      );
+    }
+    return imported.get(kid);
+  };
+
+  return async function verify(token) {
+    // Unset configuration is a rejection, not a relaxation. This is the branch
+    // that would otherwise quietly turn a misdeploy into an open Worker.
+    if (!teamDomain || !aud) return reject('not-configured');
+    if (!token) return reject('no-token');
+
+    const parts = String(token).split('.');
+    if (parts.length !== 3) return reject('malformed');
+
+    let header;
+    let claims;
+    try {
+      header = decodeJson(parts[0]);
+      claims = decodeJson(parts[1]);
+    } catch {
+      return reject('malformed');
+    }
+    if (!header || typeof header !== 'object' || !claims || typeof claims !== 'object') {
+      return reject('malformed');
+    }
+
+    // Only RS256, and only from the header we are about to verify with. `none`
+    // is the classic bypass; HS256 is the one where a verifier can be tricked
+    // into using the public key as a shared secret.
+    if (header.alg !== 'RS256') return reject('unsupported-alg');
+    if (!header.kid) return reject('unknown-kid');
+
+    let key;
+    try {
+      key = await keyFor(header.kid);
+    } catch {
+      // No key set means no way to check. That is a rejection, never a skip.
+      return reject('jwks-unavailable');
+    }
+    if (!key) return reject('unknown-kid');
+
+    let signatureOk = false;
+    try {
+      signatureOk = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        key,
+        decodeSegment(parts[2]),
+        new TextEncoder().encode(`${parts[0]}.${parts[1]}`),
+      );
+    } catch {
+      signatureOk = false;
+    }
+    if (!signatureOk) return reject('bad-signature');
+
+    // Claims are only worth reading now that the signature holds.
+    const nowS = Math.floor(now() / 1000);
+
+    // A token with no `exp` is treated as expired rather than as eternal.
+    if (typeof claims.exp !== 'number' || nowS > claims.exp + SKEW_S) return reject('expired');
+    if (typeof claims.nbf === 'number' && nowS + SKEW_S < claims.nbf) return reject('not-yet-valid');
+
+    if (claims.iss !== `https://${certsUrl(teamDomain).split('/')[2]}`) return reject('wrong-issuer');
+
+    // Every Access application on this team is signed by the same keys, so
+    // without this a token minted for the n8n app would open this Worker.
+    const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
+    if (!audiences.includes(aud)) return reject('wrong-audience');
+
+    if (!claims.email) return reject('no-email');
+
+    return { ok: true, email: String(claims.email), sub: claims.sub ? String(claims.sub) : null };
+  };
+}

--- a/cloudflare-clubworx/src/access.js
+++ b/cloudflare-clubworx/src/access.js
@@ -38,17 +38,38 @@ const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
 const UNKNOWN_KID_REFETCH_FLOOR_MS = 5 * 60 * 1000;
 
 /**
+ * How long to wait for the key set before giving up.
+ *
+ * Without this a hung certs endpoint stalls every request behind it. Failing
+ * closed is right; failing closed *slowly* is a different outage, and the same
+ * one either way from the operator's side.
+ */
+const JWKS_TIMEOUT_MS = 5000;
+
+/**
+ * The team's bare host, however the team domain was written in config.
+ *
+ * Both the certs URL and the expected `iss` are built from this, so they cannot
+ * disagree about what counts as the same team.
+ *
+ * @param {string} teamDomain e.g. `happyk.cloudflareaccess.com`
+ * @returns {string}
+ */
+export function accessHost(teamDomain) {
+  return String(teamDomain)
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/+$/, '');
+}
+
+/**
  * Where a team publishes its Access signing keys.
  *
  * @param {string} teamDomain e.g. `happyk.cloudflareaccess.com`
  * @returns {string}
  */
 export function certsUrl(teamDomain) {
-  const host = String(teamDomain)
-    .trim()
-    .replace(/^https?:\/\//, '')
-    .replace(/\/+$/, '');
-  return `https://${host}/cdn-cgi/access/certs`;
+  return `https://${accessHost(teamDomain)}/cdn-cgi/access/certs`;
 }
 
 const reject = reason => ({ ok: false, reason, email: null, sub: null });
@@ -81,6 +102,7 @@ export function createAccessVerifier({
   fetchImpl = fetch,
   now = Date.now,
   cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  jwksTimeoutMs = JWKS_TIMEOUT_MS,
 }) {
   /** @type {{keys: any[], fetchedAt: number} | null} */
   let cache = null;
@@ -90,7 +112,9 @@ export function createAccessVerifier({
 
   const loadKeys = async () => {
     lastFetchAttemptAt = now();
-    const res = await fetchImpl(certsUrl(teamDomain));
+    const res = await fetchImpl(certsUrl(teamDomain), {
+      signal: AbortSignal.timeout(jwksTimeoutMs),
+    });
     if (!res || !res.ok) throw new Error(`jwks ${res ? res.status : 'no response'}`);
     const body = await res.json();
     const keys = Array.isArray(body?.keys) ? body.keys : [];
@@ -182,7 +206,7 @@ export function createAccessVerifier({
     if (typeof claims.exp !== 'number' || nowS > claims.exp + SKEW_S) return reject('expired');
     if (typeof claims.nbf === 'number' && nowS + SKEW_S < claims.nbf) return reject('not-yet-valid');
 
-    if (claims.iss !== `https://${certsUrl(teamDomain).split('/')[2]}`) return reject('wrong-issuer');
+    if (claims.iss !== `https://${accessHost(teamDomain)}`) return reject('wrong-issuer');
 
     // Every Access application on this team is signed by the same keys, so
     // without this a token minted for the n8n app would open this Worker.

--- a/cloudflare-clubworx/src/clubworx.js
+++ b/cloudflare-clubworx/src/clubworx.js
@@ -31,76 +31,132 @@
 
 import { buildUrl, redact } from './request.js';
 import { errorMessageOf } from './errors.js';
-import { createPacer } from './pace.js';
+import { sharedPacer } from './pace.js';
 
 /** How much of a non-JSON body is worth keeping to diagnose a throttle or a WAF block. */
 const BODY_TEXT_LIMIT = 500;
 
 /**
+ * Everything that leaves this module as free text goes through here.
+ *
+ * `redact` removes the account key and nothing else, which is not enough on its
+ * own: both runtimes interpolate the failing request URL into a connection
+ * error, and that URL carries the query as well as the key. So the key goes,
+ * and any query string hanging off a URL goes with it.
+ */
+function scrub(text, accountKey) {
+  return redact(String(text), accountKey).replace(/(https?:\/\/\S+?)\?\S*/g, '$1');
+}
+
+/**
+ * A body and the Content-Type it has to be sent with — one concept, not two
+ * independent flags. Clubworx wants JSON for a create and form encoding for a
+ * delete, and pairing them here is what stops a caller sending one with the
+ * other's header.
+ */
+function encodeBody({ json: payload, form }) {
+  if (payload !== undefined) {
+    return {
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    };
+  }
+  if (form !== undefined) {
+    return {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(form).toString(),
+    };
+  }
+  return { headers: {}, body: undefined };
+}
+
+/** One shape for every outcome, so a caller never has to ask which kind it got. */
+const outcome = ({
+  ok,
+  status,
+  endpoint,
+  ms,
+  body = null,
+  bodyText = null,
+  message = null,
+  networkError = false,
+}) => ({
+  ok,
+  status,
+  url: endpoint,
+  ms,
+  body,
+  nonJson: body === null && !networkError,
+  bodyText,
+  message,
+  networkError,
+});
+
+/**
  * @param {object} opts
  * @param {string} opts.accountKey
  * @param {typeof fetch} [opts.fetchImpl]
- * @param {ReturnType<typeof createPacer>} [opts.pacer]
+ * @param {typeof sharedPacer} [opts.pacer]
  */
-export function createClubworxClient({ accountKey, fetchImpl = fetch, pacer = createPacer() }) {
+export function createClubworxClient({ accountKey, fetchImpl = fetch, pacer = sharedPacer }) {
   if (!accountKey) {
     throw new Error('createClubworxClient: an account key is required; refusing to call anonymously');
   }
 
   const send = async ({ method, path, params, json: payload, form }) => {
     const url = buildUrl({ path, accountKey, params });
-    const safeUrl = redact(url, accountKey);
+
+    // The endpoint WITHOUT its query, and it is the only form that leaves this
+    // module. The obvious use of a url field is a log line, and the query is
+    // where `?last_name=&dob=` puts a student's surname and date of birth —
+    // §6/D10. redact() would not catch that: it removes the account key and
+    // nothing else. Dropping the query is what makes the rule hold here.
+    const endpoint = redact(url.split('?')[0], accountKey);
+
+    const { headers, body: requestBody } = encodeBody({ json: payload, form });
     const started = Date.now();
 
     return pacer(async () => {
       try {
         const res = await fetchImpl(url, {
           method,
-          headers: {
-            Accept: 'application/json',
-            ...(payload !== undefined ? { 'Content-Type': 'application/json' } : {}),
-            ...(form !== undefined ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {}),
-          },
-          ...(payload !== undefined ? { body: JSON.stringify(payload) } : {}),
-          ...(form !== undefined ? { body: new URLSearchParams(form).toString() } : {}),
+          headers: { Accept: 'application/json', ...headers },
+          ...(requestBody !== undefined ? { body: requestBody } : {}),
         });
 
         const text = await res.text();
 
         // A throttle or a WAF block answers in HTML. Parsing must not be what
         // decides whether the caller gets a usable result.
-        let body = null;
+        let parsed = null;
         try {
-          body = JSON.parse(text);
+          parsed = JSON.parse(text);
         } catch {
-          body = null;
+          parsed = null;
         }
 
-        return {
+        return outcome({
           ok: res.ok,
           status: res.status,
-          url: safeUrl,
+          endpoint,
           ms: Date.now() - started,
-          body,
-          nonJson: body === null,
-          bodyText: body === null ? redact(text, accountKey).slice(0, BODY_TEXT_LIMIT) : null,
-          message: errorMessageOf(body),
-          networkError: false,
-        };
+          body: parsed,
+          bodyText: parsed === null ? scrub(text, accountKey).slice(0, BODY_TEXT_LIMIT) : null,
+          message: errorMessageOf(parsed),
+        });
       } catch (err) {
-        return {
+        return outcome({
           ok: false,
           // 0 rather than null, so a caller comparing statuses cannot mistake a
           // connection failure for an upstream answer it simply did not read.
           status: 0,
-          url: safeUrl,
+          endpoint,
           ms: Date.now() - started,
-          body: null,
-          nonJson: false,
-          bodyText: null,
-          message: redact(err?.message ?? err?.code ?? 'unknown error', accountKey),
+          // Both runtimes interpolate the request URL into connection errors,
+          // and that URL carries the key and the query.
+          message: scrub(err?.message ?? err?.code ?? 'unknown error', accountKey),
           networkError: true,
-        };
+        });
       }
     });
   };

--- a/cloudflare-clubworx/src/clubworx.js
+++ b/cloudflare-clubworx/src/clubworx.js
@@ -1,0 +1,118 @@
+/**
+ * The Worker's only path to Clubworx.
+ *
+ * Every request shape here is measured, not read off the reference — the
+ * reference has been wrong twice on this effort. In particular:
+ *
+ *   - `account_key` travels in the **query string** on every call, including
+ *     writes. It is never a body field.
+ *   - A create is `POST` with a **JSON** body, and Clubworx answers **200**, not
+ *     201 (#49/#60).
+ *   - `DELETE /bookings/:id` needs a **form-encoded** body carrying
+ *     `contact_key`. Sent any other way it answers `401 "Authorization failed"`,
+ *     which is indistinguishable from a key without delete permission — and was
+ *     misread as exactly that, until #60 sent it correctly (#50/#60).
+ *
+ * Two rules this layer adds, both of which exist because staff-site is a public
+ * repo talking to a 60,000-person production database with no sandbox:
+ *
+ *   - **Everything goes through the pacer.** There is no unpaced escape hatch,
+ *     because the one call that skips it is the one that spends the gym's
+ *     allowance (see `pace.js`).
+ *   - **Nothing handed back carries the key.** The url is redacted, the error
+ *     message is redacted, and a non-JSON body is redacted and truncated. Node
+ *     and Workers both interpolate the request URL into connection errors, and
+ *     that URL carries the key.
+ *
+ * On bodies: the parsed body is returned to the caller, because serving it to
+ * the operator's own page is the entire job. It is never *logged* — see the log
+ * line in `index.js`, which records route, status, operator and timing only.
+ */
+
+import { buildUrl, redact } from './request.js';
+import { errorMessageOf } from './errors.js';
+import { createPacer } from './pace.js';
+
+/** How much of a non-JSON body is worth keeping to diagnose a throttle or a WAF block. */
+const BODY_TEXT_LIMIT = 500;
+
+/**
+ * @param {object} opts
+ * @param {string} opts.accountKey
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {ReturnType<typeof createPacer>} [opts.pacer]
+ */
+export function createClubworxClient({ accountKey, fetchImpl = fetch, pacer = createPacer() }) {
+  if (!accountKey) {
+    throw new Error('createClubworxClient: an account key is required; refusing to call anonymously');
+  }
+
+  const send = async ({ method, path, params, json: payload, form }) => {
+    const url = buildUrl({ path, accountKey, params });
+    const safeUrl = redact(url, accountKey);
+    const started = Date.now();
+
+    return pacer(async () => {
+      try {
+        const res = await fetchImpl(url, {
+          method,
+          headers: {
+            Accept: 'application/json',
+            ...(payload !== undefined ? { 'Content-Type': 'application/json' } : {}),
+            ...(form !== undefined ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {}),
+          },
+          ...(payload !== undefined ? { body: JSON.stringify(payload) } : {}),
+          ...(form !== undefined ? { body: new URLSearchParams(form).toString() } : {}),
+        });
+
+        const text = await res.text();
+
+        // A throttle or a WAF block answers in HTML. Parsing must not be what
+        // decides whether the caller gets a usable result.
+        let body = null;
+        try {
+          body = JSON.parse(text);
+        } catch {
+          body = null;
+        }
+
+        return {
+          ok: res.ok,
+          status: res.status,
+          url: safeUrl,
+          ms: Date.now() - started,
+          body,
+          nonJson: body === null,
+          bodyText: body === null ? redact(text, accountKey).slice(0, BODY_TEXT_LIMIT) : null,
+          message: errorMessageOf(body),
+          networkError: false,
+        };
+      } catch (err) {
+        return {
+          ok: false,
+          // 0 rather than null, so a caller comparing statuses cannot mistake a
+          // connection failure for an upstream answer it simply did not read.
+          status: 0,
+          url: safeUrl,
+          ms: Date.now() - started,
+          body: null,
+          nonJson: false,
+          bodyText: null,
+          message: redact(err?.message ?? err?.code ?? 'unknown error', accountKey),
+          networkError: true,
+        };
+      }
+    });
+  };
+
+  return {
+    /** @param {string} path @param {Record<string, string|number|undefined>} [params] */
+    get: (path, params = {}) => send({ method: 'GET', path, params }),
+
+    /** A create or a booking. JSON body; Clubworx answers 200, not 201. */
+    post: (path, payload, params = {}) => send({ method: 'POST', path, params, json: payload }),
+
+    /** Form-encoded, and `contact_key` is not optional. */
+    del: (path, form, params = {}) => send({ method: 'DELETE', path, params, form }),
+  };
+}

--- a/cloudflare-clubworx/src/errors.js
+++ b/cloudflare-clubworx/src/errors.js
@@ -1,0 +1,50 @@
+/**
+ * The one thing this system is allowed to read out of a Clubworx response body.
+ *
+ * Promoted here from `probes/lib/report.mjs` for staff-site#66. The probes wrote
+ * it against measured Clubworx behaviour and it keeps its test file; the Worker
+ * needs exactly the same extraction and re-deriving it would re-derive its bugs.
+ *
+ * The Worker stores and logs nothing from a body (§6, D10). This function is the
+ * bounded exception, and it is bounded on purpose: it reads only the
+ * `error`-shaped fields — the server's complaint about **our own request** —
+ * never the record fields, which is where student names and dates of birth are.
+ */
+
+/**
+ * The error message out of a rejected write.
+ *
+ * A deliberate, bounded exception to *never record a row of production data*.
+ * The rule exists because responses are drawn from a 60,000-person database —
+ * but this reads the server's complaint about **the caller's own request**,
+ * which is the only place the reason for a rejection is written down.
+ * Discarding it leaves a refusal as "HTTP 400" and no answer to what a booking
+ * actually requires.
+ *
+ * Bounded three ways: only the `error`-shaped fields are read, never the whole
+ * body; the result is truncated; and the caller redacts before it is printed or
+ * written.
+ *
+ * @param {unknown} body
+ * @param {{limit?: number}} [opts]
+ * @returns {string|null}
+ */
+export function errorMessageOf(body, { limit = 300 } = {}) {
+  if (body === null || typeof body !== 'object') return null;
+
+  const raw = body.error ?? body.errors ?? body.message ?? null;
+  if (raw === null || raw === undefined) return null;
+
+  // Rails-shaped APIs answer with either a string, a list, or field → messages.
+  const text = Array.isArray(raw)
+    ? raw.map(String).join('; ')
+    : typeof raw === 'object'
+      ? Object.entries(raw)
+          .map(([field, messages]) => `${field}: ${[].concat(messages).map(String).join(', ')}`)
+          .join('; ')
+      : String(raw);
+
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  return trimmed.length > limit ? `${trimmed.slice(0, limit)}…` : trimmed;
+}

--- a/cloudflare-clubworx/src/errors.js
+++ b/cloudflare-clubworx/src/errors.js
@@ -5,25 +5,22 @@
  * it against measured Clubworx behaviour and it keeps its test file; the Worker
  * needs exactly the same extraction and re-deriving it would re-derive its bugs.
  *
- * The Worker stores and logs nothing from a body (§6, D10). This function is the
- * bounded exception, and it is bounded on purpose: it reads only the
+ * The Worker stores and logs nothing from a body (§6, D10), and the probes never
+ * record a row of production data — both rules exist because what comes back is
+ * drawn from a 60,000-person database. This function is the one bounded
+ * exception to both, and it is bounded on purpose: it reads only the
  * `error`-shaped fields — the server's complaint about **our own request** —
  * never the record fields, which is where student names and dates of birth are.
+ * Discarding it would leave a refusal as "HTTP 400" with no answer to what a
+ * booking actually requires, which is the question #50 existed to settle.
  */
 
 /**
  * The error message out of a rejected write.
  *
- * A deliberate, bounded exception to *never record a row of production data*.
- * The rule exists because responses are drawn from a 60,000-person database —
- * but this reads the server's complaint about **the caller's own request**,
- * which is the only place the reason for a rejection is written down.
- * Discarding it leaves a refusal as "HTTP 400" and no answer to what a booking
- * actually requires.
- *
- * Bounded three ways: only the `error`-shaped fields are read, never the whole
- * body; the result is truncated; and the caller redacts before it is printed or
- * written.
+ * Bounded three ways, per the header above: only the `error`-shaped fields are
+ * read, never the whole body; the result is truncated; and the caller redacts
+ * before it is printed or written.
  *
  * @param {unknown} body
  * @param {{limit?: number}} [opts]

--- a/cloudflare-clubworx/src/index.js
+++ b/cloudflare-clubworx/src/index.js
@@ -1,0 +1,147 @@
+/**
+ * uj-clubworx-api — the staff site's only path to the Clubworx API.
+ *
+ * staff-site#66. Part of the school group booking tool (#46); the design is
+ * `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §6.
+ *
+ * **Why this Worker exists at all.** Clubworx issues exactly one key per gym
+ * (#47) — the same key reads and writes UJ's whole ~60,000-profile contact
+ * database, and is shared with the HVT Worker and every n8n workflow. staff-site
+ * is a PUBLIC repo whose `pages.yml` rsyncs the entire tree into the published
+ * site, so a key in the page would be a key on the open internet, permanently,
+ * in git history. The browser talks to this Worker; only this Worker talks to
+ * Clubworx.
+ *
+ * **This Worker stores nothing.** No student name, no date of birth, in any
+ * Cloudflare store, KV, D1, or log (§6, D10). It is a transit, not a database.
+ * There is no run store and no persistence of any kind, and the log line below
+ * records the route, the status, the operator and the timing — never a body and
+ * never the query string, because `?last_name=&dob=` is where a student's name
+ * and date of birth travel. That rule is one debugging `console.log` away from
+ * being untrue, which is why `test/worker.test.js` asserts it directly.
+ *
+ * **Auth is Cloudflare Access, verified rather than assumed.** See `access.js`.
+ *
+ * Routes are added by later tickets (#67, #68, #70). This one ships the
+ * skeleton, the gate, the pacer and the request layer — deliberately, because
+ * `main` is production on this repo and a page calling a route that does not
+ * exist is a broken tool on the live hub (§17).
+ */
+
+import { createAccessVerifier } from './access.js';
+
+export const PREFIX = '/api/clubworx';
+
+const WORKER = 'uj-clubworx-api';
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      // Every answer is scoped to one authenticated operator. Nothing in front
+      // of this Worker should ever hold one and hand it to somebody else.
+      'Cache-Control': 'no-store',
+    },
+  });
+
+/**
+ * One verifier per isolate, so the JWKS cache inside it survives between
+ * requests instead of being refetched on each one.
+ */
+let cachedVerifier = null;
+let cachedVerifierFor = null;
+
+function defaultMakeVerifier(env) {
+  const signature = `${env.ACCESS_TEAM_DOMAIN}|${env.ACCESS_AUD}`;
+  if (!cachedVerifier || cachedVerifierFor !== signature) {
+    cachedVerifier = createAccessVerifier({
+      teamDomain: env.ACCESS_TEAM_DOMAIN,
+      aud: env.ACCESS_AUD,
+    });
+    cachedVerifierFor = signature;
+  }
+  return cachedVerifier;
+}
+
+/**
+ * Build the request handler. The seams exist so the log line and the gate can be
+ * asserted directly — both are things that fail silently in production.
+ *
+ * @param {object} [deps]
+ * @param {(env: object) => (token: string|null) => Promise<object>} [deps.makeVerifier]
+ * @param {(line: string) => void} [deps.log]
+ */
+export function createHandler({ makeVerifier = defaultMakeVerifier, log = console.log } = {}) {
+  return async function handle(request, env) {
+    const url = new URL(request.url);
+
+    // `ujstaff.happyk.au/api/*` also routes to the roster Worker and
+    // `/api/payments/*` to the voucher proxy. Anything that reaches this Worker
+    // outside its own prefix is not its to answer, or to log.
+    if (url.pathname !== PREFIX && !url.pathname.startsWith(`${PREFIX}/`)) {
+      return json({ error: 'not found' }, 404);
+    }
+
+    const started = Date.now();
+    // Only ever the path. Never url.search — see the header note.
+    const route = url.pathname;
+    const method = request.method;
+
+    const done = (response, { email = null, reason = null } = {}) => {
+      log(
+        JSON.stringify({
+          worker: WORKER,
+          route,
+          method,
+          status: response.status,
+          email,
+          ms: Date.now() - started,
+          ...(reason ? { reason } : {}),
+        }),
+      );
+      return response;
+    };
+
+    // The gate runs before routing. A caller who cannot get through it should
+    // not be able to learn which routes exist by watching 404s and 401s differ.
+    const verify = makeVerifier(env);
+    const auth = await verify(request.headers.get('Cf-Access-Jwt-Assertion'));
+    if (!auth.ok) {
+      // The reason goes to the log, not to the caller: told apart, "expired"
+      // and "wrong-audience" describe the gate to whoever is rattling it.
+      return done(json({ error: 'unauthorized' }, 401), { reason: auth.reason });
+    }
+
+    const email = auth.email;
+    const path = url.pathname.slice(PREFIX.length) || '/';
+
+    if (path === '/health') {
+      if (method !== 'GET') return done(json({ error: 'method not allowed' }, 405), { email });
+      return done(
+        json({
+          ok: true,
+          worker: WORKER,
+          // Echoing the operator back is what makes a post-deploy check prove
+          // the gate actually ran, rather than proving the Worker is awake.
+          email,
+          // Whether the secret was ever put. Never the secret.
+          clubworxKey: env.CLUBWORX_ACCOUNT_KEY ? 'configured' : 'missing',
+          time: new Date().toISOString(),
+        }),
+        { email },
+      );
+    }
+
+    // events, plan, schools, contacts, student and unbook arrive with #67/#68/#70.
+    return done(json({ error: 'not found' }, 404), { email });
+  };
+}
+
+const handle = createHandler();
+
+export default {
+  async fetch(request, env) {
+    return handle(request, env);
+  },
+};

--- a/cloudflare-clubworx/src/pace.js
+++ b/cloudflare-clubworx/src/pace.js
@@ -96,3 +96,15 @@ export function createPacer({
   run.calls = 0;
   return run;
 }
+
+/**
+ * The pacer every Clubworx client uses unless it is handed another one.
+ *
+ * Module scope, deliberately. The account key comes from `env`, so the natural
+ * way to wire a client is to build one per request — and a pacer created inside
+ * that constructor would reset with it, leaving "one in flight" true only
+ * within a single request while the gym-wide ceiling it is protecting is not
+ * per-request at all. One pacer per isolate is the smallest thing that is
+ * actually the property being claimed.
+ */
+export const sharedPacer = createPacer();

--- a/cloudflare-clubworx/src/pace.js
+++ b/cloudflare-clubworx/src/pace.js
@@ -1,0 +1,98 @@
+/**
+ * The Clubworx pace: 75 requests per minute, one in flight.
+ *
+ * Measured, not guessed. staff-site#51 spent requests faster than ~3/s and got
+ * roughly **50** through before the API answered `429` for about **18 seconds**.
+ * 75/min ran clean; 120/min did not. See `probes/51-events-and-burst.md`.
+ *
+ * Two properties of Clubworx make this a design constant rather than an
+ * adaptive one, and both are load-bearing:
+ *
+ *   - **No rate-limit headers exist.** Not `Retry-After`, not `X-RateLimit-*`,
+ *     not at any point — confirmed live, and confirmed again *while being
+ *     throttled*. There is nothing to read back, so a client cannot discover it
+ *     is approaching a ceiling. It can only hit one.
+ *   - **The allowance is gym-wide.** One key per gym (#47), so the roster Worker
+ *     and n8n spend from the same budget, unseen. Being under the ceiling alone
+ *     is not the same as being under it.
+ *
+ * **Concurrency is the wrong lever.** The ceiling is on requests, not on
+ * connections, so running two at once buys nothing and reaches the wall sooner.
+ * This module therefore serialises rather than pooling: one in flight, and a
+ * minimum gap between the moments two calls *start*.
+ *
+ * Scope, honestly: a pacer instance paces the calls made through it. The whole
+ * pipeline is strictly serial by design — the browser sends one student at a
+ * time and waits, and the Worker paces its own calls inside that — so the
+ * aggregate rate stays under the ceiling without a global governor (§6). This
+ * is not a distributed rate limiter and does not pretend to be one.
+ */
+
+/** The rate #51 measured as running clean. */
+export const MAX_REQUESTS_PER_MINUTE = 75;
+
+/**
+ * Derived, so the two can never disagree. A hand-written 800 beside a changed
+ * rate is the standard way a pacing constant goes quietly wrong.
+ */
+export const MIN_INTERVAL_MS = Math.ceil(60_000 / MAX_REQUESTS_PER_MINUTE);
+
+const defaultSleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Build a pacer: a function that runs tasks one at a time, no sooner than
+ * `minIntervalMs` after the previous one started.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.minIntervalMs] Minimum gap between two starts. May be
+ *   slower than the measured pace, never faster.
+ * @param {() => number} [opts.now]
+ * @param {(ms: number) => Promise<void>} [opts.sleep]
+ * @returns {(<T>(task: () => Promise<T>) => Promise<T>) & { calls: number }}
+ */
+export function createPacer({
+  minIntervalMs = MIN_INTERVAL_MS,
+  now = Date.now,
+  sleep = defaultSleep,
+} = {}) {
+  if (minIntervalMs < MIN_INTERVAL_MS) {
+    throw new Error(
+      `createPacer: ${minIntervalMs}ms is faster than the measured pace; ` +
+        `${MIN_INTERVAL_MS}ms or slower only`,
+    );
+  }
+
+  // The queue is a promise chain rather than an array, so ordering is the
+  // language's problem rather than this module's.
+  let tail = Promise.resolve();
+  let lastStartedAt = null;
+
+  const run = task => {
+    const queued = tail.then(async () => {
+      if (lastStartedAt !== null) {
+        // A call that took longer than the interval has already spent it. The
+        // ceiling is on how often a request *starts*, so waiting again here
+        // would halve the achievable rate for nothing.
+        const wait = lastStartedAt + minIntervalMs - now();
+        if (wait > 0) await sleep(wait);
+      }
+      lastStartedAt = now();
+      run.calls += 1;
+      return task();
+    });
+
+    // The chain continues on a settled promise, not a rejected one. Without
+    // this, one 500 from Clubworx mid-run strands every remaining student
+    // behind an unhandled rejection — the caller still sees the failure,
+    // because `queued` is what is returned.
+    tail = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return queued;
+  };
+
+  run.calls = 0;
+  return run;
+}

--- a/cloudflare-clubworx/src/request.js
+++ b/cloudflare-clubworx/src/request.js
@@ -1,10 +1,16 @@
 /**
- * Request shaping and secret redaction for read-only Clubworx probes.
+ * Request shaping and secret redaction for every Clubworx call this repo makes.
  *
- * staff-site is a PUBLIC repo and Clubworx has no sandbox — every probe runs
- * against the live gym database. Both functions here exist so that neither the
- * URL nor anything printed about it can carry the account key into a terminal
- * log, a pasted issue comment, or a committed findings document.
+ * Written for the read-only probes; promoted here from `probes/lib/request.mjs`
+ * by staff-site#66 so the Worker uses the same two functions rather than a
+ * second copy of them. The probes now import it from here — there is one
+ * definition of how a Clubworx URL is built and one of how the key is hidden.
+ *
+ * staff-site is a PUBLIC repo and Clubworx has no sandbox — every call, probe or
+ * Worker, runs against the live gym database. Both functions here exist so that
+ * neither the URL nor anything printed about it can carry the account key into a
+ * terminal log, a Worker log line, a pasted issue comment, or a committed
+ * findings document.
  */
 
 export const CLUBWORX_BASE = 'https://app.clubworx.com/api/v2';

--- a/cloudflare-clubworx/test/access.test.js
+++ b/cloudflare-clubworx/test/access.test.js
@@ -1,0 +1,355 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createAccessVerifier, certsUrl } from '../src/access.js';
+
+// The Worker's only gate. staff-site#66 is explicit that a present-but-invalid
+// JWT is a rejection and never a fallback, so these tests sign real RS256
+// tokens with a real key pair and serve a real JWKS from a stubbed fetch.
+//
+// Asserting against a fake verifier would prove nothing: the failure mode this
+// guards against is a verifier that returns ok for a token it never checked,
+// and only a genuinely forged signature can catch that.
+
+const TEAM_DOMAIN = 'happyk.cloudflareaccess.com';
+const AUD = '65dd83df311d06ffbc7db624cc4e88e3c4d216e716630cfaf60d6d09b7f0e939';
+const ISSUER = `https://${TEAM_DOMAIN}`;
+const NOW_MS = 1_755_000_000_000; // fixed, so expiry tests do not rot
+const NOW_S = Math.floor(NOW_MS / 1000);
+
+const b64url = bytes =>
+  btoa(String.fromCharCode(...new Uint8Array(bytes)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+const b64urlJson = obj => b64url(new TextEncoder().encode(JSON.stringify(obj)));
+
+let signingKey;
+let otherKey;
+let jwks;
+
+/** Sign a JWT with one of the test key pairs. */
+async function sign(payload, { kid = 'kid-1', alg = 'RS256', key = signingKey } = {}) {
+  const head = b64urlJson({ alg, kid, typ: 'JWT' });
+  const body = b64urlJson(payload);
+  const signed = `${head}.${body}`;
+  const sig = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key.privateKey,
+    new TextEncoder().encode(signed),
+  );
+  return `${signed}.${b64url(sig)}`;
+}
+
+/** The claims Cloudflare Access actually puts in the assertion. */
+const validClaims = (over = {}) => ({
+  aud: [AUD],
+  email: 'staff@urbanjungleirc.com',
+  exp: NOW_S + 3600,
+  iat: NOW_S - 10,
+  nbf: NOW_S - 10,
+  iss: ISSUER,
+  sub: 'sub-abc',
+  ...over,
+});
+
+/** A fetch stub that serves the JWKS and counts how often it was asked. */
+function jwksFetch(keys = jwks, { status = 200, body = null } = {}) {
+  const impl = async url => {
+    impl.calls.push(String(url));
+    if (status !== 200) return new Response(body ?? 'nope', { status });
+    return new Response(JSON.stringify({ keys }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  impl.calls = [];
+  return impl;
+}
+
+const verifierWith = (fetchImpl, over = {}) =>
+  createAccessVerifier({
+    teamDomain: TEAM_DOMAIN,
+    aud: AUD,
+    fetchImpl,
+    now: () => NOW_MS,
+    ...over,
+  });
+
+beforeAll(async () => {
+  const params = {
+    name: 'RSASSA-PKCS1-v1_5',
+    modulusLength: 2048,
+    publicExponent: new Uint8Array([1, 0, 1]),
+    hash: 'SHA-256',
+  };
+  signingKey = await crypto.subtle.generateKey(params, true, ['sign', 'verify']);
+  otherKey = await crypto.subtle.generateKey(params, true, ['sign', 'verify']);
+
+  const pub = await crypto.subtle.exportKey('jwk', signingKey.publicKey);
+  jwks = [{ ...pub, kid: 'kid-1', alg: 'RS256', use: 'sig' }];
+});
+
+describe('certsUrl', () => {
+  it('points at the team domain, where Access publishes the signing keys', () => {
+    expect(certsUrl(TEAM_DOMAIN)).toBe(`https://${TEAM_DOMAIN}/cdn-cgi/access/certs`);
+  });
+
+  it('tolerates a team domain written with its scheme', () => {
+    expect(certsUrl(`https://${TEAM_DOMAIN}/`)).toBe(`https://${TEAM_DOMAIN}/cdn-cgi/access/certs`);
+  });
+});
+
+describe('a token that is genuinely valid', () => {
+  it('is accepted, and hands back the operator email', async () => {
+    const verify = verifierWith(jwksFetch());
+    const result = await verify(await sign(validClaims()));
+
+    expect(result.ok).toBe(true);
+    expect(result.email).toBe('staff@urbanjungleirc.com');
+    expect(result.sub).toBe('sub-abc');
+  });
+
+  it('accepts a string aud as well as the array form', async () => {
+    const verify = verifierWith(jwksFetch());
+    const result = await verify(await sign(validClaims({ aud: AUD })));
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts an aud array carrying other applications alongside ours', async () => {
+    const verify = verifierWith(jwksFetch());
+    const result = await verify(await sign(validClaims({ aud: ['some-other-app', AUD] })));
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('fail closed', () => {
+  it('rejects a missing token — presence is what is being tested, not trusted', async () => {
+    const verify = verifierWith(jwksFetch());
+    expect((await verify(null)).ok).toBe(false);
+    expect((await verify('')).reason).toBe('no-token');
+  });
+
+  it('rejects something that is not three dot-separated parts', async () => {
+    const verify = verifierWith(jwksFetch());
+    expect((await verify('not-a-jwt')).reason).toBe('malformed');
+    expect((await verify('a.b')).reason).toBe('malformed');
+    expect((await verify('a.b.c.d')).reason).toBe('malformed');
+  });
+
+  it('rejects a token whose payload is not decodable JSON', async () => {
+    const verify = verifierWith(jwksFetch());
+    expect((await verify('eyJhbGciOiJSUzI1NiJ9.@@@@.sig')).reason).toBe('malformed');
+  });
+
+  it('rejects a forged signature — the whole point of verifying', async () => {
+    const verify = verifierWith(jwksFetch());
+    const token = await sign(validClaims());
+    // Same header and claims, signature from a different key. A verifier that
+    // only decodes would call this valid.
+    const forged = `${token.split('.').slice(0, 2).join('.')}.${
+      (await sign(validClaims(), { key: otherKey })).split('.')[2]
+    }`;
+
+    expect((await verify(forged)).reason).toBe('bad-signature');
+  });
+
+  it('rejects a token whose claims were edited after signing', async () => {
+    const verify = verifierWith(jwksFetch());
+    const [head, , sig] = (await sign(validClaims())).split('.');
+    const tampered = `${head}.${b64urlJson(validClaims({ email: 'attacker@example.com' }))}.${sig}`;
+
+    expect((await verify(tampered)).reason).toBe('bad-signature');
+  });
+
+  it('rejects alg:none, the classic bypass', async () => {
+    const verify = verifierWith(jwksFetch());
+    const token = `${b64urlJson({ alg: 'none', kid: 'kid-1', typ: 'JWT' })}.${b64urlJson(
+      validClaims(),
+    )}.`;
+
+    expect((await verify(token)).reason).toBe('unsupported-alg');
+  });
+
+  it('rejects an HS256 token, which would let the public key be used as a secret', async () => {
+    const verify = verifierWith(jwksFetch());
+    const token = await sign(validClaims(), { alg: 'HS256' });
+
+    expect((await verify(token)).reason).toBe('unsupported-alg');
+  });
+
+  it('rejects a kid that is in no published key set', async () => {
+    const verify = verifierWith(jwksFetch());
+    expect((await verify(await sign(validClaims(), { kid: 'kid-unknown' }))).reason).toBe(
+      'unknown-kid',
+    );
+  });
+
+  it('rejects an expired token', async () => {
+    const verify = verifierWith(jwksFetch());
+    expect((await verify(await sign(validClaims({ exp: NOW_S - 3600 })))).reason).toBe('expired');
+  });
+
+  it('rejects a token that is not valid yet', async () => {
+    const verify = verifierWith(jwksFetch());
+    expect((await verify(await sign(validClaims({ nbf: NOW_S + 3600 })))).reason).toBe(
+      'not-yet-valid',
+    );
+  });
+
+  it('rejects a token with no expiry at all rather than treating it as eternal', async () => {
+    const verify = verifierWith(jwksFetch());
+    const claims = validClaims();
+    delete claims.exp;
+
+    expect((await verify(await sign(claims))).reason).toBe('expired');
+  });
+
+  it('rejects a token issued by a different Access team', async () => {
+    const verify = verifierWith(jwksFetch());
+    expect(
+      (await verify(await sign(validClaims({ iss: 'https://someone-else.cloudflareaccess.com' }))))
+        .reason,
+    ).toBe('wrong-issuer');
+  });
+
+  it('rejects a token minted for a different application on the same team', async () => {
+    // Every Access app on happyk.au is signed by the same keys. Without the aud
+    // check, a token for the n8n app would open this Worker.
+    const verify = verifierWith(jwksFetch());
+    expect((await verify(await sign(validClaims({ aud: ['a-different-app'] })))).reason).toBe(
+      'wrong-audience',
+    );
+  });
+
+  it('rejects a validly signed token carrying no email', async () => {
+    // Every write is logged against the operator. A token with nobody attached
+    // has nothing to log, so it is not good enough to act on.
+    const verify = verifierWith(jwksFetch());
+    const claims = validClaims();
+    delete claims.email;
+
+    expect((await verify(await sign(claims))).reason).toBe('no-email');
+  });
+
+  it('rejects everything when the audience is not configured', async () => {
+    // An unset ACCESS_AUD must not degrade into "any token from this team".
+    const verify = verifierWith(jwksFetch(), { aud: '' });
+    expect((await verify(await sign(validClaims()))).reason).toBe('not-configured');
+  });
+
+  it('rejects everything when the team domain is not configured', async () => {
+    const verify = verifierWith(jwksFetch(), { teamDomain: '' });
+    expect((await verify(await sign(validClaims()))).reason).toBe('not-configured');
+  });
+
+  it('rejects when the key set cannot be fetched, rather than skipping the check', async () => {
+    const verify = verifierWith(jwksFetch(jwks, { status: 503 }));
+    expect((await verify(await sign(validClaims()))).reason).toBe('jwks-unavailable');
+  });
+
+  it('rejects when the key set fetch throws', async () => {
+    const verify = verifierWith(async () => {
+      throw new Error('dns');
+    });
+    expect((await verify(await sign(validClaims()))).reason).toBe('jwks-unavailable');
+  });
+
+  it('tolerates a small clock skew rather than rejecting on a second', async () => {
+    // Access and this Worker do not share a clock. A token that expired one
+    // second ago is a clock difference, not an attack.
+    const verify = verifierWith(jwksFetch());
+    expect((await verify(await sign(validClaims({ exp: NOW_S - 1 })))).ok).toBe(true);
+  });
+
+  it('never reports an email alongside a rejection', async () => {
+    const verify = verifierWith(jwksFetch());
+    const result = await verify(await sign(validClaims({ exp: NOW_S - 3600 })));
+
+    expect(result.ok).toBe(false);
+    expect(result.email).toBeNull();
+  });
+});
+
+describe('the key set is cached, but not forever', () => {
+  it('fetches once for repeated verifications', async () => {
+    const fetchImpl = jwksFetch();
+    const verify = verifierWith(fetchImpl);
+
+    await verify(await sign(validClaims()));
+    await verify(await sign(validClaims()));
+    await verify(await sign(validClaims()));
+
+    expect(fetchImpl.calls).toHaveLength(1);
+    expect(fetchImpl.calls[0]).toBe(certsUrl(TEAM_DOMAIN));
+  });
+
+  it('refetches after the cache expires, so a rotated key is picked up', async () => {
+    const fetchImpl = jwksFetch();
+    let clock = NOW_MS;
+    const verify = createAccessVerifier({
+      teamDomain: TEAM_DOMAIN,
+      aud: AUD,
+      fetchImpl,
+      now: () => clock,
+      cacheTtlMs: 60_000,
+    });
+
+    await verify(await sign(validClaims()));
+    clock += 61_000;
+    await verify(await sign(validClaims({ exp: Math.floor(clock / 1000) + 3600 })));
+
+    expect(fetchImpl.calls).toHaveLength(2);
+  });
+
+  it('refetches once on an unknown kid — a rotation mid-cache, not a forgery', async () => {
+    const fetchImpl = jwksFetch();
+    let clock = NOW_MS;
+    const verify = createAccessVerifier({
+      teamDomain: TEAM_DOMAIN,
+      aud: AUD,
+      fetchImpl,
+      now: () => clock,
+    });
+
+    await verify(await sign(validClaims())); // warms the cache
+    clock += 10 * 60 * 1000; // past the refetch floor, inside the cache TTL
+    await verify(await sign(validClaims(), { kid: 'kid-unknown' }));
+
+    expect(fetchImpl.calls).toHaveLength(2);
+  });
+
+  it('does not refetch on every unknown kid, or a bad token becomes an outbound flood', async () => {
+    // Five garbage kids in quick succession must cost one outbound fetch, not
+    // five. Otherwise anyone who can reach the Worker can make it hammer
+    // Cloudflare on their behalf, using tokens it is about to reject anyway.
+    const fetchImpl = jwksFetch();
+    let clock = NOW_MS;
+    const verify = createAccessVerifier({
+      teamDomain: TEAM_DOMAIN,
+      aud: AUD,
+      fetchImpl,
+      now: () => clock,
+    });
+
+    await verify(await sign(validClaims()));
+    clock += 10 * 60 * 1000;
+    for (let i = 0; i < 5; i += 1) {
+      await verify(await sign(validClaims(), { kid: `kid-unknown-${i}` }));
+    }
+
+    expect(fetchImpl.calls).toHaveLength(2);
+  });
+
+  it('rejects an unknown kid without refetching while the floor holds', async () => {
+    const fetchImpl = jwksFetch();
+    const verify = verifierWith(fetchImpl);
+
+    await verify(await sign(validClaims()));
+    const result = await verify(await sign(validClaims(), { kid: 'kid-unknown' }));
+
+    expect(result.reason).toBe('unknown-kid');
+    expect(fetchImpl.calls).toHaveLength(1);
+  });
+});

--- a/cloudflare-clubworx/test/access.test.js
+++ b/cloudflare-clubworx/test/access.test.js
@@ -249,6 +249,19 @@ describe('fail closed', () => {
     expect((await verify(await sign(validClaims()))).reason).toBe('jwks-unavailable');
   });
 
+  it('bounds the key-set fetch, so a hung certs endpoint cannot stall every request', async () => {
+    let sawSignal = null;
+    const fetchImpl = async (url, init) => {
+      sawSignal = init?.signal ?? null;
+      return new Response(JSON.stringify({ keys: jwks }), { status: 200 });
+    };
+    const verify = verifierWith(fetchImpl);
+
+    await verify(await sign(validClaims()));
+
+    expect(sawSignal).toBeInstanceOf(AbortSignal);
+  });
+
   it('rejects when the key set fetch throws', async () => {
     const verify = verifierWith(async () => {
       throw new Error('dns');

--- a/cloudflare-clubworx/test/clubworx.test.js
+++ b/cloudflare-clubworx/test/clubworx.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createClubworxClient } from '../src/clubworx.js';
-import { createPacer } from '../src/pace.js';
+import { createPacer, sharedPacer } from '../src/pace.js';
 
 // The Worker's only path to Clubworx. Everything asserted here is measured
 // behaviour from probes/ — the JSON POST, the form-encoded DELETE, the key in
@@ -128,9 +128,10 @@ describe('DELETE — measured as form-encoded, and it needs contact_key', () => 
 });
 
 describe('the key never leaves in anything handed back', () => {
-  it('redacts the key out of a network error message', async () => {
-    // node interpolates the URL into connection errors, and the URL carries the
-    // key. An unredacted throw is how a gym key reaches a log line.
+  it('strips the key out of a network error message', async () => {
+    // Both runtimes interpolate the failing URL into connection errors, and
+    // that URL carries the key. An unscrubbed throw is how a gym key reaches a
+    // log line.
     const client = clientWith(async () => {
       throw new Error(`connect ECONNREFUSED for https://app.clubworx.com/api/v2/events?account_key=${KEY}`);
     });
@@ -139,6 +140,21 @@ describe('the key never leaves in anything handed back', () => {
 
     expect(res.ok).toBe(false);
     expect(res.networkError).toBe(true);
+    expect(res.message).not.toContain(KEY);
+    // The whole query goes, not just the key inside it — the query is also
+    // where a student's surname would be.
+    expect(res.message).toBe('connect ECONNREFUSED for https://app.clubworx.com/api/v2/events');
+  });
+
+  it('still redacts a key quoted outside a url', async () => {
+    // Stripping the query is not a substitute for redaction: an error that
+    // names the key on its own has no query to strip.
+    const client = clientWith(async () => {
+      throw new Error(`bad credentials: ${KEY}`);
+    });
+
+    const res = await client.get('events');
+
     expect(res.message).not.toContain(KEY);
     expect(res.message).toContain('<CLUBWORX_ACCOUNT_KEY>');
   });
@@ -156,12 +172,35 @@ describe('the key never leaves in anything handed back', () => {
     expect(res.bodyText).not.toContain(KEY);
   });
 
-  it('reports the url it called with the key removed', async () => {
+  it('reports the endpoint it called, with the key removed', async () => {
     const client = clientWith(recorder(() => json({})));
     const res = await client.get('events');
 
-    expect(res.url).toContain('app.clubworx.com/api/v2/events');
+    expect(res.url).toBe('https://app.clubworx.com/api/v2/events');
     expect(res.url).not.toContain(KEY);
+  });
+
+  it('never hands back the query string, where a student surname travels', async () => {
+    // §6/D10: no student name or DOB in any log. The obvious use of a `url`
+    // field is a log line, and `GET /contacts?last_name=&dob=` is a route this
+    // design calls for — so the query must not survive this layer. redact()
+    // removes the account key and nothing else; it would not catch this.
+    const client = clientWith(recorder(() => json({})));
+    const res = await client.get('contacts', { last_name: 'Nowak', dob: '2009-03-02' });
+
+    expect(JSON.stringify(res)).not.toContain('Nowak');
+    expect(JSON.stringify(res)).not.toContain('2009-03-02');
+    expect(res.url).toBe('https://app.clubworx.com/api/v2/contacts');
+  });
+
+  it('keeps the query out of a network error message too', async () => {
+    const client = clientWith(async () => {
+      throw new Error('connect ECONNREFUSED https://app.clubworx.com/api/v2/contacts?last_name=Nowak');
+    });
+
+    const res = await client.get('contacts', { last_name: 'Nowak' });
+
+    expect(res.message).not.toContain('Nowak');
   });
 
   it('bounds a non-JSON body rather than carrying a whole error page around', async () => {
@@ -173,6 +212,20 @@ describe('the key never leaves in anything handed back', () => {
 });
 
 describe('pacing', () => {
+  it('defaults to one pacer for the whole isolate, not a fresh one per client', async () => {
+    // The account key comes from env, so the natural wiring downstream is to
+    // build a client per request. A per-client pacer would then mean "one in
+    // flight" held only within a single request — and the ceiling is gym-wide.
+    const before = sharedPacer.calls;
+    const a = createClubworxClient({ accountKey: KEY, fetchImpl: recorder(() => json({})) });
+    const b = createClubworxClient({ accountKey: KEY, fetchImpl: recorder(() => json({})) });
+
+    await a.get('events');
+    await b.get('events');
+
+    expect(sharedPacer.calls).toBe(before + 2);
+  });
+
   it('sends every call through the pacer', async () => {
     const pacer = instantPacer();
     const client = clientWith(recorder(() => json({})), { pacer });

--- a/cloudflare-clubworx/test/clubworx.test.js
+++ b/cloudflare-clubworx/test/clubworx.test.js
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import { createClubworxClient } from '../src/clubworx.js';
+import { createPacer } from '../src/pace.js';
+
+// The Worker's only path to Clubworx. Everything asserted here is measured
+// behaviour from probes/ — the JSON POST, the form-encoded DELETE, the key in
+// the query string — plus the two rules the Worker adds on top: it paces, and
+// the key never leaves in anything it hands back.
+
+const KEY = 'super-secret-gym-key-1234';
+
+/** A fetch stub recording exactly what was sent. */
+function recorder(responder) {
+  const impl = async (url, init) => {
+    impl.sent.push({ url: String(url), ...init });
+    return responder(String(url), init);
+  };
+  impl.sent = [];
+  return impl;
+}
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+/** No waiting in tests — the pacer's own schedule is pinned in pace.test.js. */
+const instantPacer = () => createPacer({ now: () => 0, sleep: async () => {} });
+
+const clientWith = (fetchImpl, over = {}) =>
+  createClubworxClient({ accountKey: KEY, fetchImpl, pacer: instantPacer(), ...over });
+
+describe('construction', () => {
+  it('refuses to build without an account key rather than calling anonymously', () => {
+    expect(() => createClubworxClient({ accountKey: '', fetchImpl: recorder(() => json({})) })).toThrow(
+      /account key/i,
+    );
+  });
+});
+
+describe('GET', () => {
+  it('sends the key as a query parameter and asks for JSON', async () => {
+    const fetchImpl = recorder(() => json({ events: [] }));
+    const client = clientWith(fetchImpl);
+
+    await client.get('events', { page_size: 100 });
+
+    const sent = fetchImpl.sent[0];
+    expect(sent.url).toContain('https://app.clubworx.com/api/v2/events?');
+    expect(sent.url).toContain(`account_key=${KEY}`);
+    expect(sent.url).toContain('page_size=100');
+    expect(sent.method).toBe('GET');
+    expect(sent.headers.Accept).toBe('application/json');
+  });
+
+  it('hands back the parsed body and the status', async () => {
+    const client = clientWith(recorder(() => json({ contacts: [{ id: 1 }] })));
+    const res = await client.get('contacts');
+
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ contacts: [{ id: 1 }] });
+    expect(res.message).toBeNull();
+  });
+
+  it('keeps an omitted parameter omitted and a blank one blank', async () => {
+    // #51 turns on telling those two apart for contact_key, so the distinction
+    // must survive this layer rather than being normalised away.
+    const fetchImpl = recorder(() => json({}));
+    const client = clientWith(fetchImpl);
+
+    await client.get('events', { contact_key: '', page: undefined });
+
+    expect(fetchImpl.sent[0].url).toContain('contact_key=');
+    expect(fetchImpl.sent[0].url).not.toContain('page=');
+  });
+});
+
+describe('POST — measured as a JSON body with the key still in the query', () => {
+  it('sends JSON and reports a Clubworx refusal in words', async () => {
+    const fetchImpl = recorder(() => json({ error: 'Contact has no active membership' }, 400));
+    const client = clientWith(fetchImpl);
+
+    const res = await client.post('bookings', { contact_key: 'ck-1', event_id: 7 });
+
+    const sent = fetchImpl.sent[0];
+    expect(sent.method).toBe('POST');
+    expect(sent.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(sent.body)).toEqual({ contact_key: 'ck-1', event_id: 7 });
+    expect(sent.url).toContain(`account_key=${KEY}`);
+
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(400);
+    expect(res.message).toBe('Contact has no active membership');
+  });
+
+  it('treats 200 as success, since Clubworx answers 200 and not 201 on create', async () => {
+    const client = clientWith(recorder(() => json({ contact_key: 'ck-new' }, 200)));
+    expect((await client.post('members', {})).ok).toBe(true);
+  });
+
+  it('never puts the account key in the body', async () => {
+    const fetchImpl = recorder(() => json({}));
+    const client = clientWith(fetchImpl);
+
+    await client.post('members', { first_name: 'Ztest' });
+
+    expect(fetchImpl.sent[0].body).not.toContain(KEY);
+  });
+});
+
+describe('DELETE — measured as form-encoded, and it needs contact_key', () => {
+  it('form-encodes the body, the shape that made DELETE /bookings work', async () => {
+    // Sent any other way, Clubworx answers 401 "Authorization failed", which
+    // reads exactly like a permissions problem and was misread as one (#50/#60).
+    const fetchImpl = recorder(() => json({ success: true }));
+    const client = clientWith(fetchImpl);
+
+    await client.del('bookings/bk-1', { contact_key: 'ck-1' });
+
+    const sent = fetchImpl.sent[0];
+    expect(sent.method).toBe('DELETE');
+    expect(sent.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    expect(sent.body).toBe('contact_key=ck-1');
+    expect(sent.url).toContain(`account_key=${KEY}`);
+  });
+});
+
+describe('the key never leaves in anything handed back', () => {
+  it('redacts the key out of a network error message', async () => {
+    // node interpolates the URL into connection errors, and the URL carries the
+    // key. An unredacted throw is how a gym key reaches a log line.
+    const client = clientWith(async () => {
+      throw new Error(`connect ECONNREFUSED for https://app.clubworx.com/api/v2/events?account_key=${KEY}`);
+    });
+
+    const res = await client.get('events');
+
+    expect(res.ok).toBe(false);
+    expect(res.networkError).toBe(true);
+    expect(res.message).not.toContain(KEY);
+    expect(res.message).toContain('<CLUBWORX_ACCOUNT_KEY>');
+  });
+
+  it('redacts the key out of a non-JSON body, which is what a throttle returns', async () => {
+    const client = clientWith(
+      async () => new Response(`<html>blocked ${KEY}</html>`, { status: 429 }),
+    );
+
+    const res = await client.get('events');
+
+    expect(res.status).toBe(429);
+    expect(res.body).toBeNull();
+    expect(res.nonJson).toBe(true);
+    expect(res.bodyText).not.toContain(KEY);
+  });
+
+  it('reports the url it called with the key removed', async () => {
+    const client = clientWith(recorder(() => json({})));
+    const res = await client.get('events');
+
+    expect(res.url).toContain('app.clubworx.com/api/v2/events');
+    expect(res.url).not.toContain(KEY);
+  });
+
+  it('bounds a non-JSON body rather than carrying a whole error page around', async () => {
+    const client = clientWith(async () => new Response('x'.repeat(5000), { status: 502 }));
+    const res = await client.get('events');
+
+    expect(res.bodyText.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe('pacing', () => {
+  it('sends every call through the pacer', async () => {
+    const pacer = instantPacer();
+    const client = clientWith(recorder(() => json({})), { pacer });
+
+    await client.get('events');
+    await client.post('members', {});
+    await client.del('bookings/1', { contact_key: 'ck' });
+
+    expect(pacer.calls).toBe(3);
+  });
+
+  it('leaves the measured gap between two calls', async () => {
+    let t = 0;
+    const pacer = createPacer({
+      now: () => t,
+      sleep: async ms => {
+        t += ms;
+      },
+    });
+    const at = [];
+    const client = clientWith(
+      recorder(() => {
+        at.push(t);
+        return json({});
+      }),
+      { pacer },
+    );
+
+    await client.get('events');
+    await client.get('events');
+
+    expect(at).toEqual([0, 800]);
+  });
+
+  it('never runs two Clubworx calls at once', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const client = clientWith(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return json({});
+    });
+
+    await Promise.all([client.get('a'), client.get('b'), client.get('c')]);
+
+    expect(maxInFlight).toBe(1);
+  });
+});
+
+describe('timing', () => {
+  it('reports how long the call took', async () => {
+    const client = clientWith(recorder(() => json({})));
+    const res = await client.get('events');
+
+    expect(typeof res.ms).toBe('number');
+    expect(res.ms).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/cloudflare-clubworx/test/errors.test.js
+++ b/cloudflare-clubworx/test/errors.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { errorMessageOf } from '../src/errors.js';
+
+// Moved from probes/lib/report.test.js when staff-site#66 promoted errorMessageOf
+// into the Worker's own module. The Worker and the probes read a Clubworx refusal
+// the same way because they read it with the same function.
+
+describe('errorMessageOf', () => {
+  it('reads a plain string error — the shape Clubworx actually answers with', () => {
+    expect(errorMessageOf({ error: 'Contact has no active membership' })).toBe(
+      'Contact has no active membership',
+    );
+  });
+
+  it('joins a list of errors', () => {
+    expect(errorMessageOf({ errors: ['too late', 'no spaces'] })).toBe('too late; no spaces');
+  });
+
+  it('flattens field → messages, the Rails shape', () => {
+    expect(errorMessageOf({ errors: { base: ['not permitted'], event: 'is full' } })).toBe(
+      'base: not permitted; event: is full',
+    );
+  });
+
+  it('truncates rather than recording an unbounded body', () => {
+    const v = errorMessageOf({ error: 'x'.repeat(500) }, { limit: 20 });
+    expect(v).toHaveLength(21); // 20 + the ellipsis
+    expect(v.endsWith('…')).toBe(true);
+  });
+
+  it('returns null when there is no error to read', () => {
+    // It must never fall back to serialising the whole body — that is how a row
+    // of production data would end up in a log line.
+    expect(errorMessageOf({ booking_id: 'bk-1', contact_key: 'ck-real' })).toBeNull();
+    expect(errorMessageOf(null)).toBeNull();
+    expect(errorMessageOf('<html>')).toBeNull();
+    expect(errorMessageOf({ error: '   ' })).toBeNull();
+  });
+});

--- a/cloudflare-clubworx/test/pace.test.js
+++ b/cloudflare-clubworx/test/pace.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { createPacer, MAX_REQUESTS_PER_MINUTE, MIN_INTERVAL_MS } from '../src/pace.js';
+
+// The pace is a design constant, not an adaptive one. Clubworx advertises no
+// rate-limit headers at any point — confirmed live, and confirmed again while
+// being throttled (#51) — so there is nothing to read back and self-throttle
+// from. These tests pin the constant and the seriality, because the only other
+// way to find out the pacer is broken is a gym-wide 18-second outage.
+
+/**
+ * A virtual clock, so the tests assert the schedule rather than sleep through it.
+ * `sleep` advances time instead of waiting, which is what makes an 800 ms gap
+ * assertable in a millisecond.
+ */
+function virtualClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async ms => {
+      t += ms;
+    },
+    advance: ms => {
+      t += ms;
+    },
+    set: ms => {
+      t = ms;
+    },
+  };
+}
+
+describe('the measured constants', () => {
+  it('paces at 75 requests per minute, the rate #51 found ran clean', () => {
+    expect(MAX_REQUESTS_PER_MINUTE).toBe(75);
+  });
+
+  it('derives the interval from the rate rather than restating it', () => {
+    // 60000/75 = 800. Derived so that changing the rate cannot leave a stale
+    // interval behind, which is the failure mode of two hand-kept constants.
+    expect(MIN_INTERVAL_MS).toBe(Math.ceil(60_000 / MAX_REQUESTS_PER_MINUTE));
+    expect(MIN_INTERVAL_MS).toBe(800);
+  });
+});
+
+describe('createPacer', () => {
+  it('runs one request at a time, never two in flight', async () => {
+    const clock = virtualClock();
+    const pace = createPacer(clock);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const task = async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return 'done';
+    };
+
+    await Promise.all([pace(task), pace(task), pace(task)]);
+
+    expect(maxInFlight).toBe(1);
+  });
+
+  it('leaves at least the interval between the starts of two calls', async () => {
+    const clock = virtualClock();
+    const pace = createPacer(clock);
+    const starts = [];
+
+    await pace(async () => starts.push(clock.now()));
+    await pace(async () => starts.push(clock.now()));
+    await pace(async () => starts.push(clock.now()));
+
+    expect(starts).toEqual([0, 800, 1600]);
+  });
+
+  it('does not wait when the caller was already slow enough', async () => {
+    // A Clubworx call that itself takes a second has already spent the interval.
+    // Sleeping another 800 ms on top would halve the achievable rate for no
+    // reason — the ceiling is on how often a request *starts*.
+    const clock = virtualClock();
+    const pace = createPacer(clock);
+    const starts = [];
+
+    await pace(async () => {
+      starts.push(clock.now());
+      clock.advance(2000);
+    });
+    await pace(async () => starts.push(clock.now()));
+
+    expect(starts).toEqual([0, 2000]);
+  });
+
+  it('starts the very first call immediately', async () => {
+    const clock = virtualClock();
+    clock.set(5_000_000);
+    const pace = createPacer(clock);
+
+    let at = null;
+    await pace(async () => {
+      at = clock.now();
+    });
+
+    expect(at).toBe(5_000_000);
+  });
+
+  it('returns what the task returned', async () => {
+    const pace = createPacer(virtualClock());
+    await expect(pace(async () => 42)).resolves.toBe(42);
+  });
+
+  it('rejects to the caller that queued the failing task', async () => {
+    const pace = createPacer(virtualClock());
+    await expect(pace(async () => {
+      throw new Error('upstream fell over');
+    })).rejects.toThrow('upstream fell over');
+  });
+
+  it('keeps running after a task throws, rather than wedging the queue', async () => {
+    // A single 500 from Clubworx mid-run must not strand every remaining
+    // student behind a rejected promise in the chain.
+    const clock = virtualClock();
+    const pace = createPacer(clock);
+
+    const failed = pace(async () => {
+      throw new Error('boom');
+    });
+    const after = pace(async () => 'still here');
+
+    await expect(failed).rejects.toThrow('boom');
+    await expect(after).resolves.toBe('still here');
+  });
+
+  it('paces the call after a failure too', async () => {
+    const clock = virtualClock();
+    const pace = createPacer(clock);
+
+    await pace(async () => {
+      throw new Error('boom');
+    }).catch(() => {});
+    const at = await pace(async () => clock.now());
+
+    expect(at).toBe(800);
+  });
+
+  it('counts the calls it has let through', async () => {
+    const pace = createPacer(virtualClock());
+    await pace(async () => null);
+    await pace(async () => null);
+
+    expect(pace.calls).toBe(2);
+  });
+
+  it('accepts a slower interval but never a faster one than the measured ceiling', () => {
+    // 120/min did not run clean (#51). A caller asking for a tighter pace is
+    // asking for the failure that was already measured, so it is refused here
+    // rather than discovered in production.
+    expect(() => createPacer({ ...virtualClock(), minIntervalMs: 400 })).toThrow(/slower/i);
+    expect(() => createPacer({ ...virtualClock(), minIntervalMs: 2000 })).not.toThrow();
+  });
+});

--- a/cloudflare-clubworx/test/request.test.js
+++ b/cloudflare-clubworx/test/request.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildUrl, redact } from './request.mjs';
+import { buildUrl, redact } from '../src/request.js';
 
 // The two things a probe against a public repo's live production API must get
 // right before it makes a single call: the URL it asks for, and the text it is

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { createHandler, PREFIX } from '../src/index.js';
+
+// The Worker's front door. Two things are being pinned here and they pull in
+// opposite directions, which is why they are tested together:
+//
+//   - It fails closed. No valid Access assertion, no answer — and the client is
+//     told nothing about *why*, because "wrong-audience" and "bad-signature" are
+//     a map of the gate for anyone probing it.
+//   - It logs enough to attribute a write, and no more. The operator email and
+//     the route go in the log line. The query string, the body and the key do
+//     not — §6's D10 is one careless console.log away from being untrue, and a
+//     student's surname travels in `?last_name=`.
+
+const ENV = {
+  ACCESS_TEAM_DOMAIN: 'happyk.cloudflareaccess.com',
+  ACCESS_AUD: '65dd83df311d06ffbc7db624cc4e88e3c4d216e716630cfaf60d6d09b7f0e939',
+  CLUBWORX_ACCOUNT_KEY: 'super-secret-gym-key-1234',
+};
+
+const accepts = email => async () => ({ ok: true, email, sub: 'sub-1' });
+const rejects = reason => async () => ({ ok: false, reason, email: null, sub: null });
+
+/** A handler with a stubbed verifier and a capturing log. */
+function handlerWith(verify, { env = ENV } = {}) {
+  const lines = [];
+  const handle = createHandler({ makeVerifier: () => verify, log: line => lines.push(line) });
+  return {
+    lines,
+    call: (path, init = {}) => handle(new Request(`https://ujstaff.happyk.au${path}`, init), env),
+  };
+}
+
+const withJwt = { headers: { 'Cf-Access-Jwt-Assertion': 'header.claims.signature' } };
+
+describe('the route prefix', () => {
+  it('is the one wrangler.toml routes and the design names', () => {
+    expect(PREFIX).toBe('/api/clubworx');
+  });
+
+  it('answers 404 for anything outside it, without consulting Access', async () => {
+    // ujstaff.happyk.au/api/* also routes to the roster Worker. Anything that
+    // reaches this one by mistake is not this one's to answer.
+    let consulted = false;
+    const h = handlerWith(async () => {
+      consulted = true;
+      return { ok: true, email: 'x@y', sub: null };
+    });
+
+    const res = await h.call('/api/payments/v1/vouchers', withJwt);
+
+    expect(res.status).toBe(404);
+    expect(consulted).toBe(false);
+  });
+
+  it('does not treat a lookalike prefix as its own', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    expect((await h.call('/api/clubworx-other/health', withJwt)).status).toBe(404);
+  });
+});
+
+describe('the Access gate', () => {
+  it('refuses a request with no assertion at all', async () => {
+    const h = handlerWith(rejects('no-token'));
+    const res = await h.call('/api/clubworx/health');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('refuses a present-but-invalid assertion — presence is not proof', async () => {
+    const h = handlerWith(rejects('bad-signature'));
+    expect((await h.call('/api/clubworx/health', withJwt)).status).toBe(401);
+  });
+
+  it('refuses a token minted for a different Access application', async () => {
+    const h = handlerWith(rejects('wrong-audience'));
+    expect((await h.call('/api/clubworx/health', withJwt)).status).toBe(401);
+  });
+
+  it('tells the client nothing about why', async () => {
+    // The reason is a map of the gate. It belongs in our log, not in a reply to
+    // whoever is rattling it.
+    const h = handlerWith(rejects('wrong-audience'));
+    const body = await (await h.call('/api/clubworx/health', withJwt)).json();
+
+    expect(JSON.stringify(body)).not.toContain('wrong-audience');
+    expect(body.error).toBe('unauthorized');
+  });
+
+  it('records the reason in the log line, where it is useful', async () => {
+    const h = handlerWith(rejects('expired'));
+    await h.call('/api/clubworx/health', withJwt);
+
+    expect(JSON.parse(h.lines[0]).reason).toBe('expired');
+    expect(JSON.parse(h.lines[0]).status).toBe(401);
+  });
+
+  it('runs before routing, so an unauthenticated caller cannot map the routes', async () => {
+    const h = handlerWith(rejects('no-token'));
+    // A route that does not exist still answers 401, not 404.
+    expect((await h.call('/api/clubworx/does-not-exist')).status).toBe(401);
+  });
+
+  it('refuses when the Access configuration is missing, rather than opening up', async () => {
+    // An unset ACCESS_AUD on a deploy must not become "let everyone through".
+    const h = handlerWith(rejects('not-configured'), { env: { ...ENV, ACCESS_AUD: '' } });
+    expect((await h.call('/api/clubworx/health', withJwt)).status).toBe(401);
+  });
+});
+
+describe('GET /health', () => {
+  it('answers 200 behind a valid assertion', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    const res = await h.call('/api/clubworx/health', withJwt);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('names the operator Access authenticated, so a deploy check proves the gate ran', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    const body = await (await h.call('/api/clubworx/health', withJwt)).json();
+
+    expect(body.email).toBe('staff@urbanjungleirc.com');
+  });
+
+  it('reports whether the Clubworx secret is set, without revealing it', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    const res = await h.call('/api/clubworx/health', withJwt);
+    const text = await res.text();
+
+    expect(JSON.parse(text).clubworxKey).toBe('configured');
+    expect(text).not.toContain(ENV.CLUBWORX_ACCOUNT_KEY);
+  });
+
+  it('says so plainly when the secret was never put, instead of looking healthy', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'), {
+      env: { ...ENV, CLUBWORX_ACCOUNT_KEY: undefined },
+    });
+    const body = await (await h.call('/api/clubworx/health', withJwt)).json();
+
+    expect(body.clubworxKey).toBe('missing');
+  });
+
+  it('refuses a method it does not implement', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    expect((await h.call('/api/clubworx/health', { ...withJwt, method: 'POST' })).status).toBe(405);
+  });
+});
+
+describe('routes not built yet', () => {
+  it('answers 404 for an authenticated call to a route this ticket does not add', async () => {
+    // #67/#68/#70 add events, contacts, student and unbook. Until then a 404 is
+    // the honest answer — not a 500, and not a silent 200.
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    const res = await h.call('/api/clubworx/student', { ...withJwt, method: 'POST' });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('not found');
+  });
+});
+
+describe('the log line', () => {
+  it('carries the operator, the route, the status and the timing', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    await h.call('/api/clubworx/health', withJwt);
+
+    const line = JSON.parse(h.lines[0]);
+    expect(line.email).toBe('staff@urbanjungleirc.com');
+    expect(line.route).toBe('/api/clubworx/health');
+    expect(line.method).toBe('GET');
+    expect(line.status).toBe(200);
+    expect(typeof line.ms).toBe('number');
+  });
+
+  it('never carries the query string, where a student surname travels', async () => {
+    // GET /contacts?last_name=&dob= is a documented route (§6). Logging the
+    // path with its query would put a student's surname and date of birth in
+    // Cloudflare's log store — exactly what D10 forbids.
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    await h.call('/api/clubworx/health?last_name=Nowak&dob=2009-03-02', withJwt);
+
+    const raw = h.lines[0];
+    expect(raw).not.toContain('Nowak');
+    expect(raw).not.toContain('2009-03-02');
+    expect(JSON.parse(raw).route).toBe('/api/clubworx/health');
+  });
+
+  it('never carries the request body', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    await h.call('/api/clubworx/student', {
+      ...withJwt,
+      method: 'POST',
+      body: JSON.stringify({ first_name: 'Amelia', last_name: 'Nowak', dob: '2009-03-02' }),
+    });
+
+    expect(h.lines[0]).not.toContain('Amelia');
+    expect(h.lines[0]).not.toContain('Nowak');
+  });
+
+  it('never carries the account key', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    await h.call('/api/clubworx/health', withJwt);
+
+    expect(h.lines[0]).not.toContain(ENV.CLUBWORX_ACCOUNT_KEY);
+  });
+
+  it('writes one line per request, not one per branch', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    await h.call('/api/clubworx/health', withJwt);
+    await h.call('/api/clubworx/nope', withJwt);
+
+    expect(h.lines).toHaveLength(2);
+  });
+
+  it('is not written for traffic that is not this Worker\'s', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    await h.call('/api/payments/v1/vouchers', withJwt);
+
+    expect(h.lines).toHaveLength(0);
+  });
+});
+
+describe('responses', () => {
+  it('answers JSON and forbids caching, since every answer is per-operator', async () => {
+    const h = handlerWith(accepts('staff@urbanjungleirc.com'));
+    const res = await h.call('/api/clubworx/health', withJwt);
+
+    expect(res.headers.get('Content-Type')).toContain('application/json');
+    expect(res.headers.get('Cache-Control')).toContain('no-store');
+  });
+});

--- a/cloudflare-clubworx/wrangler.toml
+++ b/cloudflare-clubworx/wrangler.toml
@@ -1,0 +1,37 @@
+name = "uj-clubworx-api"
+main = "src/index.js"
+compatibility_date = "2026-08-19"
+account_id = "7b9239b4304637147e3e26d2ceb27666"
+
+# No *.workers.dev address. That URL is not fronted by Cloudflare Access, so
+# leaving it on would publish an unauthenticated door beside the guarded one —
+# and the Worker's own JWT check would then be the only thing standing between
+# the open internet and the gym's whole contact database. It holds (see
+# src/access.js), but it should not have to hold alone.
+workers_dev = false
+
+[observability]
+enabled = true
+
+# Deliberately NOT secrets. Neither identifies anything private: the team domain
+# is in every Access redirect and the AUD tag is in every JWT the browser already
+# holds. Committing them is what makes the Worker fail *closed* on a fresh
+# deploy — src/access.js rejects every request when either is unset, so leaving
+# them to be set by hand would mean a deploy that silently refuses everything
+# until somebody remembers.
+#
+# The one value that IS a secret is CLUBWORX_ACCOUNT_KEY. It is never here:
+#
+#   npx wrangler secret put CLUBWORX_ACCOUNT_KEY
+#
+# staff-site is a PUBLIC repo and this file is committed. See ACCESS.md.
+[vars]
+ACCESS_TEAM_DOMAIN = "happyk.cloudflareaccess.com"
+ACCESS_AUD = "65dd83df311d06ffbc7db624cc4e88e3c4d216e716630cfaf60d6d09b7f0e939"
+
+# More specific than the existing ujstaff.happyk.au/api/* -> uj-tools-editor
+# route, so this one wins for /api/clubworx/* and both the roster Worker and
+# uj-payments-proxy (/api/payments/*) are untouched.
+[[routes]]
+pattern = "ujstaff.happyk.au/api/clubworx/*"
+zone_name = "happyk.au"


### PR DESCRIPTION
Closes #66. Part of the #46 school-group booking map. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §6.

`cloudflare-clubworx/` held `ACCESS.md` and the probes; it now holds the Worker they were reconnaissance for. Routed at `ujstaff.happyk.au/api/clubworx/*`, and it deploys separately — a Pages publish does not touch it.

## Auth is verified, not assumed

The signature is checked against the `happyk.cloudflareaccess.com` JWKS and every failure is a rejection. There is no fallback branch in `src/access.js`: a present-but-invalid token is further from acceptable than an absent one, not closer. Unset config rejects everything rather than degrading into "any token from this team", and `workers_dev = false` so there is no address Access does not front.

The client is told only `unauthorized`. The reason goes to the log — told apart, `expired` and `wrong-audience` describe the gate to whoever is rattling it.

`test/access.test.js` signs real RS256 tokens with a real key pair, so the forged-signature, `alg:none`, HS256 and wrong-audience cases genuinely fail rather than being asserted against a stub.

## The Worker stores nothing

The log line carries the route **path**, method, status, operator email and timing. Never the query string — `?last_name=&dob=` is where a student's surname and date of birth travel — and never a body. Both are asserted directly, because a rule of that shape fails silently.

## Pacing

75 req/min, one in flight, from #51's measurement. Non-adaptive by necessity: Clubworx advertises no rate-limit headers at any point, even mid-throttle. The interval is derived from the rate so the two cannot disagree, and a caller asking for a faster pace is refused. One pacer per isolate, not per client — the key comes from `env`, so a per-client pacer would make "one in flight" true only within a single request while the ceiling it protects is gym-wide.

## Promoted, not re-implemented

`buildUrl`, `redact` and `errorMessageOf` were **moved** out of `probes/lib/` into `src/`, and the probes import them back. A second copy would re-derive their bugs and drift on the first fix that landed in only one.

## Scope

Only `GET /api/clubworx/health`. The working routes arrive with #67/#68/#70 — §17 puts the Worker before the page because a page calling a route that does not exist is a broken tool on the live hub, and `main` is production here.

## Verification

Deployed 2026-08-19 14:52 UTC, secret set. Confirmed against production:

- The Worker's own log line for a real signed-in visit: `route=/api/clubworx/health status=200 email=jiri@urbanjungleirc.com ms=25`. That one line shows the request cleared Access, that the Worker's own JWT verification then accepted it (a rejection logs `email: null`), that the handler answered 200 — and that the route logged is the bare path, with no query string.
- `CLUBWORX_ACCOUNT_KEY` is bound as `secret_text`; `ACCESS_AUD` and `ACCESS_TEAM_DOMAIN` as plain vars.
- Route `ujstaff.happyk.au/api/clubworx/*` resolves to `uj-clubworx-api`, ahead of the broader `/api/*` → `uj-tools-editor`. Roster, payments and hvt routes untouched.
- An anonymous request never reaches the Worker: Access bounces it at the edge, returning HTTP 200 carrying the login page.
- 293 tests in `cloudflare-clubworx` (105 new), 81 `cloudflare-worker`, 80 `school-booking`, 217 `vouchers`, 9 `cloudflare-payments-proxy` — all pass. `secret-hygiene.test.js` passes with everything staged.
- Reviewed on both axes (standards + spec); fixes in `f0878ca`.

### Note for #67/#68/#70: the 401 half is not observable in production

The "401 without a valid JWT" half of #66's bar is verified by tests, not against production, and deliberately so.

Access **sets** `Cf-Access-Jwt-Assertion` on requests it forwards, so a client cannot inject its own through Access, and an unauthenticated request never arrives at all. The Worker's verification therefore does not guard the Access-fronted path — it guards paths that skip Access entirely, which is what `workers_dev = false` exists to prevent. An Access service token would not exercise it either, since it also goes through Access.

**Decision: no service token was created.** It would add a permanent credential that bypasses the human Access policy in front of a Worker fronting the gym's whole contact database, in exchange for a result the tests already give. Don't re-litigate this to "test the 401 live" on a later ticket.