### PR TITLE
Probe #63: POST /members works, and the School Pass rides along

### DIFF
--- a/cloudflare-clubworx/ACCESS.md
+++ b/cloudflare-clubworx/ACCESS.md
@@ -250,6 +250,43 @@ prospects that ticket needs. A fourth contact is a new decision.
 
 Findings: `probes/49-plus-addressed-duplicates.md`.
 
+### Amendment, 2026-08-20: two more, for #63 — SPENT
+
+**Authorised by Jiri, 2026-08-20**, when #63 ran. The amendment above is spent
+and could not be stretched: #63 asks what `POST /api/v2/members` does when it
+**creates** a contact, and every contact from #49 already exists. There is no
+way to ask that of a contact that is already there.
+
+Two, not one, for the same structural reason #49 needed three. Question 1 needs
+a create carrying only the required fields; questions 3 and 4 need
+`membership_plan_id` **on the create call**, which only a contact that does not
+yet exist can test. Folding them together would have answered one pair and left
+the other resting on the reference.
+
+These two now exist in production and are **permanent**:
+
+| | Name | Email | `contact_key` |
+|---|---|---|---|
+| D | `Ztest Wayfinderfour` | `noreply+wayfindertest@urbanjungleirc.com` | `5a7f1d25-7964-4f42-bbc2-1ec93e7f7aeb` |
+| E | `Ztest Wayfinderfive` | `noreply+wayfindertest@urbanjungleirc.com` | `676df583-e637-42e6-9fee-38631461baad` |
+
+Both were created through `POST /api/v2/members` and both landed **directly in
+the `/members` view, holding no membership at all** — so a contact's status view
+is set by the endpoint that created it, not derived from holding a pass.
+
+**Two School Passes came with them, and are equally permanent:**
+
+| Contact | Membership | Start | Expires |
+|---|---|---|---|
+| D | `2629905` | 2026-08-20 | 2026-11-11 |
+| E | `2629906` (granted by the create call) | 2026-08-20 | 2026-11-11 |
+
+**This authorisation is spent.** It covered #63's two contacts. A sixth contact
+is a new decision. `run-63.mjs` searches before every create and reuses what it
+finds, so re-running it costs nothing permanent — verified on 2026-08-20.
+
+Findings: `probes/63-member-creation.md`.
+
 ### Before the first write probe
 
 Search first. If `Ztest Wayfinder` already exists from an earlier run, reuse it
