### PR TITLE
Run version.mjs on Node 22

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,9 +49,11 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          # The Node that runs version.mjs. A different knob from the action's
-          # own runtime, and untouched by the bump that fixed #82.
-          node-version: '20'
+          # The Node that runs version.mjs — a different knob from the action's
+          # own runtime, which #82 moved to 24. 20 left LTS in April 2026.
+          # version.mjs needs 20.11 or newer for `import.meta.dirname`, so this
+          # can move up but not back down.
+          node-version: '22'
 
       - name: Generate the voucher hub build version
         # The generator cannot throw, but the step around it can: if node were


### PR DESCRIPTION
`node-version: '20'` → `'22'` in `.github/workflows/pages.yml`.

This is the Node that runs `vouchers/scripts/version.mjs` — a different knob from the action runtimes, which #82 moved to Node 24 and deliberately left this one alone so the two could be judged separately. Node 20 left LTS in April 2026, so this is the last place the deploy still asked for an unsupported runtime.

## Verified, not assumed

Run locally on v22.23.1:

```
$ node vouchers/scripts/version.mjs
{"version":"78","sha":"31624ba","builtAt":"2026-08-19T15:18:18.498Z"}
```

…and the workflow's own post-generation assertion (`v.version && v.builtAt && typeof v.sha === "string"`) passes against that output. YAML still parses, and the step's other inputs are untouched.

**The floor is 20.11**, not 20: `version.mjs` uses `import.meta.dirname`. So this version can move up but never back down — worth knowing before anyone "reverts to be safe".

## Risk

Same caveat as #82, and no more than it: the job is gated to `main`, so this cannot be rehearsed and the first run of the changed workflow is a production publish.

The failure shape is benign. If Node 22 were unavailable, the setup step fails and the deploy stops — the site stays on its previous build. It cannot publish a half-built version file, because the generator is followed by an assertion that fails the job rather than letting an unusable `version.json` through. That guard is why this step was written the way it was.

## Why 22 and not 24

Asked for. Worth noting that **24 is the current Active LTS** (22 entered maintenance in October 2025), and the action runtimes now run on 24 — so aligning on 24 would make the whole workflow one version. Nothing here depends on the difference; say the word and it's a one-character change.

> ⚠️ **Merging this repo is deploying it** (`main` → `ujstaff.happyk.au`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYGFYNFXj8pM5beoUa75Uo
