### PR TITLE
Move the Pages workflow onto Node 24 action runtimes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # The version is a commit count, and a shallow checkout answers that
           # with 1 without erroring. The generator refuses to emit a version
@@ -47,8 +47,10 @@ jobs:
           # does not ship a wrong number — it ships "dev".
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
+          # The Node that runs version.mjs. A different knob from the action's
+          # own runtime, and untouched by the bump that fixed #82.
           node-version: '20'
 
       - name: Generate the voucher hub build version
@@ -83,9 +85,15 @@ jobs:
             test -f "_site/$f" || { echo "missing from staged site: $f"; exit 1; }
           done
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _site
+          # v4 stopped including dotfiles in the artifact, and `.nojekyll` is a
+          # dotfile. The staging check above would still have passed — it reads
+          # `_site`, not the artifact — so the file would have gone missing
+          # silently. `.git` and `.github` stay excluded regardless of this flag,
+          # which is a small improvement: they were being published until now.
+          include-hidden-files: true
 
       - id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Closes #82.

| | Was | Now | Why |
|---|---|---|---|
| `actions/checkout` | `v4` | `v7` | v4 declares `node20`, v5+ declare `node24` |
| `actions/setup-node` | `v4` | `v7` | same |
| `actions/upload-pages-artifact` | `v3` | `v5` | v3 wraps `upload-artifact@v4` (node20); v5 wraps v7 |
| `actions/deploy-pages` | `v4` | `v5` | v4 declares `node20`, v5 declares `node24` |

Versions were read out of each action's own `action.yml` at each tag rather than guessed, which is what #82 asked for. Release notes for the newest majors were checked for breaking changes touching the inputs this workflow uses — `fetch-depth`, `node-version`, `path`. None do. (checkout v7 blocks fork-PR checkout for `pull_request_target`/`workflow_run`, which this workflow does not use.)

## The one real trap

**`upload-pages-artifact` v4 stopped including dotfiles in the artifact, and `.nojekyll` is a dotfile.**

Nothing would have failed. The pre-publish check reads `_site`, not the artifact, so it would have kept passing while the file quietly stopped being published — exactly the silent class of failure this repo's docs keep warning about. `include-hidden-files: true` keeps it.

Worth knowing: `.nojekyll` is probably vestigial. It was added in `d5006ab` (July) to bypass the **legacy branch build**, which no longer runs now that ADR 0004 moved publishing to Actions. Keeping it is the conservative choice for a workflow that cannot be rehearsed — this PR changes runtimes, not what gets served. Dropping it is a separate, easily-tested decision.

**Small improvement that comes free:** the action excludes `.git` and `.github` unconditionally, regardless of that flag. `.github/` has been published to the live site until now, since the rsync excludes `.git` but not `.github`.

## Deliberately not changed

`node-version: '20'` — the Node that runs `version.mjs`. It is a different knob from the action runtime and #82 separated the two so that a bump here could not be mistaken for the fix. It is worth revisiting on its own merits (Node 20 is past LTS), but not inside the change that has to be right first time.

## Verification, and its limit

Done here:

- YAML parses to the same seven steps, in the same order
- all four moving major tags resolve to real commits
- `include-hidden-files` exists at `v5`, and the tar line applies `--exclude=.[^/]*` only when it is not `'true'`, with `--exclude=.git --exclude=.github` unconditional

**What cannot be done here:** the job is gated to `main` (`if: github.ref == 'refs/heads/main'`), deliberately, so a dispatch cannot publish a feature branch to production. The first run of the changed workflow is therefore a production publish — as #82 recorded. The mitigation is the shape of the failure: a red run leaves the site frozen on its **previous** build rather than broken, and the staged-site check still fails the deploy rather than publishing a site missing whole tools.

After merging:

```bash
gh run list --workflow=pages.yml --repo urbanjungleirc/staff-site --limit 1
```

Green **and** built the expected commit, with no Node 20 annotation. Not by fetching the URL — Access returns 200 with a login page either way.

## Known gap, not addressed here

The staged-site check verifies `_site`, not the artifact that is actually published. That is what would have made the dotfile change silent, and it stays true for anything else the packaging step might drop. Worth a ticket if you want the check moved after packaging; it is not a regression introduced by this PR.

> ⚠️ **Merging this repo is deploying it** (`main` → `ujstaff.happyk.au`), and this PR changes the deploy mechanism itself. Yours to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYGFYNFXj8pM5beoUa75Uo
