### PR TITLE
chore: ignore the .claude agent scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ _site/
 # tree to a public site, and the write probes on #49/#50 will hold contact keys.
 # The findings that matter are written up by hand in probes/*.md.
 cloudflare-clubworx/probes/out/
+
+# Agent scratch space, including git worktrees. A worktree under .claude/ is a
+# second full checkout of this repo, so `git add -A` would commit a duplicate
+# of the tree into itself. Nothing here is authored — the worktree's own
+# checkout is tracked by the branch it holds, not by this one.
+.claude/


### PR DESCRIPTION
Worktrees created under `.claude/worktrees/` are full checkouts of this repo. Untracked and unignored, they surfaced in every `git status`, and a single `git add -A` would have committed a copy of the tree into itself.

Found while syncing a second machine: `.claude/` showed as untracked at the repo root, and `git check-ignore` appeared to cover it — but the rule it matched came from the *nested worktree's own* `.gitignore`, not this one. The root was genuinely unprotected.

The work inside a worktree is already tracked by the branch that worktree holds, so nothing is lost by ignoring the path here.

## Verification

- `git ls-files .claude/` is empty — the rule shadows no tracked file.
- `git check-ignore -v .claude/` now resolves to `.gitignore:49`, this repo's own rule.
- `git worktree list` still resolves both checkouts; ignoring the path does not unregister the worktree.

One line of config, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)