### PR TITLE
docs(school-booking): the School Pass runs 26 weeks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -320,10 +320,15 @@ meaning is one too many.
 
 ### School Pass
 
-The **membership plan** every imported student is given, valid **12 weeks** —
-long enough to cover a UJ [term](#uj-term-week) including its snapped edges. It
-is what makes a student bookable: a School Session admits pass-holders and
-nobody else.
+The **membership plan** every imported student is given, valid **26 weeks** —
+long enough to cover a UJ [term](#uj-term-week) including its snapped edges *and*
+the lead time the booking is made with. It is what makes a student bookable: a
+School Session admits pass-holders and nobody else.
+
+It ran 12 weeks until 2026-08-20, which covered the term but not a term booked
+three or four weeks ahead of its first session. See
+[ADR 0005](docs/adr/0005-school-pass-runs-26-weeks.md) — and do not shorten it
+back, which is what that ADR exists to say.
 
 Deliberately a different noun from School Session. A *session* happens on a
 date; a *pass* is held by a person. The pair was otherwise easy to confuse in a
@@ -349,6 +354,33 @@ pass as inactive.
 *Avoid*: "has a School Pass" as a synonym. Holding the plan and holding an
 **active** one are different: an expired pass is still a returned row, and the
 session admits only the active kind.
+
+*Avoid*: treating it as the test for whether a student can be booked into a
+**term**. That is a [covering pass](#covering-pass), and it is a different
+question.
+
+### Covering pass
+
+Whether a School Pass admits its holder on **the last session of the run** — not
+today. `expiration_date` against the latest selected session date, inclusive.
+
+This is the test the write chain uses, because *active today* is exactly the
+answer that hid the problem [ADR 0005](docs/adr/0005-school-pass-runs-26-weeks.md)
+was written about: every booking is made on the day of the run, when any pass
+granted that day is unambiguously active, and the shortfall only shows up weeks
+later at a session nobody is looking at.
+
+The distinction bites hardest on a **returning student**. At 26 weeks the tool
+will regularly find someone holding a pass that is active but expires mid-term —
+a case a 12-week pass mostly turned into a clean "expired, grant a new one".
+Granting the covering pass then means granting a **second** pass to a live
+holder, which is the one thing on this effort deliberately never probed
+([#90](https://github.com/urbanjungleirc/staff-site/issues/90)), because
+memberships have no delete.
+
+*Avoid*: hard-coding the 26 weeks to compute it. For a held pass, read
+`expiration_date`; for a pass not yet granted, read `membership_duration` off the
+plan. The number lives in Clubworx.
 
 ### Reversible write
 

--- a/docs/adr/0005-school-pass-runs-26-weeks.md
+++ b/docs/adr/0005-school-pass-runs-26-weeks.md
@@ -1,0 +1,116 @@
+# ADR 0005 — the School Pass runs 26 weeks, not a term
+
+- **Status**: Accepted
+- **Date**: 2026-08-20
+- **Context**: school group booking ([#46](https://github.com/urbanjungleirc/staff-site/issues/46), [#90](https://github.com/urbanjungleirc/staff-site/issues/90)); design spec [`2026-08-19-school-group-booking-design.md`](../superpowers/specs/2026-08-19-school-group-booking-design.md) §3
+
+> Companion: [ADR 0002](0002-uj-term-weeks-are-snapped.md), on why a UJ term
+> block is a run of whole Monday–Sunday weeks rather than the official dates.
+
+## Context
+
+School students are created in Clubworx as **members** holding a **School Pass**,
+and the pass is what makes them bookable into a School Session. The plan was
+configured for **12 weeks**, sized to cover a UJ term including the edges ADR
+0002 snaps outward.
+
+That sizing carried an assumption nobody wrote down: **that the booking is made
+at the start of the term it covers.** Schools do not always work that way. A
+school can send its list and have staff book the whole term — ten weekly
+sessions — three or four weeks before the first one.
+
+The arithmetic is unforgiving, and it is off by only a little, which is what
+makes it dangerous:
+
+```
+pass          12 weeks = 84 days of access from start_date, inclusive
+term          10 weekly sessions = 63 days, first session to last
+start_date    the day of the run — Clubworx sets it, and #63 measured it
+
+lead time L → last session lands on day L + 63
+safe while    L ≤ 20 days
+```
+
+**Three weeks ahead loses the last session. Four weeks ahead loses the last
+two.** And nothing in the tool would notice: every booking is written on the day
+of the run, when the pass is unambiguously active.
+
+Whether an expiring pass actually costs anything is **unmeasured** — Clubworx
+may check the pass only at booking time, in which case the expiry never bites, or
+against the session date, in which case the tail bookings are refused, or both,
+in which case a future `start_date` cannot help because the pass would not be
+active when the booking is written.
+
+## Decision
+
+**The School Pass plan is configured for 26 weeks.**
+
+26 weeks is 182 days of access, so a 63-day term stays covered with **up to 118
+days — just under 17 weeks — of lead time**. That is past any plausible school
+booking.
+
+Two things follow, and they are the reason this is an ADR rather than a config
+note:
+
+- **The duration is not encoded anywhere in the tool.** The number 26 appears in
+  no source file. The tool sends a `start_date` and *reads* `expiration_date`
+  back, so the plan's configuration is the single source of truth and the change
+  needed no code at all.
+- **Coverage is checked, not assumed.** Before any write, the last selected
+  session must fall inside the pass. For a **found** student the check is exact —
+  the held pass's `expiration_date` against the last session. For a **new** one
+  it is best-effort, because `GET /membership_plans` returns
+  `membership_duration` as a human string (`"12 weeks"`, `"26 weeks"`); an
+  unparseable duration is reported on screen, never skipped silently.
+
+## Consequences
+
+**This deliberately over-covers.** A student attending a ten-week term holds a
+pass for six months. That is the point: the alternative fixes bought a tighter
+window at the price of unproven API behaviour.
+
+**A term's intake now reads as current members for six months**, and lapses
+mid-following-term rather than at the end of the term it attended. What that does
+to Clubworx member counts, retention and revenue reporting is the open question
+already carried on #46 — this decision makes it larger, not smaller, and does not
+resolve it.
+
+**The `found` branch gets harder, not easier.** Under a 12-week pass a returning
+student's old School Pass had usually expired, so the branch simply granted a new
+one. At 26 weeks the tool will far more often find a pass that is **active today
+but expires mid-term**. So `ensure School Pass` cannot mean *active today* — it
+means **covers the last selected session** — and granting that pass means
+granting a second one to a live holder. Whether that duplicates is the one thing
+on this effort deliberately never probed, because memberships have no delete.
+It is now the sharper of the two open questions; #90 is re-scoped to it.
+
+**Do not shorten this back to a term.** It looks like an over-long default and it
+is not. Twelve weeks is exactly long enough to look correct in testing — every
+booking succeeds on the day it is written — and to lose the last session of a
+term booked a few weeks ahead, in production, silently. The guard above is what
+would catch a shortening; this ADR is what explains it.
+
+**A School Pass costs nothing** — `upfront_payment_amount "0.0"`, no recurring
+charge, no billing schedule (#60) — so the duration is free in money.
+
+## Alternatives considered
+
+- **Start the pass at the first selected session.** Rejected. It rests on two
+  unmeasured things at once: that Clubworx honours a *future* `start_date` (#63
+  flagged this as unproven — every probe so far sent today's date, which is also
+  what Clubworx defaults to, so an honoured request is indistinguishable from an
+  ignored one), and that the pass is checked against the session date at all. It
+  also gives up the one-call create route adopted in #63, since `POST /members`
+  starts the pass today, and it needs session dates the write chain does not
+  receive. Two unknowns and a lost optimisation to buy what a config change buys
+  outright.
+- **Set the expiry explicitly, a few days after the last session.** Not
+  available. `expiration_date` comes back as exactly the plan's configured
+  duration; the API offers the *start*, not the end.
+- **Refuse the run when the last session falls outside the pass.** Kept, but as
+  a guard rather than the fix — it makes the failure visible instead of silent,
+  and on its own it would simply block the far-ahead bookings this effort exists
+  to make possible.
+- **A second plan — a longer "School Term Pass" alongside the 12-week one.**
+  Rejected: two plans mean a choice at run time, and reporting fragments across
+  both. The plan name is deliberately never varied (spec §3).

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -150,11 +150,11 @@ is needed, because the contact starts where it belongs.
 **A School Pass costs nothing** — `upfront_payment_amount "0.0"`, no recurring
 charge — and starts no billing schedule.
 
-**`expiration_date` comes back as exactly the configured 12 weeks.** The tool
-sends a `start_date` and *reads* the end date. It never computes an expiry, so
-nothing here can drift from the plan's configuration. Whether twelve weeks from
-*the day of the run* is long enough is a different question, and the answer is
-no for a term booked far enough ahead — see §3.
+**`expiration_date` comes back as exactly the plan's configured duration** — 12
+weeks when #60 and #63 measured it, **26 weeks since 2026-08-20** (§3, ADR 0005).
+The tool sends a `start_date` and *reads* the end date. It never computes an
+expiry, so nothing here can drift from the plan's configuration, and the
+duration change needed no code.
 
 **A membership has no `status` field.** Whether a pass is active is derived from
 `start_date`/`expiration_date`, inclusive at both ends. Code that looks for
@@ -180,10 +180,13 @@ membership's `start_date`.
 Duration stays out of the name because `GET /membership_plans` already exposes
 `membership_duration`.
 
-**12 weeks** is chosen to cover a UJ term including its snapped edges — see
-[ADR 0002](../../adr/0002-uj-term-weeks-are-snapped.md).
+**The pass runs 26 weeks** — long enough to cover a UJ term including its
+snapped edges ([ADR 0002](../../adr/0002-uj-term-weeks-are-snapped.md)) *and*
+the lead time a school booking is made with. It ran 12 weeks until 2026-08-20;
+why it does not any more is the next section, and the decision is
+[ADR 0005](../../adr/0005-school-pass-runs-26-weeks.md).
 
-### 12 weeks covers a term. It does not cover a term booked far ahead
+### Why the pass is 26 weeks and not 12
 
 > **Raised 2026-08-20, after the spec was written.** The 12 weeks were sized
 > against the *term*, and silently assumed the booking is made at the start of
@@ -208,8 +211,10 @@ A run made **three weeks ahead loses the last session; four weeks ahead loses
 the last two.** Nothing in the tool would notice: every booking is written on
 the day of the run, when the pass is unambiguously active.
 
-**Whether that actually costs anything is unmeasured**, and it is the first
-thing to establish, because it decides whether there is a bug at all:
+**Whether that actually costs anything is unmeasured** — and the fix adopted
+below deliberately does not wait to find out, because it holds either way. The
+three possibilities are worth stating, because they are what makes the *other*
+two fixes conditional and this one not:
 
 - If Clubworx checks the pass **only at booking time**, a pass expiring before
   session ten is irrelevant — the booking already exists, and attendance is a
@@ -220,20 +225,56 @@ thing to establish, because it decides whether there is a bug at all:
   would not be active when the booking is written — and the only lever left is
   the plan's **duration**.
 
-Three candidate fixes follow, and they are deliberately not chosen here:
+Three fixes were considered. **The plan is lengthened to 26 weeks** — decided
+2026-08-20, recorded in [ADR 0005](../../adr/0005-school-pass-runs-26-weeks.md).
 
-| Fix | Cost | Depends on |
-|---|---|---|
-| **Lengthen the plan** in Clubworx (e.g. a 20–26 week School Pass) | Config only. **No code, no date logic anywhere** | Nothing. Works under all three checking models |
-| **Start the pass at the first selected session** | Loses the one-call create route for any far-ahead run, since `POST /members` starts the pass *today* (#63); the write chain needs the session dates it does not currently receive; "active" stops meaning "active today" and starts meaning "covers every selected session", which drags in the never-probed second-pass question | A future `start_date` being honoured — **unproven**, flagged in #63 — *and* session-date checking |
-| **Refuse the run** when the last selected session falls outside the pass | Small, and consistent with §11's stated posture — refuse and let the human fix it | Session-date checking. Solves nothing on its own; it makes the failure visible instead of silent |
+| Fix | Verdict |
+|---|---|
+| **Lengthen the plan** in Clubworx to **26 weeks** | **Adopted.** Config only — no code, no date arithmetic, and it holds under all three checking models above, so it does not wait on #90 |
+| **Start the pass at the first selected session** | Rejected. Gives up the one-call create for any far-ahead run, since `POST /members` starts the pass *today* (#63); the write chain would need session dates it does not receive; and it rests on a future `start_date` being honoured, which is **unproven** — flagged in #63 — *and* on session-date checking, which is unmeasured. Two unknowns to buy what a config change buys outright |
+| **Refuse the run** when the last selected session falls outside the pass | **Kept, but as a guard rather than a fix.** It solves nothing alone — it makes the failure visible instead of silent — and it is the thing that stops this hole reopening quietly. See below |
 
-The pass **costs nothing and starts no billing schedule**, so lengthening it is
-cheap in money. What it is not free of is §15's open reporting question: a
-longer pass keeps a term's intake counted as **current members** for longer.
+**26 weeks is 182 days of access.** A 63-day term therefore stays covered with
+**up to 118 days — just under 17 weeks — of lead time**, which is past any
+plausible school booking. The pass costs nothing and starts no billing schedule
+(#60), so the duration is free in money.
 
-Filed as [#90](https://github.com/urbanjungleirc/staff-site/issues/90), which
-blocks the write chain ([#69](https://github.com/urbanjungleirc/staff-site/issues/69)).
+**What it is not free of** is §15's open reporting question, and this decision
+makes it bigger rather than smaller: a term's intake now reads as **current
+members for six months** rather than three, and the lapse lands mid-following-term
+rather than at the end of the one they attended.
+
+### The guard that keeps this from reopening
+
+The duration lives in Clubworx, where it can be edited by anyone, and the tool
+reads it rather than owning it. So the tool checks coverage rather than trusting
+the number:
+
+- **Before any write** — the last selected session must fall within
+  `today + membership_duration`. `GET /membership_plans` returns
+  `membership_duration` as a **human string** (`"12 weeks"`, `"6 weeks"`), so
+  this parse is best-effort: if it cannot be read, say so on screen rather than
+  skipping the check silently.
+- **For a found student** — compare the held pass's **`expiration_date`** against
+  the last selected session. No parsing, no assumption: the field is exact.
+  *This is the check that matters, and it is not solved by the 26 weeks* — see
+  below.
+- **The number 26 appears nowhere in the code.** A pass whose duration is later
+  shortened produces a visible refusal, not a silent tail of missing bookings.
+
+### 26 weeks makes the *found* branch harder, not easier
+
+Under a 12-week pass a returning student's old School Pass had usually expired,
+so §2's `found` branch simply granted a new one. At 26 weeks it will far more
+often find a pass that is **active today but expires mid-term** — the band where
+the old pass covers session one and not session ten.
+
+`ensure School Pass` therefore cannot mean *active today*. It means **covers the
+last selected session**. That is what makes the never-probed question — whether a
+second School Pass on an active holder duplicates it — start to matter, where D4
+previously closed it for free. It stays open, and it is now the sharper of the
+two: [#90](https://github.com/urbanjungleirc/staff-site/issues/90) is re-scoped
+to this branch, and no longer blocks #69.
 
 ### Why there is no event-naming convention
 
@@ -768,18 +809,30 @@ matched contacts.**
 | Case | Read-then-write | Blind assign |
 |---|---|---|
 | New contact (provably holds no pass) | 1 read + 1 write = **2** | **1** |
-| Returning, holds an active pass | 1 read, skip = **1** | **1** |
+| Returning, holds a **covering** pass | 1 read, skip = **1** | **1** |
 | Returning, pass expired | 1 read + 1 write = **2** | **1** |
 
 The read is only ever wasted on a contact we just created. For a student who
-already holds an active pass, reading and assigning cost the **same single
+already holds a covering pass, reading and assigning cost the **same single
 request** — so blind assignment buys nothing in exactly the case where it would
 create the duplicate.
 
-**Consequence: whether a second School Pass duplicates is no longer worth
-probing.** It is not load-bearing under this design, and memberships have no
-delete, so no permanent duplicate is spent learning something that would change
-nothing.
+**The test is *covers the last selected session*, not *active today*.** Amended
+2026-08-20 with the 26-week pass (§3, ADR 0005). Compare the held pass's
+`expiration_date` against the latest selected session date, inclusive. *Active
+today* is the answer that hides the problem, because every booking is written on
+a day the pass is active and the shortfall surfaces weeks later at a session
+nobody is watching.
+
+**Consequence: whether a second School Pass duplicates matters again.** It was
+not load-bearing while D4 only ever assigned to a holder with no live pass. At 26
+weeks the middle row above splits — a returning student can hold a pass that is
+active and **not** covering — and granting the covering pass means granting a
+second one to a live holder. Still not probed, because memberships have no
+delete; carried on [#90](https://github.com/urbanjungleirc/staff-site/issues/90)
+and §15. **Until it is answered, a non-covering live pass is a
+`needs-confirmation` row rather than a silent second grant** — §11's posture:
+refuse and let the human fix it.
 
 **D14 — The membership is re-read at Apply, immediately before its own write.**
 Preview reads can be minutes old. Contact and booking both have server-side
@@ -799,6 +852,8 @@ staleness. Nothing else is re-validated.
 | Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* |
 | No events selected, or zero parseable rows | **Hard-stop** |
 | Any unresolved gate — unparseable row, count mismatch, unconfirmed age | **Hard-stop** (§9) |
+| The last selected session falls outside `today + membership_duration` | **Hard-stop the run** (§3, ADR 0005) |
+| `membership_duration` unparseable — it is a human string | **Warn on screen**, naming the raw value. Never skip the coverage check silently |
 | `spaces_available` below the student count | **Warn, never block.** That number has been wrong in both directions |
 
 **D9, the lead time.** Dropping the event automatically was rejected as a silent
@@ -1019,16 +1074,18 @@ removed through the API. Use a marker slug that makes them findable
 
 ## 15. Known gaps and open questions
 
-Carried forward deliberately. All but the first block nothing.
+Carried forward deliberately. None blocks the build.
 
 - **Whether a School Pass is checked against the session date, or only at
-  booking time.** Raised 2026-08-20. A term booked three or four weeks ahead
-  puts its last sessions past the pass's 84 days — see §3 for the arithmetic and
-  the three candidate fixes. **This one blocks the write chain**, because it
-  decides whether the pass may start on the day of the run at all. It is
-  cheaply answerable and fully reversible: book a pass-holder into an event
-  beyond their `expiration_date` and see whether Clubworx refuses. Bookings are
-  the one write that can be undone. Filed as
+  booking time.** Raised 2026-08-20, when a term booked three or four weeks
+  ahead was found to put its last sessions past the pass's 84 days. **Answered
+  by configuration rather than by measurement** — the plan now runs 26 weeks
+  (§3, ADR 0005), which holds whichever way Clubworx behaves. The question
+  survives in one place: §2's `found` branch, where a returning student may hold
+  a pass that is active today and expires mid-term. It is cheaply answerable and
+  fully reversible — book a pass-holder into an event beyond their
+  `expiration_date` and see whether Clubworx refuses; bookings are the one write
+  that can be undone. [#90](https://github.com/urbanjungleirc/staff-site/issues/90). Filed as
   [#90](https://github.com/urbanjungleirc/staff-site/issues/90).
 
 - **Whether `POST /api/v2/members` works, and whether it can carry
@@ -1043,14 +1100,19 @@ Carried forward deliberately. All but the first block nothing.
   own issue.
 - **Whether a second School Pass on an active holder duplicates it.** Not
   probed, on purpose — memberships have no delete, so the probe would leave the
-  permanent record it was testing for. D4's read-then-write guard closes it for
-  free.
+  permanent record it was testing for. D4's read-then-write guard closed it for
+  free while *active* meant "active today". **The 26-week pass reopens it**: a
+  returning student will now often hold a pass that is active today and expires
+  mid-term, and granting the pass that covers the term means granting a second
+  one to a live holder. See §3.
 - **What a term's intake does to Clubworx reporting.** These are now *members*,
   not prospects, so a school group lands in member counts, retention and revenue,
   and an expired School Pass leaves a **lapsed member** rather than a stale
   prospect. Whether that needs archiving, marketing suppression (Resend), or any
   cleanup at all is unresolved — and contacts cannot be deleted, so the options
-  are narrow. Open on #46.
+  are narrow. **Sharper since the pass went to 26 weeks:** an intake reads as
+  current members for six months rather than three, and lapses mid-following-term
+  rather than at the end of the term it attended. Open on #46.
 - **Who may run the tool.** staff-portal is Access-gated as a whole; bulk
   creation of permanent contacts may warrant a narrower allowlist, as the
   voucher hard-delete has. v1 gates on Access alone and records the verified

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -152,7 +152,9 @@ charge — and starts no billing schedule.
 
 **`expiration_date` comes back as exactly the configured 12 weeks.** The tool
 sends a `start_date` and *reads* the end date. It never computes an expiry, so
-nothing here can drift from the plan's configuration.
+nothing here can drift from the plan's configuration. Whether twelve weeks from
+*the day of the run* is long enough is a different question, and the answer is
+no for a term booked far enough ahead — see §3.
 
 **A membership has no `status` field.** Whether a pass is active is derived from
 `start_date`/`expiration_date`, inclusive at both ends. Code that looks for
@@ -180,6 +182,58 @@ Duration stays out of the name because `GET /membership_plans` already exposes
 
 **12 weeks** is chosen to cover a UJ term including its snapped edges — see
 [ADR 0002](../../adr/0002-uj-term-weeks-are-snapped.md).
+
+### 12 weeks covers a term. It does not cover a term booked far ahead
+
+> **Raised 2026-08-20, after the spec was written.** The 12 weeks were sized
+> against the *term*, and silently assumed the booking is made at the start of
+> it. School bookings are not always made that way: a school can send its list
+> and have staff book the whole term **three or four weeks before the first
+> session**. This is unlikely but real, and it is the one case the duration
+> was never checked against.
+
+The pass runs from its `start_date` for **84 days of access** (#63 measured
+83 days of difference, inclusive at both ends). A ten-session weekly term spans
+**63 days** — first session day 0, tenth session day 63. Under the adopted
+route the pass starts on the **creation day**, which is the day staff run the
+tool, so:
+
+```
+lead time L  →  last session lands on day L + 63
+pass covers  →  days 0 … 83
+safe while   →  L ≤ 20 days
+```
+
+A run made **three weeks ahead loses the last session; four weeks ahead loses
+the last two.** Nothing in the tool would notice: every booking is written on
+the day of the run, when the pass is unambiguously active.
+
+**Whether that actually costs anything is unmeasured**, and it is the first
+thing to establish, because it decides whether there is a bug at all:
+
+- If Clubworx checks the pass **only at booking time**, a pass expiring before
+  session ten is irrelevant — the booking already exists, and attendance is a
+  property of the booking. Nothing needs changing.
+- If it checks the pass **against the session date**, the far-ahead bookings are
+  refused at write time, and the run visibly fails on the tail sessions.
+- If it checks **both**, then a future `start_date` cannot be the fix — the pass
+  would not be active when the booking is written — and the only lever left is
+  the plan's **duration**.
+
+Three candidate fixes follow, and they are deliberately not chosen here:
+
+| Fix | Cost | Depends on |
+|---|---|---|
+| **Lengthen the plan** in Clubworx (e.g. a 20–26 week School Pass) | Config only. **No code, no date logic anywhere** | Nothing. Works under all three checking models |
+| **Start the pass at the first selected session** | Loses the one-call create route for any far-ahead run, since `POST /members` starts the pass *today* (#63); the write chain needs the session dates it does not currently receive; "active" stops meaning "active today" and starts meaning "covers every selected session", which drags in the never-probed second-pass question | A future `start_date` being honoured — **unproven**, flagged in #63 — *and* session-date checking |
+| **Refuse the run** when the last selected session falls outside the pass | Small, and consistent with §11's stated posture — refuse and let the human fix it | Session-date checking. Solves nothing on its own; it makes the failure visible instead of silent |
+
+The pass **costs nothing and starts no billing schedule**, so lengthening it is
+cheap in money. What it is not free of is §15's open reporting question: a
+longer pass keeps a term's intake counted as **current members** for longer.
+
+Filed as [#90](https://github.com/urbanjungleirc/staff-site/issues/90), which
+blocks the write chain ([#69](https://github.com/urbanjungleirc/staff-site/issues/69)).
 
 ### Why there is no event-naming convention
 
@@ -965,7 +1019,17 @@ removed through the API. Use a marker slug that makes them findable
 
 ## 15. Known gaps and open questions
 
-Carried forward deliberately. None blocks the build.
+Carried forward deliberately. All but the first block nothing.
+
+- **Whether a School Pass is checked against the session date, or only at
+  booking time.** Raised 2026-08-20. A term booked three or four weeks ahead
+  puts its last sessions past the pass's 84 days — see §3 for the arithmetic and
+  the three candidate fixes. **This one blocks the write chain**, because it
+  decides whether the pass may start on the day of the run at all. It is
+  cheaply answerable and fully reversible: book a pass-holder into an event
+  beyond their `expiration_date` and see whether Clubworx refuses. Bookings are
+  the one write that can be undone. Filed as
+  [#90](https://github.com/urbanjungleirc/staff-site/issues/90).
 
 - **Whether `POST /api/v2/members` works, and whether it can carry
   `membership_plan_id`.** The one write in the chain that has never been run —


### PR DESCRIPTION
The 12-week School Pass was sized against a UJ term on the unstated assumption that the booking is made at the start of it. A school can send its list and have staff book the whole term — ten weekly sessions — **three or four weeks before the first one**. Raised 2026-08-20; decided the same day.

**The hole.** The pass runs 84 days from `start_date` and, under the one-call route adopted in #63, starts on **the day of the run**. Ten sessions span 63 days, so a lead time over **20 days** puts the tail past the expiry — three weeks ahead loses the last session, four weeks ahead the last two. Nothing in the tool would notice: every booking is written on a day the pass is unambiguously active.

**The fix: the plan is configured for 26 weeks.** 182 days of access, so a 63-day term stays covered with up to **118 days — just under 17 weeks — of lead**.

It was chosen over starting the pass at the first selected session, which rests on two unmeasured things at once — that Clubworx honours a *future* `start_date` (#63 flagged this unproven) and that it checks the pass against the session date at all — and would also give up the one-call create route. A config change buys the same outcome with neither unknown, so it does not wait on #90.

**No code changed, and that is structural**: the number 26 appears in no source file. The tool reads `membership_duration` off the plan and `expiration_date` off the granted pass, so Clubworx stays the single source of truth.

### Two things this makes harder — recorded, not hidden

- **`ensure School Pass` can no longer mean *active today*.** It means **covers the last selected session**. *Active today* is precisely the answer that hides this class of bug.
- **Whether a second pass duplicates a live one matters again.** At 26 weeks a returning student will often hold a pass that is active and *not* covering; D4 used to close this for free. Until #90 answers, that row is `needs-confirmation`, never a silent second grant.

### What changed

- **New: [ADR 0005](docs/adr/0005-school-pass-runs-26-weeks.md)** — the decision, the arithmetic, the three alternatives, and the reason not to shorten it back to a term.
- **Spec §2** — `expiration_date` is the plan's configured duration; 12 weeks when #60/#63 measured it, 26 since.
- **Spec §3** — new subsection: why the pass is 26 weeks and not 12, the coverage guard, and why the *found* branch gets harder.
- **Spec §10 (D4)** — the covering-pass test replaces *active today*.
- **Spec §11** — two new pre-write rulings: hard-stop when the last session falls outside the pass, warn when `membership_duration` is unparseable.
- **Spec §15** — the session-date question is answered by configuration and re-scoped; the duplicate-pass question reopens; the reporting question gets sharper.
- **CONTEXT.md** — School Pass is 26 weeks; new domain term **covering pass**, with the *avoid* notes that keep it apart from *active pass*.

**Still needs doing by hand:** the plan duration itself, in the Clubworx UI. Until that is changed, School Pass is still 12 weeks and this PR describes an intent rather than the configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)