@@ -271,6 +308,9 @@ verified to make zero writes. Any new write probe must do the same.
 | **Memberships have no delete** (#60) | `POST /memberships` creates a permanent record. A School Pass lapses at `expiration_date`; it cannot be removed. Search first and reuse an active one |
 | A membership record has **no `status` field** (#60) | Only `start_date` and `expiration_date`. Code checking `status` reads `undefined` and would treat a live pass as inactive — derive activity from the dates |
 | `GET /membership_plans` **truncates at 50** (#60) | UJ has 57 plans and `School Pass` was beyond the default page, so a name lookup reports "no such plan". Same trap as `/events` (#51). Always pass `page_size`, and treat a full page as truncated |
+| `POST /members` answers **200**, and works with a **JSON** body (#63) | The reference calls it form-encoded; JSON was tried first because it is the only contact-create shape ever measured here (#49) and it succeeded, so the form shape is still untested. Build on JSON. A client testing for `201` reads a successful create as a failure |
+| A contact's **status view is set by the creating endpoint** (#63) | `POST /members` puts a contact straight into `/members` while it holds *no membership at all*. #49's "disjoint views by status" holds, but the status is a label applied at creation, not a consequence of holding a pass |
+| `membership_plan_id` **works on `POST /members`** (#63) | The pass is granted by the create call, active immediately, and starts on the **creation day** — the same date the two-call route was sending. A new student is two writes, not three |
 | Clubworx issues **one key per gym**, confirmed | Attribution by key is impossible; the `noreply+<school>@` marker is the only provenance signal. One key's leak or rotation hits every integration |
 | Rate limits undocumented **and unadvertised** | Confirmed live, and confirmed again *while being throttled* (#51): no `Retry-After` or `X-RateLimit-*` headers come back at any point. A client cannot self-throttle from response metadata or see a ceiling approaching — only hit it |
 | The ceiling is **tight**: ~50 fast requests, then ~18s of 429 (#51) | 75 req/min ran clean; 120 did not. Every caller must pace, and the allowance is shared across the whole gym key, so this tool can throttle HVT and vice versa |

--- a/cloudflare-clubworx/package.json
+++ b/cloudflare-clubworx/package.json
@@ -8,7 +8,9 @@
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
     "probe:51": "node probes/run-51.mjs",
-    "probe:49": "node probes/run-49.mjs"
+    "probe:49": "node probes/run-49.mjs",
+    "probe:60": "node probes/run-60.mjs",
+    "probe:63": "node probes/run-63.mjs"
   },
   "devDependencies": {
     "vitest": "^2.1.0",

--- a/cloudflare-clubworx/probes/63-member-creation.md
+++ b/cloudflare-clubworx/probes/63-member-creation.md
@@ -1,0 +1,195 @@
+# Creating a member, and the pass that rides along — the answer to #63
+
+Probed against production Clubworx on **2026-08-20**, into the same purpose-made
+School Session [#60](60-member-school-pass-booking.md) used (`20481679`, "test
+school booking", moved to 2026-08-28 so it cleared the lead-time rule).
+
+**Every one of the four answers is yes, and the best case won.** `POST
+/api/v2/members` creates a contact, the contact books once it holds a School
+Pass, `membership_plan_id` on the create call produces a *usable* pass — and the
+start date it receives is the same one the two-call route was sending anyway. The
+trade-off §2 of the design spec was braced for **does not exist**.
+
+| | Question | Answer |
+|---|---|---|
+| 1 | Does `POST /api/v2/members` succeed? | **Yes** — HTTP **200**, JSON body |
+| 2 | Is the resulting contact bookable with an active School Pass? | **Yes** — both routes booked |
+| 3 | Does `membership_plan_id` on create produce a usable pass? | **Yes** — active immediately |
+| 4 | What `start_date` does that pass get? | **The creation day** — identical to the two-call route |
+
+**A new student is two writes, not three.**
+
+Nothing was left outstanding: both bookings were created and then cancelled,
+verified by re-count. Four permanent records were added — two contacts and two
+School Passes. See [Cleanup](#cleanup).
+
+## 1. `POST /api/v2/members` works — and answers 200
+
+`Ztest Wayfinderfour` ("D") was created with only the four fields the reference
+marks required: `first_name`, `last_name`, `email`, plus `dob` for the probe
+identity, with `account_key` in the query string.
+
+**HTTP 200, not 201** — exactly as [#49](49-plus-addressed-duplicates.md) found
+for `POST /prospects`. A client testing for `201` reads a successful create as a
+failure. The verdict here came from re-reading all three status views, not from
+the number.
+
+### The body was **JSON**, and that is what is measured
+
+#63 quotes the reference as saying form-encoded. This probe tried **JSON first**,
+because JSON is the only contact-create shape anyone on this map has ever
+watched work (#49, `POST /prospects`), and the reference has been wrong twice
+already. It answered 200 on the first attempt, so the form-encoded fallback
+never ran.
+
+> ⚠️ **Form-encoded on `/members` is therefore still untested**, and can no
+> longer be tested cheaply: D and E now exist, and the probe reuses them rather
+> than creating more. Build the Worker (#69) on **JSON**, which is measured.
+> Do not "fix" it to form-encoding on the strength of the reference.
+
+`lib/write.mjs` grew an `encoding` option for this, defaulting to `json` and
+throwing on anything it does not recognise. A re-read sits between the two
+attempts, so the fallback can never turn a create that quietly worked into a
+permanent duplicate.
+
+### A contact created this way is a **member with no membership**
+
+D appeared in `GET /members` **immediately, before any pass was assigned** —
+and `GET /memberships?contact_key=…` returned nothing for it at that moment.
+
+That is worth stating plainly, because it refines
+[#49](49-plus-addressed-duplicates.md)'s finding that the three contact
+endpoints are disjoint views *by status*. They are — but the status is set by
+**the endpoint that created the contact**, not derived from whether a membership
+is held. "Member" is a label, not a computed consequence of holding a pass.
+
+The design spec's reasoning in §2 ran the other way: it assumed a pass would be
+what *moved* a contact into `/members`. It reached the right conclusion, for a
+reason that turns out not to be the mechanism. The practical effect is the same
+and better — no move is needed, because the contact starts there.
+
+## 2. It books
+
+Both contacts were booked into School Session `20481679` (25 spaces, 191h
+ahead, comfortably outside the one-day rule #60 measured), then cancelled.
+
+| Contact | How it got its pass | Book | Bookings after | Cancel | Bookings after |
+|---|---|---|---|---|---|
+| D `Wayfinderfour` | `POST /memberships` (two-call) | **200**, `63558070` | 0 → **1** | **200** | 1 → **0** |
+| E `Wayfinderfive` | `membership_plan_id` on create (one-call) | **200**, `63558071` | 0 → **1** | **200** | 1 → **0** |
+
+Every one of those transitions was read back off the contact's booking list. The
+status codes agreed this time, but they were not what was trusted.
+
+**The pass is what makes a contact bookable, and its origin does not matter.**
+A pass assigned by the separate call and a pass granted by the create call
+produced booking results indistinguishable from each other.
+
+## 3 and 4. The pass rides along, on terms nobody has to give up
+
+`Ztest Wayfinderfive` ("E") was created with `membership_plan_id: 64189` in the
+same call. One membership came back — exactly one, not a duplicate — and it was
+active the moment it was read.
+
+| | D — two calls, `start_date` sent | E — one call, no `start_date` sent |
+|---|---|---|
+| `start_date` | 2026-08-20 | **2026-08-20** |
+| `expiration_date` | 2026-11-11 | **2026-11-11** |
+| Span | 83 days | **83 days** |
+| Active on read | yes | **yes** |
+| `class_access` | Unlimited classes | Unlimited classes |
+| Writes to get here | **2** (`/members` + `/memberships`) | **1** (`/members`) |
+
+**Clubworx defaults the start date to the day of creation** — which is precisely
+the value the two-call route was computing and sending. The spec's worry, *"the
+pass would start whenever Clubworx decides"*, is answered: it decides *today*,
+and today is what we wanted.
+
+**The 12-week plan expires on day 83, not day 84.** 2026-08-20 → 2026-11-11 is
+83 days of difference and 84 days of access, because `expiration_date` is
+inclusive (#60). The tool still never computes an expiry — it reads one — so
+this is a fact to recognise, not one to reproduce.
+
+## What this settles for #46
+
+**Adopt the one-call route for new students.** A student who is not already in
+Clubworx is created and given their School Pass in a **single** `POST
+/api/v2/members` carrying `membership_plan_id`.
+
+Three things follow:
+
+- **Three writes per new student become two.** On a 63-student list that is 63
+  fewer requests against a gym-wide rate ceiling measured at ~75/min (#51) —
+  roughly 50 seconds off the run.
+- **The "contact created, pass failed" stranded state disappears for new
+  students.** §12 of the design spec exists to handle a student who has a
+  contact record but no pass, created by a run that died between two writes.
+  For a *new* student that gap is now unreachable: the contact and the pass are
+  one request, and it either happened or it did not.
+- **Nothing is given up.** Same start date, same expiry, same access.
+
+**The two-call route stays in the code, for existing contacts.** A student the
+matcher *finds* already in Clubworx cannot be re-created, so a found contact
+lacking an active pass still needs `POST /memberships`. Both paths are now
+measured; neither is speculative.
+
+## Still open
+
+- **Form-encoded `POST /members` is untested.** JSON worked first and the probe
+  reuses its contacts, so proving the form shape would cost another permanent
+  contact. JSON is what the Worker should send.
+- **Whether the two-call route can set a *future* `start_date` is unproven.**
+  Both #60 and this probe sent *today's* date — which is also Clubworx's
+  default — so no run has yet distinguished "Clubworx honoured what we sent"
+  from "Clubworx ignored it and used today". D's `honouredRequest: true` is
+  therefore not evidence of control. It does not matter for #46, which always
+  wants a pass active now, but nothing should be built on the assumption that a
+  future start date is expressible.
+- **Whether `spaces_available` refuses at the cap** — still
+  [#75](https://github.com/urbanjungleirc/staff-site/issues/75), untouched here.
+  Only one booking at a time was made against 25 spaces.
+- **What a term's worth of school members does to Clubworx reporting.** Open on
+  #46, unchanged.
+
+## How it was run
+
+```bash
+node probes/run-63.mjs --dry-run                 # the plan and every request, zero network
+node probes/run-63.mjs                           # read-only: what exists, and the plan lookup
+node probes/run-63.mjs --event=20481679 --write  # the run above
+```
+
+23 reads and 6 writes, paced at one per 800ms (~75/min) per #51.
+
+The probe **searches all three status views before every verdict** and before
+every create, so a re-run costs nothing permanent — verified: a second read-only
+run reported `SKIPPED — already exists` for both contacts and `SKIPPED — an
+active pass is already held` for D's pass.
+
+Two gates keep the permanence proportionate. **E is only attempted if D is seen
+to exist**, so an endpoint that refused would have cost one contact rather than
+two. And **`--write` without `--event=<id>` refuses to start**: questions 1, 3
+and 4 need no event, so without that gate a run could spend two permanent
+contacts and two permanent passes and still leave question 2 — the one that
+decides whether any of it is usable — unanswered.
+
+## Cleanup
+
+Both bookings were cancelled by the probe and the re-counts confirmed it —
+nothing is outstanding on the event.
+
+**Permanent, and recorded in ACCESS.md §4:**
+
+| | Record | Id | Note |
+|---|---|---|---|
+| D | contact `Ztest Wayfinderfour` | `5a7f1d25-7964-4f42-bbc2-1ec93e7f7aeb` | in `/members` |
+| E | contact `Ztest Wayfinderfive` | `676df583-e637-42e6-9fee-38631461baad` | in `/members` |
+| D | School Pass | `2629905` | 2026-08-20 → 2026-11-11 |
+| E | School Pass | `2629906` | 2026-08-20 → 2026-11-11, granted by the create |
+
+Contacts have no delete endpoint and must be removed by hand in the Clubworx UI.
+Memberships have none either; both passes lapse on 2026-11-11 by themselves.
+
+Still owed a manual deletion, unchanged by this probe: the three `Ztest`
+contacts from [#49](49-plus-addressed-duplicates.md), the School Pass #60 left
+on `Ztest Wayfinder`, and the test event `20481679` once it is finished with.

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -15,6 +15,13 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-50.mjs` | The probe that produced it — **writes** |
 | `60-member-school-pass-booking.md` | [#60](https://github.com/urbanjungleirc/staff-site/issues/60) — the member + **School Pass** route **works**: it books, the server refuses duplicates itself, and `DELETE` reverses cleanly |
 | `run-60.mjs` | The probe that produced it — **writes, and deletes** |
+| `63-member-creation.md` | [#63](https://github.com/urbanjungleirc/staff-site/issues/63) — the gate on the #46 build: does `POST /api/v2/members` create a contact, is it bookable, and can the School Pass ride along on the create call |
+| `run-63.mjs` | The probe that produced it — **creates contacts, assigns passes, books and cancels** |
+
+A file's number is the issue it answers, so `63-member-creation.md` belongs to
+[#63](https://github.com/urbanjungleirc/staff-site/issues/63). That ticket's own
+*Done when* line asks for `61-member-creation.md`, written before the issue was
+renumbered — there is no #61, and a file named for it would point at nothing.
 
 Access, authorisation and the key's whereabouts: `../ACCESS.md`.
 
@@ -46,6 +53,11 @@ node probes/run-60.mjs --dry-run     # the plan and every request, zero network
 node probes/run-60.mjs               # read-only: contacts, plan, memberships, event
 node probes/run-60.mjs --event=<id> --write  # ⚠️ assigns a PERMANENT School Pass, then books
 
+node probes/run-63.mjs --dry-run     # the plan and every request, zero network
+node probes/run-63.mjs               # read-only: what exists already, and the plan lookup
+node probes/run-63.mjs --event=<id> --write  # ⚠️ creates up to 2 PERMANENT contacts + 2 passes
+node probes/run-63.mjs --encoding=form       # force the body shape rather than discovering it
+
 npm test                             # the pure logic, no network
 ```
 
@@ -53,7 +65,7 @@ npm test                             # the pure logic, no network
 worktree, for instance, where `.dev.vars` is gitignored and so does not follow
 the checkout.
 
-**Neither booking probe picks the event itself.** `--write` without
+**No booking probe picks the event itself.** `--write` without
 `--event=<id>` stops. A booking lands on a real class that staff see and consumes
 one of its spaces, so choosing by sort order means choosing somebody's actual
 session; a read-only run lists the candidates and a human picks one. Everything
@@ -148,6 +160,8 @@ run-51.mjs        the #51 probe itself — read-only
 run-49.mjs        the #49 probe itself — writes
 run-50.mjs        the #50 probe itself — writes and deletes
 run-60.mjs        the #60 probe itself — writes and deletes
+run-63.mjs        the #63 probe itself — creates contacts,
+                  assigns passes, books and deletes
 ```
 
 The two `../src/` entries are not probe files any more. staff-site#66 promoted

--- a/cloudflare-clubworx/probes/lib/identity.mjs
+++ b/cloudflare-clubworx/probes/lib/identity.mjs
@@ -7,9 +7,11 @@
  * UI. So the identity is not a fixture detail — it is the blast radius, and
  * `assertProbeIdentity` is the control that keeps it that size.
  *
- * The set below is deliberately the *smallest* one that can answer
- * staff-site#49. Adding to it is a decision to leave more permanent records in
- * a production database, not a refactor.
+ * Each set below is deliberately the *smallest* one that can answer its ticket
+ * — `PROBE_CONTACTS` for staff-site#49, `MEMBER_PROBE_CONTACTS` for #63. Adding
+ * to either is a decision to leave more permanent records in a production
+ * database, not a refactor, and each set carries its own authorisation in
+ * ACCESS.md section 4.
  */
 
 /** The identity ACCESS.md section 4 agreed, 2026-08-17. */
@@ -189,3 +191,61 @@ export function planContacts({ wanted, existing = [] }) {
 
   return { create, reuse };
 }
+
+/**
+ * The two contacts staff-site#63 needs, and why there are two.
+ *
+ * **This is a new authorisation, not a reuse of #49's.** ACCESS.md section 4
+ * says the three-contact amendment is *spent* — *"A fourth contact is a new
+ * decision"* — and #63 cannot borrow those three: every one of them already
+ * exists, and the question is what `POST /api/v2/members` does when it
+ * *creates* one. There is no way to ask that of a contact that is already
+ * there.
+ *
+ * Two is the minimum that answers all four of #63's questions, for the same
+ * structural reason #49 needed three rather than one:
+ *
+ *   - **D** is created with only the four required fields. That is question 1
+ *     on its own — does the endpoint work at all — and, once it is given a pass
+ *     through the *measured* two-call route, question 2: is a contact made this
+ *     way bookable.
+ *   - **E** is created with `membership_plan_id` in the same call. That is
+ *     questions 3 and 4, and it cannot be folded into D: the plan has to ride
+ *     along on the **create**, so testing it needs a contact that does not yet
+ *     exist.
+ *
+ * Folding them into one contact would answer either 1 and 2, or 3 and 4, and
+ * leave the other pair resting on the reference — which is the exact thing #63
+ * exists to stop, the reference having been wrong twice on this map already.
+ *
+ * They reuse #49's plus-tag deliberately. A third tag would be a new search
+ * surface every later probe has to sweep, and #49 already settled that a tag
+ * isolates.
+ *
+ * Both are **permanent**. The probe creates E only if D's create is seen to
+ * work, so a `POST /members` that turns out to be refused costs one contact
+ * rather than two.
+ */
+export const MEMBER_PROBE_CONTACTS = [
+  {
+    label: 'D',
+    first_name: 'Ztest',
+    last_name: 'Wayfinderfour',
+    dob: PROBE_DOB,
+    email: TEST_IDENTITY.email,
+    why: 'plain create — does POST /members work, and is the result bookable with a pass? (Q1, Q2)',
+  },
+  {
+    label: 'E',
+    first_name: 'Ztest',
+    last_name: 'Wayfinderfive',
+    dob: PROBE_DOB,
+    email: TEST_IDENTITY.email,
+    // The id itself is resolved by name at run time and deliberately not
+    // declared here — #60 watched `GET /membership_plans` truncate at 50 and
+    // hide this very plan, so a hard-coded id is a guess nobody can check
+    // against the Clubworx UI.
+    withPlanOnCreate: true,
+    why: 'create with membership_plan_id — does the pass ride along, and what start_date does it get? (Q3, Q4)',
+  },
+];

--- a/cloudflare-clubworx/probes/lib/identity.test.js
+++ b/cloudflare-clubworx/probes/lib/identity.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   TEST_IDENTITY,
   PROBE_CONTACTS,
+  MEMBER_PROBE_CONTACTS,
   assertProbeIdentity,
   planContacts,
   pickProbeRows,
@@ -211,5 +212,90 @@ describe('plusTag', () => {
 
   it('returns null when there is no tag', () => {
     expect(plusTag('noreply@urbanjungleirc.com')).toBeNull();
+  });
+});
+
+// ── staff-site#63 ───────────────────────────────────────────────────────────
+//
+// #63 is the first ticket to create a contact through `POST /members`, and the
+// #49 authorisation is spent — ACCESS.md section 4 says in as many words that a
+// fourth contact is a new decision. These assertions are what make the size of
+// that decision checkable: two contacts, both inside the guard that already
+// exists, and neither of them able to carry the probe's own bookkeeping onto a
+// record that can never be deleted.
+
+describe('MEMBER_PROBE_CONTACTS', () => {
+  it('is two contacts — the minimum that answers all four of #63’s questions', () => {
+    // One contact cannot answer both. Question 1 needs a create with only the
+    // required fields; question 3 needs `membership_plan_id` *on the create
+    // call*, which a contact that already exists can never test.
+    expect(MEMBER_PROBE_CONTACTS).toHaveLength(2);
+  });
+
+  it('passes the identity guard that fronts every write', () => {
+    // If a surname were mistyped here, the refusal would arrive mid-run against
+    // production rather than in this file.
+    for (const contact of MEMBER_PROBE_CONTACTS) {
+      expect(() => assertProbeIdentity(contact)).not.toThrow();
+    }
+  });
+
+  it('gives each one a surname no earlier probe used', () => {
+    const earlier = new Set(PROBE_CONTACTS.map(c => c.last_name));
+    const names = MEMBER_PROBE_CONTACTS.map(c => c.last_name);
+
+    expect(new Set(names).size).toBe(names.length);
+    for (const name of names) expect(earlier.has(name)).toBe(false);
+  });
+
+  it('reuses an existing plus-tag rather than opening a new one', () => {
+    // A new tag is a new search surface for every later probe to sweep. #49
+    // already proved a tag isolates; #63 has nothing to learn from a third one.
+    const tags = new Set(PROBE_CONTACTS.map(c => plusTag(c.email)));
+    for (const contact of MEMBER_PROBE_CONTACTS) {
+      expect(tags.has(plusTag(contact.email))).toBe(true);
+    }
+  });
+
+  it('marks exactly one of them as the pass-on-create case', () => {
+    const marked = MEMBER_PROBE_CONTACTS.filter(c => c.withPlanOnCreate);
+    expect(marked).toHaveLength(1);
+    expect(marked[0].label).toBe('E');
+  });
+
+  it('carries no membership_plan_id of its own — the id is resolved by name at run time', () => {
+    // A hard-coded plan id is a number nobody can check against the Clubworx
+    // UI, and #60 found the name lookup silently truncating at 50 plans. The
+    // probe resolves it and refuses to guess; declaring one here would smuggle
+    // the guess back in.
+    for (const contact of MEMBER_PROBE_CONTACTS) {
+      expect(contact.membership_plan_id).toBeUndefined();
+    }
+  });
+
+  it('is found by planContacts once it exists, so a re-run creates nothing', () => {
+    const existing = MEMBER_PROBE_CONTACTS.map((c, i) => ({
+      contact_key: `ck-${i}`,
+      email: c.email,
+      last_name: c.last_name,
+    }));
+
+    const { create, reuse } = planContacts({ wanted: MEMBER_PROBE_CONTACTS, existing });
+
+    expect(create).toHaveLength(0);
+    expect(reuse).toHaveLength(2);
+  });
+
+  it('is not confused with #49’s contacts, which share its email', () => {
+    // Matching is on email *and* surname. If it were email alone, D and E would
+    // look already-present the moment A exists and #63 would silently never run.
+    const existing = PROBE_CONTACTS.map((c, i) => ({
+      contact_key: `ck-${i}`,
+      email: c.email,
+      last_name: c.last_name,
+    }));
+
+    const { create } = planContacts({ wanted: MEMBER_PROBE_CONTACTS, existing });
+    expect(create).toHaveLength(2);
   });
 });

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -744,3 +744,172 @@ export function pickBookableEvents(body, { now = new Date().toISOString() } = {}
   const byStart = (a, b) => String(a.event_start_at).localeCompare(String(b.event_start_at));
   return { free: free.sort(byStart), paid: paid.sort(byStart), skipped };
 }
+
+/**
+ * Did the create actually land? Decided by the re-read, never by the status.
+ *
+ * staff-site#63's standing rule — *"verify each write by re-reading the
+ * resource, never by the status code"* — exists because this map has been
+ * misled by a status twice. #50 read a malformed request's `401` as a
+ * permissions wall. #49 found that a successful contact create answers `200`
+ * where a reader would expect `201`. Neither number described what was in the
+ * database.
+ *
+ * So the verdict here comes from what a subsequent search found, and the status
+ * code is demoted to a single boolean — `statusAgrees` — whose only job is to
+ * record *whether Clubworx told the truth this time*. That is itself a finding
+ * the write-up wants, and it is not the same question as whether a permanent
+ * contact now exists.
+ *
+ * Three distinctions are load-bearing, because contacts cannot be deleted:
+ *
+ *   - **`absent` vs `unverified`.** "We looked and it was not there" and "we did
+ *     not look" must not collapse. The first means nothing was created; the
+ *     second means something may have been, and belongs on the cleanup list.
+ *   - **A transport error is not a failure.** A write that threw may still have
+ *     landed — ACCESS.md says so — and the re-read is the only thing that knows.
+ *   - **`duplicated` is named, not averaged.** Taking `[0]` of two rows would
+ *     hide a second permanent record behind a cheerful "created".
+ *
+ * @param {object} opts
+ * @param {{status?: number|null, error?: string|null, refused?: string|null}} opts.create
+ * @param {Array<{contact_key?: string}>|null} [opts.found] Rows the re-read matched, or null if it did not run.
+ */
+export function describeMemberCreation({ create = {}, found = null } = {}) {
+  const { status = null, error = null, refused = null } = create ?? {};
+
+  // A local refusal never reached the network, so nothing can be claimed about
+  // production and there is no status to agree or disagree with.
+  if (refused) {
+    return {
+      verdict: 'refused',
+      landed: false,
+      contactKey: null,
+      duplicates: 0,
+      status,
+      statusAgrees: null,
+      refused,
+      summary: `refused before the request: ${refused}`,
+    };
+  }
+
+  if (found === null || found === undefined) {
+    return {
+      verdict: 'unverified',
+      landed: null,
+      contactKey: null,
+      duplicates: 0,
+      status,
+      statusAgrees: null,
+      refused: null,
+      summary:
+        `HTTP ${status ?? 'n/a'} and no re-read — whether a permanent contact exists is unknown`,
+    };
+  }
+
+  const rows = Array.isArray(found) ? found.filter(Boolean) : [];
+  const ok = typeof status === 'number' && status >= 200 && status < 300;
+
+  if (rows.length === 0) {
+    return {
+      verdict: 'absent',
+      landed: false,
+      contactKey: null,
+      duplicates: 0,
+      status,
+      // A 2xx with nothing behind it is the case worth shouting about; a 4xx
+      // with nothing behind it is Clubworx being honest.
+      statusAgrees: !ok,
+      refused: null,
+      summary: ok
+        ? `HTTP ${status} but the re-read found nothing — the status did not describe the database`
+        : `HTTP ${status ?? 'n/a'} and the re-read found nothing — nothing was created`,
+    };
+  }
+
+  const verdict = rows.length > 1 ? 'duplicated' : 'created';
+
+  return {
+    verdict,
+    landed: true,
+    contactKey: rows[0].contact_key ?? null,
+    duplicates: rows.length,
+    status,
+    statusAgrees: ok,
+    refused: null,
+    summary:
+      verdict === 'duplicated'
+        ? `${rows.length} contacts match — a duplicate was created and cannot be deleted`
+        : `HTTP ${status ?? 'n/a'}${ok ? '' : ' (or none)'} and the re-read found it — created`,
+  };
+}
+
+const DAY_MS = 86_400_000;
+
+/**
+ * What pass the contact ended up holding, and on whose terms — questions 3 and 4.
+ *
+ * Question 3 asks whether `membership_plan_id` on `POST /members` produces a
+ * *usable* pass; question 4 asks what `start_date` it gets, since that call
+ * accepts none. The trade-off #63 has to price is exactly there: the two-call
+ * route sends a start date and reads a 12-week expiry back, and the one-call
+ * route would hand that choice to Clubworx.
+ *
+ * `startsOnCreationDay` and `spanDays` are what make the answer a measurement
+ * rather than an impression, and `honouredRequest` stays **null** when no start
+ * date was asked for — the one-call route sends none, so there is nothing there
+ * to have been honoured or ignored, and reporting `false` would read as
+ * "Clubworx overrode us".
+ *
+ * Takes the `planStates` from `summariseMemberships` rather than raw rows, so
+ * the "a membership has no `status` field" rule (#60) is applied in exactly one
+ * place.
+ *
+ * @param {object} opts
+ * @param {Array<{start_date?: string|null, expiration_date?: string|null, active?: boolean}>} opts.states
+ * @param {string} opts.on ISO day the create ran.
+ * @param {string|null} [opts.requested] The start_date that was asked for, if any.
+ */
+export function describeCreatedPass({ states = [], on, requested = null } = {}) {
+  const held = Array.isArray(states) ? states.filter(Boolean) : [];
+
+  if (held.length === 0) {
+    return {
+      granted: false,
+      active: false,
+      held: 0,
+      startDate: null,
+      expirationDate: null,
+      spanDays: null,
+      startsOnCreationDay: false,
+      honouredRequest: requested ? false : null,
+      summary: 'no pass on this plan',
+    };
+  }
+
+  // An expired pass is still a held plan. Reporting its dates as the answer
+  // would describe a pass the booking will not accept.
+  const state = held.find(s => s.active) ?? held[0];
+  const startDate = state.start_date ?? null;
+  const expirationDate = state.expiration_date ?? null;
+
+  const start = startDate ? Date.parse(`${startDate}T00:00:00Z`) : NaN;
+  const end = expirationDate ? Date.parse(`${expirationDate}T00:00:00Z`) : NaN;
+  const spanDays =
+    Number.isNaN(start) || Number.isNaN(end) ? null : Math.round((end - start) / DAY_MS);
+
+  return {
+    granted: true,
+    active: Boolean(state.active),
+    held: held.length,
+    startDate,
+    expirationDate,
+    spanDays,
+    startsOnCreationDay: startDate !== null && startDate === on,
+    honouredRequest: requested ? startDate === requested : null,
+    summary:
+      `start ${startDate ?? 'n/a'} · expires ${expirationDate ?? 'n/a'}` +
+      (spanDays === null ? '' : ` · ${spanDays}d`) +
+      ` · active ${Boolean(state.active)}`,
+  };
+}

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -19,6 +19,8 @@ import {
   findPlanByName,
   summariseMemberships,
   describeLeadTime,
+  describeMemberCreation,
+  describeCreatedPass,
 } from './report.mjs';
 
 // What a probe is allowed to write down. Everything here is counts, ids, status
@@ -763,5 +765,158 @@ describe('describeLeadTime', () => {
 
   it('reports an unreadable timestamp rather than guessing', () => {
     expect(describeLeadTime('not a date', { now: NOW }).unreadable).toBe(true);
+  });
+});
+
+// ── staff-site#63: did the create land, and did a pass ride along? ───────────
+//
+// #63's standing rule is "verify each write by re-reading the resource, never
+// by the status code". These two helpers are where that rule is enforced, so
+// that a probe cannot report a permanent contact into existence — or out of it
+// — on the strength of a number Clubworx returned.
+
+describe('describeMemberCreation', () => {
+  const found = keys => keys.map(contact_key => ({ contact_key }));
+
+  it('calls it created when the re-read finds the contact', () => {
+    const r = describeMemberCreation({ create: { status: 200 }, found: found(['ck-1']) });
+    expect(r.landed).toBe(true);
+    expect(r.verdict).toBe('created');
+    expect(r.contactKey).toBe('ck-1');
+  });
+
+  it('calls it absent when the re-read finds nothing, even on a 200', () => {
+    // The whole point of the rule. A 200 that did not create anything is the
+    // failure mode the status code cannot show.
+    const r = describeMemberCreation({ create: { status: 200 }, found: [] });
+    expect(r.landed).toBe(false);
+    expect(r.verdict).toBe('absent');
+    expect(r.statusAgrees).toBe(false);
+  });
+
+  it('calls it created when the re-read finds it despite a transport error', () => {
+    // ACCESS.md: a failed write may still have landed. This is the case that
+    // decides whether something goes on the cleanup list.
+    const r = describeMemberCreation({
+      create: { status: null, error: 'ECONNRESET' },
+      found: found(['ck-9']),
+    });
+    expect(r.landed).toBe(true);
+    expect(r.verdict).toBe('created');
+    expect(r.statusAgrees).toBe(false);
+  });
+
+  it('reports a refusal without claiming anything about production', () => {
+    const r = describeMemberCreation({ create: { refused: 'not Ztest' }, found: [] });
+    expect(r.verdict).toBe('refused');
+    expect(r.landed).toBe(false);
+    // Nothing was sent, so the status cannot disagree with anything.
+    expect(r.statusAgrees).toBeNull();
+  });
+
+  it('flags a duplicate when the re-read finds more than one', () => {
+    // Contacts cannot be deleted, so a second one is a permanent mistake that
+    // has to be named rather than averaged away by taking [0].
+    const r = describeMemberCreation({ create: { status: 200 }, found: found(['ck-1', 'ck-2']) });
+    expect(r.verdict).toBe('duplicated');
+    expect(r.landed).toBe(true);
+    expect(r.duplicates).toBe(2);
+  });
+
+  it('says the status agreed when a 4xx is matched by an absent contact', () => {
+    const r = describeMemberCreation({ create: { status: 422 }, found: [] });
+    expect(r.verdict).toBe('absent');
+    expect(r.statusAgrees).toBe(true);
+  });
+
+  it('treats a missing re-read as unknown rather than as absent', () => {
+    // "We did not look" and "we looked and it was not there" must not collapse:
+    // one of them puts a permanent record on the cleanup list and the other
+    // does not.
+    const r = describeMemberCreation({ create: { status: 200 }, found: null });
+    expect(r.verdict).toBe('unverified');
+    expect(r.landed).toBeNull();
+  });
+});
+
+describe('describeCreatedPass', () => {
+  const on = '2026-08-20';
+
+  it('reports no pass when the plan states are empty', () => {
+    const r = describeCreatedPass({ states: [], on });
+    expect(r.granted).toBe(false);
+    expect(r.active).toBe(false);
+  });
+
+  it('reports the dates of a pass that was granted', () => {
+    const r = describeCreatedPass({
+      states: [{ start_date: '2026-08-20', expiration_date: '2026-11-12', active: true }],
+      on,
+    });
+    expect(r.granted).toBe(true);
+    expect(r.active).toBe(true);
+    expect(r.startDate).toBe('2026-08-20');
+    expect(r.expirationDate).toBe('2026-11-12');
+  });
+
+  it('measures the span in days, so a 12-week plan can be recognised', () => {
+    const r = describeCreatedPass({
+      states: [{ start_date: '2026-08-20', expiration_date: '2026-11-12', active: true }],
+      on,
+    });
+    expect(r.spanDays).toBe(84);
+  });
+
+  it('says whether the pass started on the day it was created — question 4', () => {
+    // `POST /members` takes no start_date. Whether Clubworx defaults it to
+    // today is the whole trade-off in adopting the one-call route.
+    const same = describeCreatedPass({
+      states: [{ start_date: '2026-08-20', expiration_date: '2026-11-12', active: true }],
+      on,
+    });
+    const not = describeCreatedPass({
+      states: [{ start_date: '2026-08-01', expiration_date: '2026-10-24', active: true }],
+      on,
+    });
+    expect(same.startsOnCreationDay).toBe(true);
+    expect(not.startsOnCreationDay).toBe(false);
+  });
+
+  it('says whether the start date matched one that was asked for', () => {
+    const r = describeCreatedPass({
+      states: [{ start_date: '2026-08-25', expiration_date: '2026-11-17', active: true }],
+      on,
+      requested: '2026-08-25',
+    });
+    expect(r.honouredRequest).toBe(true);
+  });
+
+  it('leaves honouredRequest null when nothing was asked for', () => {
+    // The one-call route sends no start_date at all, so there is no request to
+    // have been honoured or ignored.
+    const r = describeCreatedPass({
+      states: [{ start_date: '2026-08-20', expiration_date: '2026-11-12', active: true }],
+      on,
+    });
+    expect(r.honouredRequest).toBeNull();
+  });
+
+  it('prefers the active pass when a contact holds more than one', () => {
+    const r = describeCreatedPass({
+      states: [
+        { start_date: '2026-01-01', expiration_date: '2026-03-26', active: false },
+        { start_date: '2026-08-20', expiration_date: '2026-11-12', active: true },
+      ],
+      on,
+    });
+    expect(r.startDate).toBe('2026-08-20');
+    expect(r.held).toBe(2);
+  });
+
+  it('survives a pass with no dates rather than computing a span from null', () => {
+    const r = describeCreatedPass({ states: [{ start_date: null, expiration_date: null }], on });
+    expect(r.granted).toBe(true);
+    expect(r.spanDays).toBeNull();
+    expect(r.startsOnCreationDay).toBe(false);
   });
 });

--- a/cloudflare-clubworx/probes/lib/write.mjs
+++ b/cloudflare-clubworx/probes/lib/write.mjs
@@ -14,26 +14,81 @@
  *      dry-run sample instead of a permanent record.
  *   2. Every contact must pass `assertProbeIdentity`. A write under anything
  *      resembling a real person is refused before the network is touched.
+ *
+ * ## Which shape the body takes
+ *
+ * Both, on request, because this repo has measured contradictory things.
+ * #49 created contacts through `POST /prospects` with a **JSON** body and got a
+ * 200 — that is the only contact-create shape anyone here has seen work. But
+ * the reference calls `POST /members` form-encoded, and both write paths this
+ * repo *has* measured since (`/memberships` and `/bookings`, #60) are
+ * form-encoded.
+ *
+ * staff-site#63 is the ticket that settles it, and it cannot settle it by
+ * guessing: a guess that lands still leaves a permanent contact. So the
+ * encoding is a parameter, it defaults to the measured shape, and an
+ * unrecognised value throws rather than falling back — a probe that reported a
+ * finding under a shape it did not actually send would be worse than no probe.
  */
 
 import { buildUrl, redact } from '../../src/request.js';
 import { rateLimitHeaders } from './report.mjs';
 import { assertProbeIdentity } from './identity.mjs';
 
-/** Fields that exist for the write-up and the cleanup list, not for Clubworx. */
-const BOOKKEEPING = new Set(['label', 'why']);
+/**
+ * Fields that exist for the write-up and the cleanup list, not for Clubworx.
+ *
+ * `withPlanOnCreate` is #63's marker for which contact tests the pass-on-create
+ * route. Like `label` and `why` it is a note the probe keeps for itself, and
+ * posting it would put a field Clubworx never asked for onto a record nobody
+ * can delete.
+ */
+const BOOKKEEPING = new Set(['label', 'why', 'withPlanOnCreate']);
 
+const ENCODINGS = {
+  json: {
+    contentType: 'application/json',
+    body: payload => JSON.stringify(payload),
+  },
+  form: {
+    contentType: 'application/x-www-form-urlencoded',
+    body: payload => new URLSearchParams(payload).toString(),
+  },
+};
+
+/**
+ * Drop the bookkeeping fields, and anything absent.
+ *
+ * The absent case is not tidiness. `URLSearchParams` stringifies whatever it is
+ * handed, so an optional field left `undefined` would travel as the literal
+ * text `undefined` and be written onto a record that cannot be deleted.
+ * `JSON.stringify` drops it silently, so the two encodings would disagree about
+ * what was sent — and only one of them would be in the write-up.
+ */
 const payloadOf = contact =>
-  Object.fromEntries(Object.entries(contact).filter(([name]) => !BOOKKEEPING.has(name)));
+  Object.fromEntries(
+    Object.entries(contact).filter(
+      ([name, value]) => !BOOKKEEPING.has(name) && value !== undefined && value !== null,
+    ),
+  );
 
 /**
  * @param {object} opts
  * @param {string} opts.accountKey
  * @param {boolean} [opts.live]  Must be explicitly true before anything is created.
+ * @param {'json'|'form'} [opts.encoding]  Defaults to `json` — #49's measured shape.
  * @param {typeof fetch} [opts.fetchImpl]
  * @returns {((path: string, contact: object) => Promise<object>) & { writes: number }}
  */
-export function createPoster({ accountKey, live = false, fetchImpl = fetch }) {
+export function createPoster({ accountKey, live = false, encoding = 'json', fetchImpl = fetch }) {
+  const shape = ENCODINGS[encoding];
+  if (!shape) {
+    throw new Error(
+      `unknown encoding ${JSON.stringify(encoding)} — expected 'json' or 'form'; ` +
+        'refusing to fall back, because the probe would then report a finding under a shape it did not send',
+    );
+  }
+
   const post = async (path, contact) => {
     const url = buildUrl({ path, accountKey });
     const safeUrl = redact(url, accountKey);
@@ -47,6 +102,7 @@ export function createPoster({ accountKey, live = false, fetchImpl = fetch }) {
     } catch (err) {
       return {
         url: safeUrl,
+        encoding,
         status: null,
         ms: 0,
         headers: {},
@@ -62,6 +118,7 @@ export function createPoster({ accountKey, live = false, fetchImpl = fetch }) {
     if (!live) {
       return {
         url: safeUrl,
+        encoding,
         status: null,
         ms: 0,
         headers: {},
@@ -81,8 +138,8 @@ export function createPoster({ accountKey, live = false, fetchImpl = fetch }) {
     try {
       const res = await fetchImpl(url, {
         method: 'POST',
-        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        headers: { Accept: 'application/json', 'Content-Type': shape.contentType },
+        body: shape.body(payload),
       });
       const ms = Math.round(performance.now() - started);
       const bodyText = await res.text();
@@ -99,6 +156,7 @@ export function createPoster({ accountKey, live = false, fetchImpl = fetch }) {
 
       return {
         url: safeUrl,
+        encoding,
         status: res.status,
         ms,
         headers: rateLimitHeaders(res.headers),
@@ -116,6 +174,7 @@ export function createPoster({ accountKey, live = false, fetchImpl = fetch }) {
       // list, not a reason to abandon the run.
       return {
         url: safeUrl,
+        encoding,
         status: null,
         ms: Math.round(performance.now() - started),
         headers: {},

--- a/cloudflare-clubworx/probes/lib/write.test.js
+++ b/cloudflare-clubworx/probes/lib/write.test.js
@@ -163,3 +163,166 @@ describe('createPoster', () => {
     expect(post.writes).toBe(0);
   });
 });
+
+// ── Encoding ────────────────────────────────────────────────────────────────
+//
+// #49 created contacts through `POST /prospects` with a JSON body and got a
+// 200, so JSON is the *measured* shape for a contact create. The reference
+// describes `POST /members` as form-encoded, and the two sibling write paths
+// this repo has measured — `/memberships` (#60) and `/bookings` (#60) — are
+// both form-encoded. staff-site#63 has to be able to try either without
+// guessing, because a guess that lands still creates a permanent contact.
+
+describe('createPoster encoding', () => {
+  it('defaults to JSON, so #49’s measured shape is what an unconfigured caller sends', async () => {
+    const calls = [];
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch(calls), live: true });
+
+    await post('members', contact);
+
+    expect(calls[0].init.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('sends a form-encoded body when asked for one', async () => {
+    const calls = [];
+    const post = createPoster({
+      accountKey: key,
+      fetchImpl: fakeFetch(calls),
+      live: true,
+      encoding: 'form',
+    });
+
+    await post('members', contact);
+
+    expect(calls[0].init.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    const sent = Object.fromEntries(new URLSearchParams(calls[0].init.body));
+    expect(sent).toMatchObject({
+      first_name: contact.first_name,
+      last_name: contact.last_name,
+      email: contact.email,
+      dob: contact.dob,
+    });
+  });
+
+  it('strips bookkeeping fields from a form body too', async () => {
+    const calls = [];
+    const post = createPoster({
+      accountKey: key,
+      fetchImpl: fakeFetch(calls),
+      live: true,
+      encoding: 'form',
+    });
+
+    await post('members', contact);
+
+    const sent = Object.fromEntries(new URLSearchParams(calls[0].init.body));
+    expect(sent.label).toBeUndefined();
+    expect(sent.why).toBeUndefined();
+  });
+
+  it('omits an absent field rather than sending the string "undefined"', async () => {
+    // URLSearchParams stringifies everything it is given, so an optional field
+    // left undefined would arrive as the literal text `undefined` and be
+    // written onto a permanent record. JSON.stringify drops it; this must too.
+    const calls = [];
+    const post = createPoster({
+      accountKey: key,
+      fetchImpl: fakeFetch(calls),
+      live: true,
+      encoding: 'form',
+    });
+
+    await post('members', { ...contact, membership_plan_id: undefined, phone: null });
+
+    const body = calls[0].init.body;
+    expect(body).not.toContain('undefined');
+    expect(body).not.toContain('membership_plan_id');
+    expect(body).not.toContain('phone');
+  });
+
+  it('carries an extra field such as membership_plan_id through both encodings', async () => {
+    // Question 3 of #63 is whether the pass can ride along on the create call.
+    // The poster must not have an allowlist that silently drops it.
+    const jsonCalls = [];
+    const formCalls = [];
+    const withPlan = { ...contact, membership_plan_id: 4242 };
+
+    await createPoster({ accountKey: key, fetchImpl: fakeFetch(jsonCalls), live: true })(
+      'members',
+      withPlan,
+    );
+    await createPoster({
+      accountKey: key,
+      fetchImpl: fakeFetch(formCalls),
+      live: true,
+      encoding: 'form',
+    })('members', withPlan);
+
+    expect(JSON.parse(jsonCalls[0].init.body).membership_plan_id).toBe(4242);
+    expect(Object.fromEntries(new URLSearchParams(formCalls[0].init.body)).membership_plan_id).toBe(
+      '4242',
+    );
+  });
+
+  it('refuses an unrecognised encoding instead of quietly falling back to JSON', async () => {
+    // A typo here would send a shape the probe did not choose and then report
+    // the result under the shape it thinks it sent — the write-up would record
+    // the wrong finding about a permanent write.
+    expect(() => createPoster({ accountKey: key, encoding: 'multipart' })).toThrow(/encoding/i);
+  });
+
+  it('still refuses an unauthorised identity when form-encoded', async () => {
+    const calls = [];
+    const post = createPoster({
+      accountKey: key,
+      fetchImpl: fakeFetch(calls),
+      live: true,
+      encoding: 'form',
+    });
+
+    const res = await post('members', { ...contact, last_name: 'Nguyen' });
+
+    expect(calls).toHaveLength(0);
+    expect(res.refused).toMatch(/Wayfinder/);
+  });
+
+  it('reports the encoding it used, so a sample says which shape was measured', async () => {
+    const post = createPoster({
+      accountKey: key,
+      fetchImpl: fakeFetch([]),
+      live: true,
+      encoding: 'form',
+    });
+    const res = await post('members', contact);
+
+    expect(res.encoding).toBe('form');
+  });
+});
+
+describe('createPoster bookkeeping', () => {
+  it('strips withPlanOnCreate, which is a probe’s note to itself', async () => {
+    // #63 marks one contact as the pass-on-create case. Posting that marker
+    // would write a field Clubworx never asked for onto a record that cannot
+    // be deleted — and it would sit there under a real-looking contact forever.
+    const calls = [];
+    const post = createPoster({ accountKey: key, fetchImpl: fakeFetch(calls), live: true });
+
+    await post('members', { ...contact, withPlanOnCreate: true });
+
+    expect(JSON.parse(calls[0].init.body).withPlanOnCreate).toBeUndefined();
+  });
+
+  it('strips it from a form body too', async () => {
+    const calls = [];
+    const post = createPoster({
+      accountKey: key,
+      fetchImpl: fakeFetch(calls),
+      live: true,
+      encoding: 'form',
+    });
+
+    await post('members', { ...contact, withPlanOnCreate: true });
+
+    expect(calls[0].init.body).not.toContain('withPlanOnCreate');
+  });
+});

--- a/cloudflare-clubworx/probes/run-60.mjs
+++ b/cloudflare-clubworx/probes/run-60.mjs
@@ -45,7 +45,8 @@ import { createBooker } from './lib/booking.mjs';
 import { createMembershipAssigner } from './lib/membership.mjs';
 import { loadAccountKey } from './lib/key.mjs';
 import { PROBE_CONTACTS, pickProbeRows, plusTag } from './lib/identity.mjs';
-import { redact } from './lib/request.mjs';
+import { redact } from '../src/request.js';
+import { errorMessageOf } from '../src/errors.js';
 import {
   summariseContacts,
   summariseBookings,
@@ -56,7 +57,6 @@ import {
   describeCancellation,
   findPlanByName,
   describeLeadTime,
-  errorMessageOf,
 } from './lib/report.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -156,7 +156,7 @@ async function resolvePlan(get) {
 }
 
 /** Question 1: does the contact hold an active pass, and assign one if not. */
-async function ensureMembership(get, assigner, { contact, plan, live }) {
+async function ensureMembership(get, assigner, { contact, plan, live, accountKey }) {
   rule('1. School Pass — does the contact hold one?');
 
   const before = await get('memberships', { contact_key: contact.contact_key });
@@ -186,7 +186,10 @@ async function ensureMembership(get, assigner, { contact, plan, live }) {
     start_date: isoDay(0),
   });
   const outcome = classifyWrite(res);
-  const reason = res.body ? redact(errorMessageOf(res.body) ?? '', ' ') : null;
+  // Was passing a NUL byte where the secret belongs: it satisfies redact's refuse-to-no-op guard
+  // while matching nothing, so the account key travelled through unredacted on
+  // the one path most likely to echo it back. Found by the #63 review.
+  const reason = res.body ? redact(errorMessageOf(res.body) ?? '', accountKey) : null;
 
   line(
     'assign',
@@ -490,6 +493,7 @@ async function main() {
     contact: subject,
     plan: plan.plan,
     live: WRITE,
+    accountKey,
   });
   await sleep(GAP_MS);
 

--- a/cloudflare-clubworx/probes/run-63.mjs
+++ b/cloudflare-clubworx/probes/run-63.mjs
@@ -1,0 +1,839 @@
+#!/usr/bin/env node
+/**
+ * staff-site#63 — can a contact be created as a member, and can the pass ride along?
+ *
+ *   node probes/run-63.mjs --dry-run              # the plan and every request, zero network
+ *   node probes/run-63.mjs                        # read-only: what already exists, and the plan
+ *   node probes/run-63.mjs --event=<id> --write   # creates up to 2 PERMANENT contacts, then books
+ *   node probes/run-63.mjs --encoding=form        # force the body shape instead of discovering it
+ *   node probes/run-63.mjs --dev-vars=<path>
+ *
+ * **This is the gate on the whole #46 build.** `POST /api/v2/members` is the one
+ * write in the chain nobody has run. #60 proved the member + School Pass route
+ * end to end, but it did not *create* its members — they were converted from
+ * prospects by hand in the Clubworx UI beforehand. #49 created contacts, but
+ * through `POST /api/v2/prospects`. So every claim about `POST /members` in the
+ * design spec comes from `uj/automations/ClubworxAPI_docs.md` and nothing else,
+ * and that reference has already been wrong twice on this map — #50's `DELETE`
+ * verdict, and the 50-of-57 plan truncation.
+ *
+ * The questions, from #63:
+ *
+ *   1. Does `POST /api/v2/members` succeed?
+ *   2. Is the resulting contact bookable once it holds an active School Pass?
+ *   3. Does `membership_plan_id` on create produce a usable pass?
+ *   4. If (3) works, what `start_date` does the pass get?
+ *
+ * ⚠️ What this probe can leave behind, in descending order of permanence:
+ *
+ *   - **Up to two contacts.** Clubworx exposes no delete for them. They are
+ *     `MEMBER_PROBE_CONTACTS` and nothing else — the guard in `lib/write.mjs`
+ *     refuses anything outside the Wayfinder identity before the network is
+ *     touched. E is attempted only if D is *seen to exist*, so an endpoint that
+ *     refuses costs one contact rather than two.
+ *   - **Up to two School Passes.** `POST /memberships` has no delete either. A
+ *     pass lapses at `expiration_date`; it cannot be removed. Searched for
+ *     first, and an active one is reused.
+ *   - **Bookings**, which are the reversible part: #60 measured
+ *     `DELETE /bookings/:id` reversing cleanly, given `contact_key` in a
+ *     form-encoded body. This probe cancels what it books and re-reads to check.
+ *
+ * Two rules shape the code more than anything else:
+ *
+ *   **Verify by re-reading, never by the status code.** #49 found a successful
+ *   create answers `200` where a reader expects `201`; #50 read a malformed
+ *   request's `401` as a permissions wall. Every verdict below comes from a
+ *   subsequent search. `describeMemberCreation` keeps the status as a single
+ *   boolean recording whether Clubworx told the truth — which is a finding in
+ *   its own right, and not the same question as what is in the database.
+ *
+ *   **Search all three status views.** #49 established the three contact
+ *   endpoints are disjoint views by status, and #60 was bitten on 2026-08-18 by
+ *   searching only `/prospects` after somebody converted its contacts. A probe
+ *   that looked only in `/members` could report "absent" about a contact that
+ *   exists — and then create a second, permanently.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createGetter } from './lib/http.mjs';
+import { createPoster } from './lib/write.mjs';
+import { createBooker } from './lib/booking.mjs';
+import { createMembershipAssigner } from './lib/membership.mjs';
+import { loadAccountKey } from './lib/key.mjs';
+import { MEMBER_PROBE_CONTACTS, pickProbeRows, plusTag } from './lib/identity.mjs';
+import { redact } from '../src/request.js';
+import { errorMessageOf } from '../src/errors.js';
+import {
+  summariseContacts,
+  summariseBookings,
+  summariseMemberships,
+  classifyWrite,
+  describeMemberCreation,
+  describeCreatedPass,
+  describeCancellation,
+  findPlanByName,
+  describeLeadTime,
+  summariseEvents,
+} from './lib/report.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(HERE, 'out');
+
+const args = process.argv.slice(2);
+const flag = name => args.find(a => a.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+
+const DRY_RUN = args.includes('--dry-run');
+const WRITE = args.includes('--write');
+const EVENT_ID = flag('event') ?? null;
+const PLAN_NAME = flag('plan') ?? 'School Pass';
+const FORCED_ENCODING = flag('encoding') ?? null;
+const DEV_VARS = flag('dev-vars') || path.join(HERE, '..', '.dev.vars');
+
+/** The three disjoint status views (#49). Searching one of them is not searching. */
+const CONTACT_TYPES = ['prospects', 'members', 'non_attending_contacts'];
+
+const TAG_EMAILS = [...new Set(MEMBER_PROBE_CONTACTS.map(c => c.email))];
+
+/**
+ * Which body shapes to try, in order.
+ *
+ * JSON first because it is the only contact-create shape anyone here has
+ * *measured* — #49 sent it to `POST /prospects` and got a 200. The reference
+ * calls `POST /members` form-encoded, and the two write paths #60 measured
+ * (`/memberships`, `/bookings`) are form-encoded, so the reference may well be
+ * right; it has simply not earned being believed on this map.
+ *
+ * The fallback is safe only because a re-read sits between the two attempts. A
+ * blind retry of a create is how you get a permanent duplicate out of a request
+ * that actually worked.
+ */
+const KNOWN_ENCODINGS = ['json', 'form'];
+const ENCODINGS_TO_TRY = FORCED_ENCODING ? [FORCED_ENCODING] : KNOWN_ENCODINGS;
+
+// `createPoster` refuses an unknown encoding, but it is not constructed until
+// after the survey and the plan lookup — so a typo in `--encoding` would be
+// paid for with a dozen requests and then throw. Checked at the boundary, where
+// it costs nothing.
+if (FORCED_ENCODING && !KNOWN_ENCODINGS.includes(FORCED_ENCODING)) {
+  console.error(
+    `unknown --encoding=${FORCED_ENCODING} — expected ${KNOWN_ENCODINGS.join(' or ')}`,
+  );
+  process.exit(1);
+}
+
+/** Big enough to see past the default 50, which silently hid this plan (#60). */
+const PAGE_SIZE = 200;
+const WINDOW_DAYS = 21;
+
+/** ~75 requests/minute, one in flight — the pace #51 measured as clean. */
+const GAP_MS = 800;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const line = (label, value) => console.log(`  ${label.padEnd(38)} ${value}`);
+const rule = title => console.log(`\n── ${title} ${'─'.repeat(Math.max(0, 58 - title.length))}`);
+
+/**
+ * The safe, human-readable reason a call failed — or null if it did not.
+ *
+ * One definition, because the alternative was three — and two of those three
+ * passed the wrong thing as the secret. `redact(message, x)` replaces every
+ * occurrence of `x`, so handing it a space replaces the spaces and leaves the
+ * account key intact; `run-60.mjs` handed it a NUL byte, which matches nothing
+ * at all and quietly redacts nothing. Both satisfy redact's "refusing to no-op"
+ * guard while doing the opposite of redacting, and both only surface on an
+ * error path — the one place a key is most likely to be echoed back. Found by
+ * the review on this ticket, and fixed in `run-60.mjs` too.
+ *
+ * @param {{body?: unknown}} sample
+ * @param {string} accountKey
+ */
+const reasonOf = (sample, accountKey) => {
+  const message = errorMessageOf(sample?.body);
+  return message ? redact(message, accountKey) : null;
+};
+
+const isoDay = offsetDays => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+};
+
+/**
+ * Find every probe contact, in whichever status view holds it.
+ *
+ * Returns rows tagged with the endpoint they were found in — which is not
+ * bookkeeping here but part of question 1's answer. Whether `POST /members`
+ * produces something that actually appears in `/members` is exactly the sort of
+ * thing the reference asserts and nobody has watched.
+ */
+async function findAll(get) {
+  const found = [];
+  for (const type of CONTACT_TYPES) {
+    for (const email of TAG_EMAILS) {
+      const res = await get(type, { email });
+      const rows = pickProbeRows(res.body);
+      const summary = summariseContacts(res.body, rows.map(r => r.contact_key));
+      if (summary.strangers) {
+        line(
+          `${type} +${plusTag(email)}`,
+          `${summary.strangers} row(s) not ours (counted, dropped)`,
+        );
+      }
+      found.push(...rows.map(r => ({ ...r, status_endpoint: type })));
+      await sleep(GAP_MS);
+    }
+  }
+  const byKey = new Map(found.map(row => [row.contact_key, row]));
+  return [...byKey.values()];
+}
+
+/** The rows matching one wanted contact. Surname *and* email — #49's D/E share A's address. */
+const matching = (rows, contact) =>
+  rows.filter(r => r.last_name === contact.last_name && r.email === contact.email);
+
+/** Question 0, in effect: what is already there, so a re-run costs nothing permanent. */
+async function survey(get) {
+  rule('0. What already exists — search before any create');
+
+  const rows = await findAll(get);
+  for (const contact of MEMBER_PROBE_CONTACTS) {
+    const mine = matching(rows, contact);
+    line(
+      `${contact.label} ${contact.last_name}`,
+      mine.length
+        ? `EXISTS in ${mine.map(r => r.status_endpoint).join(', ')} · ${mine[0].contact_key}`
+        : 'not present — would be created',
+    );
+  }
+  return rows;
+}
+
+/**
+ * Turn the plan *name* into an id — and refuse to guess.
+ *
+ * Lifted wholesale from #60's reasoning: on 2026-08-18 the default page
+ * returned exactly 50 plans of 57 and `School Pass` was among the seven that
+ * never arrived, producing a "plan not found" that would have been entirely
+ * wrong. A full page is treated as a truncated one.
+ */
+async function resolvePlan(get) {
+  rule(`Resolve the membership plan by name — "${PLAN_NAME}"`);
+
+  const res = await get('membership_plans', { page_size: PAGE_SIZE });
+  const found = findPlanByName(res.body, PLAN_NAME, { requestedPageSize: PAGE_SIZE });
+
+  line('plans returned', `HTTP ${res.status} · ${found.count}`);
+  if (found.truncated) {
+    line('⚠️  page came back full', `${found.count} = page_size — the list is truncated`);
+  }
+  if (found.ambiguous) {
+    line('⚠️  ambiguous', `${found.matches} plans named "${PLAN_NAME}" — refusing to pick one`);
+  }
+  if (found.plan) {
+    line('resolved', `id ${found.plan.id} · duration ${found.plan.membership_duration ?? 'n/a'}`);
+    line(
+      'cost',
+      `upfront ${found.plan.upfront_payment_amount ?? 'n/a'} · recurring ${found.plan.recurring_payment_amount ?? 'none'}`,
+    );
+  } else {
+    line('resolved', 'NOT FOUND');
+  }
+
+  return { ...found, status: res.status };
+}
+
+/**
+ * Create one contact through `POST /members`, and find out what actually happened.
+ *
+ * The loop over encodings is the delicate part. Between the two attempts sits a
+ * full three-view re-read, so the second attempt only ever runs against a
+ * database that has been *observed* not to contain the contact. Without that,
+ * a create that succeeded while answering something unreadable would be retried
+ * into a permanent duplicate.
+ */
+async function createMember(get, { contact, accountKey, planId, live, existing }) {
+  const already = matching(existing, contact);
+  if (already.length) {
+    line(
+      `${contact.label} create`,
+      `SKIPPED — already exists (${already[0].contact_key}), nothing permanent to add`,
+    );
+    return {
+      label: contact.label,
+      reused: true,
+      contactKey: already[0].contact_key,
+      statusEndpoint: already[0].status_endpoint,
+      attempts: [],
+      creation: { verdict: 'created', landed: true, contactKey: already[0].contact_key },
+    };
+  }
+
+  const payload = { ...contact, ...(planId ? { membership_plan_id: planId } : {}) };
+  const attempts = [];
+  let creation = null;
+  let rows = existing;
+
+  for (const encoding of ENCODINGS_TO_TRY) {
+    const post = createPoster({ accountKey, live, encoding });
+    const res = await post('members', payload);
+    const outcome = classifyWrite(res);
+    const reason = reasonOf(res, accountKey);
+
+    line(
+      `${contact.label} POST /members (${encoding})`,
+      res.refused
+        ? `REFUSED locally: ${res.refused}`
+        : res.dryRun
+          ? `would send ${JSON.stringify(res.wouldSend)}`
+          : `HTTP ${res.status ?? 'n/a'} ${outcome.outcome}` +
+            (reason ? ` · "${reason}"` : '') +
+            (res.bodyText ? ` · ${res.bodyText.slice(0, 160)}` : ''),
+    );
+
+    if (res.dryRun) {
+      attempts.push({ encoding, dryRun: true });
+      return { label: contact.label, reused: false, dryRun: true, attempts, creation: null };
+    }
+
+    await sleep(GAP_MS);
+
+    // The verdict. Not the status code — the database.
+    rows = await findAll(get);
+    const mine = matching(rows, contact);
+    creation = describeMemberCreation({ create: res, found: mine });
+
+    attempts.push({
+      encoding,
+      status: res.status ?? null,
+      error: res.error ?? null,
+      refused: res.refused ?? null,
+      reason,
+      bodyText: res.bodyText ?? null,
+      verdict: creation.verdict,
+    });
+
+    line(`${contact.label} re-read says`, creation.summary);
+    if (creation.statusAgrees === false && creation.verdict !== 'refused') {
+      line('  ⚠️  status vs database', 'the status code did not describe what happened');
+    }
+
+    if (creation.landed) {
+      const where = mine.map(r => r.status_endpoint).join(', ');
+      line(`${contact.label} appears in`, where || '(nowhere — see above)');
+      return {
+        label: contact.label,
+        reused: false,
+        contactKey: creation.contactKey,
+        statusEndpoint: mine[0]?.status_endpoint ?? null,
+        appearsIn: mine.map(r => r.status_endpoint),
+        attempts,
+        creation,
+      };
+    }
+
+    if (ENCODINGS_TO_TRY.length > 1 && encoding !== ENCODINGS_TO_TRY[ENCODINGS_TO_TRY.length - 1]) {
+      line('  retrying', 'the re-read found nothing, so a second shape cannot duplicate');
+    }
+  }
+
+  return { label: contact.label, reused: false, contactKey: null, attempts, creation };
+}
+
+/** What pass, if any, the contact now holds — and on whose terms. */
+async function readPass(get, { contactKey, planId, on, requested = null }) {
+  const res = await get('memberships', { contact_key: contactKey });
+  const held = summariseMemberships(res.body, planId, { on });
+  const pass = describeCreatedPass({ states: held.planStates, on, requested });
+  return { pass, held, status: res.status };
+}
+
+/** Question 2, first half: the measured two-call route, on a contact made by /members. */
+async function assignPass(get, assigner, { contact, planId, live }) {
+  rule(`${contact.label} — School Pass through the measured two-call route`);
+
+  const before = await readPass(get, { contactKey: contact.contactKey, planId, on: isoDay(0) });
+  line('holds this plan already', `${before.held.holdsPlan} · active ${before.held.holdsActivePlan}`);
+  await sleep(GAP_MS);
+
+  // Memberships have no delete. A re-run that skipped this would pile up
+  // permanent duplicates, and an *expired* pass is still a held plan — treating
+  // that as good enough would leave the booking to fail for a reason already seen.
+  if (before.held.holdsActivePlan) {
+    line('assign', 'SKIPPED — an active pass is already held');
+    return { reused: true, before: before.pass, after: before.pass, assigned: null };
+  }
+
+  const startDate = isoDay(0);
+  const res = await assigner.assign({
+    contact_key: contact.contactKey,
+    membership_plan_id: planId,
+    start_date: startDate,
+  });
+  const outcome = classifyWrite(res);
+  const reason = reasonOf(res, accountKey);
+
+  line(
+    'assign',
+    res.refused
+      ? `REFUSED locally: ${res.refused}`
+      : res.dryRun
+        ? `would POST ${JSON.stringify(res.wouldSend)}`
+        : `HTTP ${res.status ?? 'n/a'} ${outcome.outcome}` + (reason ? ` · "${reason}"` : ''),
+  );
+  if (res.dryRun) return { dryRun: true };
+  await sleep(GAP_MS);
+
+  const after = await readPass(get, {
+    contactKey: contact.contactKey,
+    planId,
+    on: isoDay(0),
+    requested: startDate,
+  });
+  line('pass now', after.pass.summary);
+  line('honoured the start_date we sent', String(after.pass.honouredRequest));
+
+  return {
+    reused: false,
+    requested: startDate,
+    assigned: { status: res.status ?? null, outcome: outcome.outcome, reason },
+    before: before.pass,
+    after: after.pass,
+  };
+}
+
+/** Questions 3 and 4: did the pass ride along on the create, and on what dates? */
+async function inspectRiderPass(get, { contact, planId }) {
+  rule(`${contact.label} — questions 3 and 4: did the pass ride along on the create?`);
+
+  const { pass, held, status } = await readPass(get, {
+    contactKey: contact.contactKey,
+    planId,
+    on: isoDay(0),
+  });
+
+  line('memberships held', `HTTP ${status} · ${held.count}`);
+  line('Q3  pass granted by the create', `${pass.granted} · usable now: ${pass.active}`);
+  if (pass.granted) {
+    line('Q4  start_date Clubworx chose', `${pass.startDate ?? 'n/a'}`);
+    line('    starts on the creation day', String(pass.startsOnCreationDay));
+    line('    expires', `${pass.expirationDate ?? 'n/a'} · span ${pass.spanDays ?? 'n/a'}d`);
+  }
+  line('fields returned', held.fields.join(', ') || '(none)');
+
+  return { pass, count: held.count };
+}
+
+/** The event, before anything is booked into it. */
+async function inspectEvent(get, eventId) {
+  rule('The event — capacity and lead time');
+
+  const res = await get('events', {
+    event_starts_after: isoDay(-1),
+    event_ends_before: isoDay(WINDOW_DAYS),
+    page_size: PAGE_SIZE,
+  });
+  const summary = summariseEvents(res.body);
+  const row = Array.isArray(res.body)
+    ? res.body.find(e => String(e.event_id) === String(eventId))
+    : null;
+
+  if (!row) {
+    line('event', `${eventId} NOT in the next ${WINDOW_DAYS} days (${summary.count} events seen)`);
+    return { found: false, count: summary.count };
+  }
+
+  const lead = describeLeadTime(row.event_start_at);
+  line('event', `${row.event_id} · ${row.event_name}`);
+  line('starts', `${row.event_start_at} (${lead.hoursAhead}h away)`);
+  line('capacity', `spaces_available ${row.spaces_available} · event_full ${row.event_full}`);
+  if (lead.past) line('⚠️  lead time', 'this event has already started');
+  else if (lead.withinLeadTime) line('⚠️  lead time', `inside ${lead.minLeadHours}h — may be refused`);
+
+  return {
+    found: true,
+    event_id: row.event_id,
+    event_name: row.event_name,
+    event_start_at: row.event_start_at,
+    spaces_available: row.spaces_available,
+    event_full: row.event_full,
+    lead,
+  };
+}
+
+/**
+ * Question 2, the part that matters: does a contact made by `POST /members` book?
+ *
+ * Books, verifies by re-reading the contact's bookings, then cancels and
+ * verifies that too. The booking is the only thing here that can be taken back,
+ * so it is the only thing this probe is willing to leave undone by accident.
+ */
+async function probeBooking(get, booker, { contact, eventId, accountKey }) {
+  rule(`${contact.label} — question 2: does it book?`);
+
+  const count = async () => {
+    const res = await get('bookings', { contact_key: contact.contactKey });
+    return summariseBookings(res.body, [contact.contactKey]);
+  };
+
+  const before = await count();
+  line('bookings held before', String(before.ours));
+  await sleep(GAP_MS);
+
+  const res = await booker.book({ contact_key: contact.contactKey, event_id: eventId });
+  const outcome = classifyWrite(res);
+  line(
+    'book',
+    res.refused
+      ? `REFUSED locally: ${res.refused}`
+      : res.dryRun
+        ? `would POST ${JSON.stringify(res.wouldSend)}`
+        : `HTTP ${res.status ?? 'n/a'} ${outcome.outcome}` +
+          (res.bookingId ? ` · booking ${res.bookingId}` : '') +
+          (reasonOf(res, accountKey) ? ` · "${reasonOf(res, accountKey)}"` : ''),
+  );
+  if (res.dryRun) return { dryRun: true };
+  await sleep(GAP_MS);
+
+  const afterBook = await count();
+  line('bookings held after', String(afterBook.ours));
+  // The status said something; this is what the database says.
+  const booked = afterBook.ours > before.ours;
+  line('Q2  verdict from the re-read', booked ? 'BOOKED' : 'not booked');
+  await sleep(GAP_MS);
+
+  const cancellations = [];
+  if (res.bookingId) {
+    const cancelled = await booker.cancel(res.bookingId);
+    cancellations.push({
+      id: String(res.bookingId),
+      status: cancelled.status ?? null,
+      refused: cancelled.refused ?? null,
+      reason: reasonOf(cancelled, accountKey),
+    });
+    line(
+      `cancel ${res.bookingId}`,
+      cancelled.refused
+        ? `REFUSED locally: ${cancelled.refused}`
+        : `HTTP ${cancelled.status ?? 'n/a'}` + (reasonOf(cancelled, accountKey) ? ` · "${reasonOf(cancelled, accountKey)}"` : ''),
+    );
+    await sleep(GAP_MS);
+  }
+
+  const afterCancel = cancellations.length ? await count() : null;
+  if (afterCancel) line('bookings held after cancelling', String(afterCancel.ours));
+
+  const reversal = describeCancellation({
+    cancel: cancellations[cancellations.length - 1] ?? null,
+    countBefore: afterBook.ours,
+    countAfter: afterCancel?.ours ?? null,
+  });
+
+  return {
+    dryRun: false,
+    booked,
+    outcome: outcome.outcome,
+    status: res.status ?? null,
+    reason: reasonOf(res, accountKey),
+    bookingId: res.bookingId ?? null,
+    counts: {
+      before: before.ours,
+      afterBook: afterBook.ours,
+      afterCancel: afterCancel?.ours ?? null,
+    },
+    cancellations,
+    reversal,
+    leftBehind: (afterCancel?.ours ?? afterBook.ours) > before.ours,
+  };
+}
+
+function printDryRun() {
+  console.log('--dry-run: no requests issued, nothing written.\n');
+
+  let n = 0;
+  const req = (verb, p, params) =>
+    console.log(
+      `  ${String(++n).padStart(2)}. ${verb.padEnd(6)} /${p}${params ? `?${params}` : ''}`,
+    );
+  const sweep = () => {
+    for (const type of CONTACT_TYPES) for (const email of TAG_EMAILS) req('GET', type, `email=${email}`);
+  };
+
+  console.log('0. Search all three status views before creating anything (#49):');
+  sweep();
+
+  console.log('\nResolve the plan by name:');
+  req('GET', 'membership_plans', `page_size=${PAGE_SIZE}`);
+
+  console.log(`\nQ1. Create D — plain, encodings tried in order: ${ENCODINGS_TO_TRY.join(' then ')}`);
+  for (const encoding of ENCODINGS_TO_TRY) {
+    req('POST', 'members');
+    console.log(`        ${encoding}-encoded · { first_name, last_name, dob, email }`);
+    console.log('        ⚠️ PERMANENT — contacts have no delete endpoint');
+    console.log('        then re-read all three views before any retry:');
+    sweep();
+    console.log('        (a second shape is only sent if the re-read found nothing)');
+  }
+
+  console.log('\nQ2a. Give D a pass through the measured two-call route:');
+  req('GET', 'memberships', 'contact_key=<D>');
+  req('POST', 'memberships');
+  console.log(`        { contact_key: <D>, membership_plan_id: <"${PLAN_NAME}">, start_date: ${isoDay(0)} }`);
+  console.log('        ⚠️ PERMANENT — memberships have no delete endpoint');
+  req('GET', 'memberships', 'contact_key=<D>');
+
+  console.log('\nQ3–4. Create E with membership_plan_id on the create call:');
+  console.log('        ONLY IF D was seen to exist — a refusing endpoint costs one contact, not two');
+  req('POST', 'members');
+  console.log('        ⚠️ PERMANENT — contact *and* possibly a pass, neither deletable');
+  sweep();
+  req('GET', 'memberships', 'contact_key=<E>');
+
+  if (!EVENT_ID) {
+    console.log('\nQ2b. Booking — NOTHING PLANNED. Pass --event=<id>.');
+  } else {
+    console.log(`\nQ2b. Book D and E into event ${EVENT_ID}, then cancel both:`);
+    req('GET', 'events', `event_starts_after=${isoDay(-1)}&event_ends_before=${isoDay(WINDOW_DAYS)}&page_size=${PAGE_SIZE}`);
+    for (const who of ['D', 'E']) {
+      req('GET', 'bookings', `contact_key=<${who}>`);
+      req('POST', 'bookings');
+      req('GET', 'bookings', `contact_key=<${who}>`);
+      req('DELETE', 'bookings/<id>');
+      console.log('        body: account_key=…&contact_key=…  ← reversible, measured in #60');
+      req('GET', 'bookings', `contact_key=<${who}>`);
+    }
+  }
+
+  console.log(`\n~${n} requests, paced at one per ${GAP_MS}ms (~${Math.round(60_000 / GAP_MS)}/min), per #51.`);
+  console.log(
+    'Every contact is searched for first, so a re-run creates nothing.\n' +
+      '⚠️  A first run creates up to TWO PERMANENT contacts and up to TWO PERMANENT passes.\n' +
+      '    ACCESS.md §4: the #49 three-contact authorisation is SPENT. This needs a new one.\n',
+  );
+}
+
+async function main() {
+  if (DRY_RUN) {
+    printDryRun();
+    return;
+  }
+
+  // `probes/README.md`: "**`--write` without `--event=<id>` stops.**" That rule
+  // was written for the booking probes, but it bites hardest here. Questions 1,
+  // 3 and 4 need no event, so this script would happily spend two permanent
+  // contacts and two permanent passes and then print "booking SKIPPED" — buying
+  // permanence and leaving question 2, the one that decides whether any of it
+  // is usable, unanswered. Refused before the key is even read.
+  if (WRITE && !EVENT_ID) {
+    console.error(
+      'refusing to write without --event=<id>.\n' +
+        '  Questions 1, 3 and 4 need no event, but question 2 does, and a --write run\n' +
+        '  creates permanent contacts and permanent passes either way. Run read-only\n' +
+        '  first to list candidates, then pass the event you chose.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const accountKey = loadAccountKey(DEV_VARS);
+  const get = createGetter({ accountKey });
+
+  console.log(
+    WRITE
+      ? '⚠️  staff-site#63 probe — WRITES ENABLED, against production Clubworx'
+      : 'staff-site#63 probe — read-only. Pass --event=<id> --write to create and book.',
+  );
+
+  const record = {
+    probe: 'staff-site#63',
+    ranAt: new Date().toISOString(),
+    write: WRITE,
+    encodingsTried: ENCODINGS_TO_TRY,
+  };
+
+  const existing = await survey(get);
+
+  const plan = await resolvePlan(get);
+  record.plan = {
+    name: PLAN_NAME,
+    id: plan.plan?.id ?? null,
+    duration: plan.plan?.membership_duration ?? null,
+    matches: plan.matches,
+    truncated: plan.truncated,
+    count: plan.count,
+  };
+  if (!plan.plan) {
+    rule('Stopped');
+    console.log(
+      `  Could not resolve "${PLAN_NAME}" to exactly one plan` +
+        (plan.truncated ? ' — and the page came back full, so the list is truncated.' : '.'),
+    );
+    process.exitCode = 1;
+    return;
+  }
+  await sleep(GAP_MS);
+
+  const [wantD, wantE] = MEMBER_PROBE_CONTACTS;
+
+  rule('1. Question 1 — does POST /members create a contact?');
+  const d = await createMember(get, {
+    contact: wantD,
+    accountKey,
+    planId: null,
+    live: WRITE,
+    existing,
+  });
+  record.d = d;
+
+  const save = () => {
+    mkdirSync(OUT_DIR, { recursive: true });
+    const at = path.join(OUT_DIR, `63-${record.ranAt.replace(/[:.]/g, '-')}.json`);
+    writeFileSync(at, JSON.stringify(record, null, 2));
+    console.log(`\n${get.calls} reads. Summary written to probes/out/${path.basename(at)}`);
+  };
+
+  // "Nothing was sent" and "something was sent and did not land" are opposite
+  // findings, and only one of them is an answer to question 1. Collapsing them
+  // would let a read-only run report that POST /members does not work.
+  if (d.dryRun) {
+    rule('Read-only — stopped before the first create');
+    console.log(
+      '  Nothing was sent, so question 1 is still open. Everything above is a read.\n' +
+        '  Re-run with --write to answer it — and read ACCESS.md §4 first: the #49\n' +
+        '  three-contact authorisation is spent, and D and E are a new decision.',
+    );
+    save();
+    return;
+  }
+
+  // The gate. If D is not in the database, E would be a second permanent
+  // contact bought for nothing.
+  if (!d.contactKey) {
+    rule('Stopped — question 1 answered, and the answer closes the rest');
+    console.log(
+      '  POST /members did not produce a contact under any shape tried.\n' +
+        '  E is NOT attempted: it would cost a second permanent record to learn nothing new.\n' +
+        "  The spec's fallback stands — create via POST /prospects (#49) and let the pass move them.",
+    );
+    save();
+    process.exitCode = 1;
+    return;
+  }
+  await sleep(GAP_MS);
+
+  const assigner = createMembershipAssigner({
+    accountKey,
+    allowedContactKeys: [d.contactKey],
+    live: WRITE,
+  });
+  record.dPass = await assignPass(get, assigner, {
+    contact: d,
+    planId: plan.plan.id,
+    live: WRITE,
+  });
+  await sleep(GAP_MS);
+
+  rule('2. Questions 3 and 4 — can the pass ride along on the create?');
+  const rowsNow = await findAll(get);
+  const e = await createMember(get, {
+    contact: wantE,
+    accountKey,
+    planId: plan.plan.id,
+    live: WRITE,
+    existing: rowsNow,
+  });
+  record.e = e;
+
+  if (e.contactKey) {
+    await sleep(GAP_MS);
+    record.ePass = await inspectRiderPass(get, { contact: e, planId: plan.plan.id });
+  }
+
+  if (EVENT_ID) {
+    await sleep(GAP_MS);
+    record.event = await inspectEvent(get, EVENT_ID);
+    await sleep(GAP_MS);
+
+    const subjects = [d, e].filter(c => c?.contactKey);
+    const booker = createBooker({
+      accountKey,
+      allowedContactKeys: subjects.map(c => c.contactKey),
+      live: WRITE,
+    });
+
+    record.bookings = {};
+    for (const subject of subjects) {
+      record.bookings[subject.label] = await probeBooking(get, booker, {
+        contact: subject,
+        eventId: EVENT_ID,
+        accountKey,
+      });
+      await sleep(GAP_MS);
+    }
+    record.bookerWrites = booker.book.writes + booker.cancel.writes;
+  } else {
+    rule('Question 2 — booking SKIPPED');
+    console.log('  No --event=<id> given. The event is never chosen automatically.');
+  }
+
+  rule('Verdicts');
+  line('Q1  POST /members creates a contact', `${Boolean(d.contactKey)} · ${d.creation?.verdict ?? 'n/a'}`);
+  if (d.attempts.length) {
+    const worked = d.attempts.find(a => a.verdict === 'created');
+    line('    body shape that worked', worked ? worked.encoding : 'none');
+    for (const a of d.attempts) line(`    ${a.encoding}`, `HTTP ${a.status ?? 'n/a'} → ${a.verdict}`);
+  }
+  if (d.appearsIn) line('    it appears in', d.appearsIn.join(', '));
+  if (record.dPass?.after) line('Q2  D holds an active pass', String(record.dPass.after.active));
+  if (record.bookings?.D) line('Q2  D books', String(record.bookings.D.booked));
+  line('Q3  pass rides along on create', String(record.ePass?.pass.granted ?? 'not reached'));
+  if (record.ePass?.pass.granted) {
+    line('    usable now', String(record.ePass.pass.active));
+    line('Q4  start_date it received', `${record.ePass.pass.startDate ?? 'n/a'}`);
+    line('    = the creation day', String(record.ePass.pass.startsOnCreationDay));
+    line('    span', `${record.ePass.pass.spanDays ?? 'n/a'}d vs two-call ${record.dPass?.after?.spanDays ?? 'n/a'}d`);
+  }
+  if (record.bookings?.E) line('Q2  E books', String(record.bookings.E.booked));
+
+  const permanent = [d, e].filter(c => c?.contactKey && !c.reused);
+  const passes = [
+    record.dPass?.reused === false ? { label: 'D', pass: record.dPass.after } : null,
+    record.ePass?.pass?.granted ? { label: 'E', pass: record.ePass.pass } : null,
+  ].filter(Boolean);
+
+  if ((permanent.length || passes.length) && WRITE) {
+    rule('⚠️  Permanent — record these in ACCESS.md §4');
+    for (const c of permanent) {
+      console.log(`  contact ${c.label}  ${c.contactKey}  (${c.appearsIn?.join(', ') ?? 'unknown view'})`);
+    }
+    // A pass is as undeletable as a contact and is far easier to forget, because
+    // nothing on the contact's row shouts about it. #60's write-up records its
+    // one pass by id and expiry; this does the same for both of these.
+    for (const { label, pass } of passes) {
+      console.log(
+        `  pass    ${label}  ${PLAN_NAME} · start ${pass.startDate ?? 'n/a'} · expires ${pass.expirationDate ?? 'n/a'}`,
+      );
+    }
+    console.log(
+      '  Neither contacts nor memberships have a delete endpoint. A pass lapses at its\n' +
+        '  expiration_date; a contact must be removed by hand in the Clubworx UI.',
+    );
+  }
+
+  const stranded = Object.entries(record.bookings ?? {}).filter(([, b]) => b?.leftBehind);
+  if (stranded.length) {
+    rule('⚠️  Cleanup — could not undo');
+    for (const [label] of stranded) {
+      console.log(`  ${label} still holds a booking on event ${EVENT_ID}. Clear it in the Clubworx UI.`);
+    }
+  }
+
+  save();
+}
+
+main().catch(err => {
+  console.error(`probe failed: ${err.message}`);
+  process.exitCode = 1;
+});

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -15,8 +15,9 @@ This spec describes a staff-portal page that takes the pasted list and does it
 in about four minutes.
 
 > **Every claim here about Clubworx behaviour was measured**, in
-> `cloudflare-clubworx/probes/`, against production, on 2026-08-17/18. Where
-> something is inferred from the reference rather than observed, it says so.
+> `cloudflare-clubworx/probes/`, against production, on 2026-08-17/18 and
+> 2026-08-20 (#63, the member-creation gate). Where something is inferred from
+> the reference rather than observed, it says so.
 > The reference has been wrong twice on this effort — see
 > [Two things the reference got wrong](#two-things-the-reference-got-wrong) —
 > so the distinction is not pedantry.
@@ -55,8 +56,11 @@ School Session.**
 paste ──► parse ──► match against Clubworx
                           │
                           ├─ found  ──► (re-read membership) ──► ensure School Pass ──► book ×N
-                          └─ new    ──► create contact ──────► assign School Pass ──► book ×N
+                          └─ new    ──► create contact WITH the pass ─────────────────► book ×N
 ```
+
+A **found** student needs the pass assigned separately; a **new** one gets it in
+the create call. Both measured — see below.
 
 ### Why the original prospect route failed
 
@@ -77,48 +81,71 @@ Two consequences outlived the route change:
 2. **An error message can point confidently at the wrong mechanism.** This is
    why §11 never paraphrases an unrecognised refusal.
 
-### The replacement, measured end to end in #60
+### The replacement, measured end to end in #60 and #63
 
 | Step | Call | Status |
 |---|---|---|
-| Create contact | `POST /api/v2/members` | **Documented, not measured** — see below |
-| Assign pass | `POST /api/v2/memberships` | **Measured.** Form-encoded, with `account_key`, `contact_key`, `membership_plan_id`, `start_date`. **200**; active immediately |
+| Create contact | `POST /api/v2/members` | **Measured (#63).** **JSON**, with `account_key` in the query string. **200**; lands straight in `/members`. Takes `membership_plan_id`, so the next row is optional for new students |
+| Assign pass | `POST /api/v2/memberships` | **Measured.** Form-encoded, with `account_key`, `contact_key`, `membership_plan_id`, `start_date`. **200**; active immediately. Needed only for contacts that **already existed** — see below |
 | Book | `POST /api/v2/bookings` | **Measured.** **200**; a second identical call is refused by Clubworx itself |
 | Unbook | `DELETE /api/v2/bookings/:id` | **Measured.** **200**; needs **`contact_key` as well as `account_key`, form-encoded in the body** |
 
-> ### ⚠ Creating a member is the one write in this chain nobody has run
+### Creating a member — measured, and the one-call route is adopted
+
+[#63](https://github.com/urbanjungleirc/staff-site/issues/63) ran this against
+production on 2026-08-20. Full evidence:
+`cloudflare-clubworx/probes/63-member-creation.md`.
+
+**`POST /api/v2/members` works, and the pass rides along.** So a **new** student
+is created and given their School Pass in **one** request:
+
+```
+POST /api/v2/members    first_name, last_name, email, dob, membership_plan_id
+                        JSON body, account_key in the query string
+                        -> 200, contact created, pass active from today
+```
+
+| What was unknown | What was measured |
+|---|---|
+| Does `POST /members` succeed? | **Yes** — HTTP **200**, not `201` |
+| Which body shape? | **JSON**. See the warning below |
+| Is the contact bookable? | **Yes** — booked and cancelled cleanly, both routes |
+| Does `membership_plan_id` work on create? | **Yes** — exactly one pass, active on the next read |
+| What `start_date` does it get? | **The creation day** — the same date the two-call route was sending |
+
+**The trade-off this section was braced for does not exist.** The one-call pass
+and the two-call pass came back identical — same `start_date` (2026-08-20), same
+`expiration_date` (2026-11-11), same `class_access`. Nothing is given up by
+letting Clubworx choose, because it chooses today.
+
+**The two-call route stays, for contacts that already exist.** A student the
+matcher *finds* cannot be re-created, so a found contact without an active pass
+still needs `POST /memberships` (§2's `found` branch). Both paths are measured.
+
+**Consequence for §12:** the "contact created, pass failed" stranded state is
+now unreachable **for new students** — the contact and the pass are one request,
+which either happened or did not. §12 still handles it for found contacts.
+
+> ⚠️ **Send JSON, not form-encoded.** The reference calls this endpoint
+> form-encoded. #63 tried JSON first — the only contact-create shape ever
+> measured here (#49) — and it answered 200 on the first attempt, so **the
+> form-encoded shape was never tested** and cannot now be tested without
+> creating another permanent contact. JSON is what is measured; do not "correct"
+> it to form-encoding on the strength of the reference alone.
 >
-> **#60 did not create its members — it converted existing prospects by hand in
-> the Clubworx UI before the probe ran.** #49 created contacts, but through
-> `POST /api/v2/prospects`. So `POST /api/v2/members` is taken from the
-> reference, and the reference has been wrong twice on this effort (§12).
+> To be fair to the reference: on this endpoint it was **right**. It said
+> `membership_plan_id` works on create, and it does. The encoding is the one
+> claim #63 could not check, because the first shape it tried succeeded.
 >
-> The reference gives it `account_key`, `first_name`, `last_name`, `email`
-> (all required), plus optional `phone`, `dob`, `member_number`, address fields
-> — **and `membership_plan_id`.**
->
-> Two things follow, and the first implementation ticket resolves both against
-> production before anything is built on them:
->
-> 1. **Whether a contact created this way is bookable.** The design's assumption
->    is that it does not matter: what makes a contact bookable is **holding an
->    active School Pass**, not the status label — and #49 established the three
->    status endpoints are *disjoint views by status*, so assigning a pass should
->    move the contact into `/members` regardless of which endpoint created it.
->    That reasoning is sound but unproven. **Fallback if `POST /members`
->    refuses:** create via `POST /prospects` (measured in #49) and let the pass
->    move them. The rest of this spec is unchanged either way.
-> 2. **Whether the pass can be assigned in the same call.** If
->    `membership_plan_id` works on create, a new student is **two writes, not
->    three**, and the "contact created, pass failed" stranded state (§12)
->    disappears for new students entirely — the most valuable simplification
->    available here. But it takes **no `start_date`**, so the pass would start
->    whenever Clubworx decides, where the two-call route sends a start date and
->    reads the 12-week expiry back.
->
->    **Do not adopt the one-call route on the strength of the reference.** The
->    two-call route is measured; this one is not, and getting it wrong writes a
->    permanent membership with an unintended start date. Verify it, then decide.
+> Note the sibling write paths differ: `/memberships` and `/bookings` **are**
+> form-encoded (#60). The encoding is per-endpoint, not per-API.
+
+**A created member holds no membership until one is granted.** #63 found D
+sitting in `GET /members` with an empty `/memberships` list. This section
+previously reasoned that assigning a pass is what *moves* a contact into
+`/members`; that is not the mechanism. **The status view is set by the endpoint
+that created the contact.** The conclusion was right and is now better — no move
+is needed, because the contact starts where it belongs.
 
 **A School Pass costs nothing** — `upfront_payment_amount "0.0"`, no recurring
 charge — and starts no billing schedule.
@@ -775,6 +802,13 @@ So the undo asymmetry is exactly: **bookings yes, contacts and memberships
 never.** It is narrower than the map first feared — #50 wrongly reported that
 bookings could not be deleted either — but it is still an asymmetry, and the UI
 must never imply that undo restores the prior state.
+
+**One stranded case is now unreachable.** #63 adopted the one-call create for
+new students (§2), so "contact created, then the pass call failed" cannot happen
+to a student this tool creates — the contact and the pass are a single request.
+A **found** student can still be stranded that way, and every student can still
+be stranded by D3's rollback, which cancels bookings and leaves the permanent
+contact and pass behind. The result table must still name them.
 
 ### Two things the reference got wrong
 


### PR DESCRIPTION
Answers [#63](https://github.com/urbanjungleirc/staff-site/issues/63) — the gate on the whole [#46](https://github.com/urbanjungleirc/staff-site/issues/46) build. Ran against production Clubworx on 2026-08-20.

`POST /api/v2/members` was the one write in the chain nobody had run: #60 converted its members by hand in the Clubworx UI before probing, and #49 created contacts through `POST /prospects`. Everything the design spec said about creating a member came from the reference.

## All four answered, and the best case won

| | Question | Answer |
|---|---|---|
| Q1 | Does `POST /api/v2/members` succeed? | **Yes** — HTTP **200** (not 201), **JSON** body |
| Q2 | Is the contact bookable with an active School Pass? | **Yes** — both routes booked and unbooked cleanly |
| Q3 | Does `membership_plan_id` work on create? | **Yes** — exactly one pass, active immediately |
| Q4 | What `start_date` does that pass get? | **The creation day** — identical to the two-call route |

**A new student is two writes, not three.** The one-call and two-call passes came back identical (start 2026-08-20, expires 2026-11-11, unlimited class access), so the trade-off spec §2 braced for does not exist. The one-call route is adopted for new students; the two-call route stays for contacts the matcher *finds*, which cannot be recreated.

Also found: a contact created this way lands in `/members` **holding no membership at all**. #49's "disjoint views by status" holds, but the status is a label set by the creating endpoint, not a consequence of holding a pass — the spec had the right conclusion by the wrong mechanism.

## Two latent breaks fixed in `run-60.mjs`

Both fallout from #66 promoting `request.mjs`/`errors.js` into `src/`:

1. It could not load at all — two stale imports.
2. Its error path passed a **NUL byte** where `redact` expects the secret. A NUL matches nothing, so the account key would have travelled unredacted on exactly the path most likely to echo it back. `run-63` had the same bug with a space; both now share one `reasonOf` helper. Removing the NUL also makes `run-60.mjs` diff as text again rather than as a binary blob.

Neither ever fired live — every call in this run returned 200.

## Safety

- Search-first before every create; a re-run creates nothing (verified).
- `--write` without `--event=<id>` refuses to start, so a run cannot spend permanent records and still leave Q2 unanswered.
- Every write verified by **re-reading the resource**, never by the status code.
- Paced at 75 req/min, one in flight (#51).
- `probes/out/` is gitignored; no production data, no key, in anything committed.

## Left behind in production

Recorded in `ACCESS.md` §4 under a fresh authorisation (the #49 amendment was spent):

| Record | Id |
|---|---|
| contact `Ztest Wayfinderfour` | `5a7f1d25-7964-4f42-bbc2-1ec93e7f7aeb` |
| contact `Ztest Wayfinderfive` | `676df583-e637-42e6-9fee-38631461baad` |
| School Pass (D) | `2629905`, expires 2026-11-11 |
| School Pass (E) | `2629906`, expires 2026-11-11, granted by the create call |

Both bookings were cancelled and the reversal verified by re-count — nothing outstanding on the event.

## Still unproven, recorded as such

- **Form-encoded `POST /members`** — JSON answered 200 on the first attempt, so the form shape never ran, and testing it now would cost another permanent contact. Build the Worker (#69) on JSON.
- **Whether the two-call route can set a *future* `start_date`** — both #60 and this probe sent today's date, which is also Clubworx's default, so `honouredRequest: true` is not evidence of control.

## Review

Two-axis review (standards + spec) ran before commit; the findings it raised are fixed in the commit. 326 tests green in `cloudflare-clubworx`. Two pre-existing failures in `vouchers/test/version.test.js` are unrelated and untouched.

Deploy note: probe scripts and docs only — no change to any staff-facing page or Worker.

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)