### PR TITLE
feat(clubworx): contact search across the three status views (#68)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,15 @@ index.html              - hub homepage; renders cards/groups from tools.json
 tools.json              - source of truth for hub entries
 roster.html             - daily staff roster, pulled from Deputy via Cloudflare Worker
 cloudflare-worker/      - Worker for roster API and tools.json editor API
-cloudflare-clubworx/    - Clubworx API access for the school-group booking tool (#46).
-                          ACCESS.md is the answer to #47: where the key comes from,
-                          where it lives, and what is still owed. No Worker code yet.
+cloudflare-clubworx/    - uj-clubworx-api, the Worker for the school-group booking
+                          tool (#46). Deploys separately from Pages. Start with its
+                          README.md; ACCESS.md is the answer to #47 (where the key
+                          comes from and where it lives). Verifies the Access JWT
+                          rather than trusting the header, paces at 75 req/min, and
+                          stores nothing — no student name or DOB in any store or
+                          log line. GET /api/clubworx/health (#66) and
+                          GET /api/clubworx/contacts (#68) so far; events, plan,
+                          schools, student and unbook arrive with #67/#69/#70.
 hvt/                    - High-volume Training tool copy
 slideshow/              - Google Drive TV slideshow tool
 sls_tv.html             - Summer Lead Series TV display
@@ -200,13 +206,17 @@ Access, so an unauthenticated request returns **HTTP 200 carrying the Access
 login page**, not the file you asked for — a success status and a body that
 never contains your change. Verifying content needs a real browser session.
 
-The two Workers deploy separately; a Pages publish does not touch them.
+The three Workers deploy separately; a Pages publish does not touch them.
 
 ```bash
 cd cloudflare-worker          # roster + tools.json API
 npx wrangler deploy
 
 cd cloudflare-payments-proxy  # voucher portal → uj-payments; happyk account
+npx wrangler deploy
+
+cd cloudflare-clubworx        # school-group booking → Clubworx; happyk account
+npx wrangler secret put CLUBWORX_ACCOUNT_KEY   # once per environment, not in git
 npx wrangler deploy
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,14 @@ cloudflare-clubworx/    - uj-clubworx-api, the Worker for the school-group booki
                           comes from and where it lives). Verifies the Access JWT
                           rather than trusting the header, paces at 75 req/min, and
                           stores nothing — no student name or DOB in any store or
-                          log line. Only GET /api/clubworx/health so far (#66); the
-                          working routes arrive with #67/#68/#70.
+                          log line. GET /api/clubworx/health (#66) and
+                          GET /api/clubworx/contacts (#68) so far; events, plan,
+                          schools, student and unbook arrive with #67/#69/#70.
+cloudflare-clubworx/src/contacts.js - the dedup read. Searches all three disjoint
+                          status views and merges, because a contact moves between
+                          them (#49). Every uncertain answer is a refusal: an
+                          empty candidate set means "new", and "new" writes a
+                          contact Clubworx cannot delete.
 cloudflare-clubworx/src/ - the Worker. request.js and errors.js were moved here
                           from probes/lib/ by #66 and the probes import them back.
 cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -302,6 +302,13 @@ appears in `/prospects` **only**, and moves when their status changes.
 So a lookup searches all three and merges. Which one holds a given student is a
 fact about their membership today, not about how they were created.
 
+That lookup is `cloudflare-clubworx/src/contacts.js`, behind
+`GET /api/clubworx/contacts?last_name=&dob=` (#68). It narrows and merges;
+deciding the match is `school-booking/identity.js`. It **refuses** rather than
+answering short — a failed view, an unreadable body or a query that never
+narrowed all return an error, because an empty candidate set is read as `new`,
+and `new` writes a contact Clubworx cannot delete.
+
 ## Clubworx school booking
 
 Terms for the route a student takes into a session. Decided 2026-08-18, after

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -4,10 +4,14 @@ staff-site[#66](https://github.com/urbanjungleirc/staff-site/issues/66), part of
 the school group booking map ([#46](https://github.com/urbanjungleirc/staff-site/issues/46)).
 Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §6.
 
-This ticket ships the **skeleton**: the Worker, the Access gate, the pacer and
-the request layer. The routes that do the work — `events`, `plan`, `schools`,
-`contacts`, `student`, `unbook` — arrive with #67, #68 and #70. Until then the
-only route is `GET /api/clubworx/health`.
+#66 shipped the **skeleton**: the Worker, the Access gate, the pacer and the
+request layer. #68 added the dedup read. The rest — `events`, `plan`, `schools`,
+`student`, `unbook` — arrive with #67, #69 and #70, and answer `404` until then.
+
+| Route | Ticket | Does |
+|---|---|---|
+| `GET /api/clubworx/health` | #66 | Names the authenticated operator; says whether the secret was put |
+| `GET /api/clubworx/contacts?last_name=&dob=` | #68 | Searches all three status views and merges — see below |
 
 `ACCESS.md` in this directory is the answer to #47: where the key comes from,
 where it lives, and what is still owed. Read it first.
@@ -18,6 +22,7 @@ where it lives, and what is still owed. Read it first.
 src/index.js     the Worker: routing, the Access gate, the log line
 src/access.js    Cloudflare Access JWT verification against the team JWKS
 src/clubworx.js  the only path to Clubworx: paced, redacted, measured shapes
+src/contacts.js  the dedup read: all three status views, merged  (#68)
 src/pace.js      75 req/min, one in flight — the constant #51 measured
 src/request.js   buildUrl + redact                (promoted from probes/lib)
 src/errors.js    errorMessageOf                   (promoted from probes/lib)
@@ -76,6 +81,123 @@ and on a rejection, the reason.
 
 `test/worker.test.js` asserts both directly, because a rule of this shape fails
 silently.
+
+## `GET /contacts` — the dedup read
+
+```text
+GET /api/clubworx/contacts?last_name=Nowak&dob=2009-03-02
+```
+
+Both parameters are **required**, and `dob` must be a real `YYYY-MM-DD` day.
+Surname + DOB is the candidate-narrowing key of §5; a surname-less query is a
+walk through ~60,000 contacts that can conclude nothing, and a query without a
+birthday cannot tell siblings apart. Date orientation is the standing hazard on
+this map — `03/02/2009` is two different children depending on who typed it — so
+the route takes exactly one form rather than guessing.
+
+```json
+{
+  "candidates": [
+    {
+      "contact_key": "…",
+      "first_name": "Amelia",
+      "last_name": "Nowak",
+      "dob": "2009-03-02",
+      "email": "noreply+newman@urbanjungleirc.com",
+      "status": "Prospect",
+      "status_view": "members"
+    }
+  ],
+  "views": [{ "view": "prospects", "pages": 1, "rows": 0 }],
+  "requests": 3
+}
+```
+
+### It searches all three status views
+
+`/prospects`, `/members` and `/non_attending_contacts` are **three disjoint
+views by status, not three indexes over one table** ([#49]). A contact appears
+in exactly one and *moves between them as their status changes*, so a
+prospect-only lookup stops finding a student the moment they take a membership.
+That is not hypothetical — it broke the [#60] probe when its own test contacts
+were converted. Results merge by `contact_key`.
+
+`status_view` records which of the three held them. Nothing needs it to match;
+it is the fact that explains a surprise.
+
+### It does not decide the match
+
+`new` / `matched` / `name-variant` / `ambiguous` is produced by
+`school-booking/identity.js`, which is pure so it stays testable. This route
+narrows; it does not conclude — and it does not filter the rows Clubworx
+returned, because matching runs on **compare form** (§7 P10) and that
+normalisation table lives in `school-booking/parse.js`. A second copy here would
+drift, and the drift is silent in the worst way: the day the two disagree,
+`O'Brien` stops matching `OBrien`, a student who already has a contact comes
+back as `new`, and a second permanent contact is written for them. `matchStudent`
+re-checks surname *and* DOB against every candidate, so an over-broad set is safe
+and a locally-narrowed one is not.
+
+### Every uncertain answer is a refusal
+
+The caller turns an empty candidate set into `new`, and `new` creates a contact
+that **Clubworx cannot delete** (`ACCESS.md` §4). The failure modes are not
+symmetric: an over-broad candidate set costs a human a second look, a short one
+costs a permanent duplicate. So a failure never looks like "nobody found".
+
+| Outcome | Status | `reason` |
+|---|---|---|
+| A view errored, or answered `200` with a body that is not a list | `502` | `upstream-error` |
+| A view was still returning a **full page** at the page ceiling | `502` | `search-not-narrowed` |
+| Clubworx throttled | `429` | `throttled` |
+| Missing or malformed `last_name` / `dob` | `400` | `bad-request` |
+| `CLUBWORX_ACCOUNT_KEY` was never put | `503` | `not-configured` |
+
+A failing view stops the whole search rather than answering from the other two —
+the missing view is exactly where the student might be.
+
+`502` rather than the upstream status, because Clubworx answering `401` must not
+reach the browser beside the `401` this Worker's own Access gate returns; that
+sends an operator to re-authenticate against a problem that is not theirs. The
+upstream code travels in `upstreamStatus` instead. Upstream messages are passed
+through **verbatim** — [#50] is the cautionary tale for paraphrasing one.
+
+### Paging, and the ceiling on it
+
+A page that comes back **full** is silent truncation: [#51] measured no total,
+no next-page link and no header to say more exist, so a full page is
+indistinguishable from a complete list. Each view is therefore paged until a
+short page arrives — at `page_size=200`, never the default 50 that hid `School
+Pass` from [#60].
+
+Whether Clubworx honours `last_name` and `dob` as *filters* is **unmeasured**;
+the only contact filter ever measured here is `email` ([#49]). If it ignores
+them, every page comes back full and this becomes a walk through the whole
+database at 75 req/min — minutes per student, every row a stranger's name and
+birthday travelling to a browser. So the walk is bounded at `MAX_PAGES`, and
+hitting that ceiling is a **refusal**, not a truncation flag: a flag is
+something a caller can ignore, and ignoring this one writes a duplicate contact.
+
+### It does not retry
+
+§11's D8 retries `429`, `5xx` and network errors — but **a `429` pauses the
+whole run, not one row**, because the allowance is gym-wide ([#47]) and backing
+off a single student while the others continue just spends the next window
+failing. Retrying inside the Worker would hide the throttle from the only layer
+that can act on it.
+
+### What a run costs here
+
+**3 requests per student** when each view answers on its first page — so a
+25-student list spends ~75 requests on this route alone, against a measured
+ceiling of 75/min shared with the roster Worker and n8n. `requests` is on every
+response so a run can be held to that budget.
+
+[#47]: https://github.com/urbanjungleirc/staff-site/issues/47
+[#49]: https://github.com/urbanjungleirc/staff-site/issues/49
+[#50]: https://github.com/urbanjungleirc/staff-site/issues/50
+[#51]: https://github.com/urbanjungleirc/staff-site/issues/51
+[#60]: https://github.com/urbanjungleirc/staff-site/issues/60
 
 ## Pacing
 

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -104,14 +104,21 @@ the route takes exactly one form rather than guessing.
       "last_name": "Nowak",
       "dob": "2009-03-02",
       "email": "noreply+newman@urbanjungleirc.com",
-      "status": "Prospect",
+      "status": "Member",
       "status_view": "members"
     }
   ],
-  "views": [{ "view": "prospects", "pages": 1, "rows": 0 }],
+  "views": [
+    { "view": "prospects", "pages": 1, "rows": 0 },
+    { "view": "members", "pages": 1, "rows": 1 },
+    { "view": "non_attending_contacts", "pages": 1, "rows": 0 }
+  ],
   "requests": 3
 }
 ```
+
+Amelia was created as a prospect and has since taken a membership, so she is in
+`/members` now — which is the whole reason all three are searched.
 
 ### It searches all three status views
 
@@ -178,6 +185,19 @@ birthday travelling to a browser. So the walk is bounded at `MAX_PAGES`, and
 hitting that ceiling is a **refusal**, not a truncation flag: a flag is
 something a caller can ignore, and ignoring this one writes a duplicate contact.
 
+### The unmeasured assumption underneath it — [#92]
+
+`dob` is passed through exactly as Clubworx sent it, and `matchStudent` compares
+it as a string against `parse.js`'s ISO `YYYY-MM-DD`. **Nothing has ever
+measured what format Clubworx returns** — [#49] recorded the contact schema
+deliberately without values.
+
+If it comes back as `02/05/1999`, every comparison is false, every student
+reports `new`, and a 25-student run writes 25 permanent contacts, silently.
+Normalising on a guess would be worse than not normalising, because orientation
+is ambiguous and a wrong guess is the same duplicate with a confident comment
+over it. [#92] measures it; until then this is the known soft spot in the route.
+
 ### It does not retry
 
 §11's D8 retries `429`, `5xx` and network errors — but **a `429` pauses the
@@ -185,6 +205,22 @@ whole run, not one row**, because the allowance is gym-wide ([#47]) and backing
 off a single student while the others continue just spends the next window
 failing. Retrying inside the Worker would hide the throttle from the only layer
 that can act on it.
+
+So the caller implements D8, and `upstreamStatus` is what it classifies on.
+`reason` says what kind of failure it was; `upstreamStatus` says whether D8 may
+retry it:
+
+| `upstreamStatus` | Was | D8 |
+|---|---|---|
+| `429` | throttled | retry after the ~20 s floor — and pause the **whole run** |
+| `0` | a connection failure, never an upstream answer | retryable |
+| `5xx` | Clubworx erred | retryable |
+| `4xx` | Clubworx refused our request | **never retry** — permanent for that attempt |
+| `200` | `search-not-narrowed` | not a retry; the query itself is the problem |
+
+`0` rather than `null` for a connection failure is deliberate in `clubworx.js`,
+so a caller comparing statuses cannot mistake it for an answer it simply did not
+read.
 
 ### What a run costs here
 
@@ -198,6 +234,7 @@ response so a run can be held to that budget.
 [#50]: https://github.com/urbanjungleirc/staff-site/issues/50
 [#51]: https://github.com/urbanjungleirc/staff-site/issues/51
 [#60]: https://github.com/urbanjungleirc/staff-site/issues/60
+[#92]: https://github.com/urbanjungleirc/staff-site/issues/92
 
 ## Pacing
 

--- a/cloudflare-clubworx/src/contacts.js
+++ b/cloudflare-clubworx/src/contacts.js
@@ -1,0 +1,240 @@
+/**
+ * The dedup read: does this student already exist in Clubworx?
+ *
+ * staff-site#68. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+ * §5 (identity and matching) and §6 (the route table).
+ *
+ * ---------------------------------------------------------------------------
+ * The trap this module exists to avoid
+ * ---------------------------------------------------------------------------
+ * `/prospects`, `/members` and `/non_attending_contacts` are **three disjoint
+ * views by status, not three indexes over one table** (#49). A contact appears
+ * in exactly one of them and *moves between them as their status changes* —
+ * and #63 measured that the view is set by whichever endpoint created the
+ * contact, so it is a label, not a consequence of holding a pass.
+ *
+ * A prospect-only lookup therefore stops finding a student the moment they take
+ * a membership. That is not hypothetical: it broke the #60 probe in practice
+ * when its own test contacts were converted to members. So this searches all
+ * three and merges by `contact_key`.
+ *
+ * ---------------------------------------------------------------------------
+ * Why every uncertain answer here is a refusal
+ * ---------------------------------------------------------------------------
+ * The caller turns an empty candidate set into the match state `new`, and `new`
+ * creates a contact. **Clubworx has no delete for contacts** (ACCESS.md §4) —
+ * every one written is permanent, beside ~60,000 real people, removable only by
+ * hand in the UI. So the failure modes are not symmetric: an over-broad
+ * candidate set costs a human a second look, and a short one costs a duplicate
+ * record that nobody can take back.
+ *
+ * That asymmetry is the whole design of the error handling below. A view that
+ * errors, a `200` whose body is not a list, and a sweep that never narrowed all
+ * **refuse the entire search** rather than answering from what did come back.
+ *
+ * ---------------------------------------------------------------------------
+ * What it deliberately does not do
+ * ---------------------------------------------------------------------------
+ * **It does not decide the match.** `new` / `matched` / `name-variant` /
+ * `ambiguous` is produced by `school-booking/identity.js`, which is pure so it
+ * stays testable. This module narrows; it does not conclude.
+ *
+ * **It does not filter the rows Clubworx returned.** Matching runs on *compare
+ * form* (§7 P10) — the normalisation that lets `O'Brien` match `OBrien` — and
+ * that table lives in `school-booking/parse.js`, on the browser side. A second
+ * copy here would drift, and the drift is silent in the worst way: the day the
+ * two disagree, a student who already has a contact comes back as `new` and a
+ * second permanent record is written. Nothing throws; both spellings are valid.
+ * `matchStudent` already re-checks surname *and* DOB against every candidate,
+ * so an over-broad set is safe and a locally-narrowed one is not.
+ *
+ * **It does not retry.** §11's D8 retries `429`, `5xx` and network errors — but
+ * *a `429` pauses the whole run, not one row*, because the allowance is
+ * gym-wide (one key per gym, #47) and backing off a single student while the
+ * others continue just spends the next window failing. Retrying inside the
+ * Worker would hide the throttle from the only layer that can act on it, so the
+ * `429` is reported as itself and the page decides.
+ */
+
+import { errorMessageOf } from './errors.js';
+
+/**
+ * The three disjoint status views, in the order #49 measured them.
+ *
+ * Adding a fourth is not a refactor: it is a claim about where Clubworx can put
+ * a contact, and #49 and #63 are the evidence for these three.
+ */
+export const CONTACT_VIEWS = ['prospects', 'members', 'non_attending_contacts'];
+
+/**
+ * Never the default 50.
+ *
+ * #51 measured the default page as exactly 50 rows with **no total, no
+ * next-page link and no header** to say more exist — a truncated page is
+ * indistinguishable from a complete list by anything in the response. 200 is
+ * verified to work.
+ */
+export const PAGE_SIZE = 200;
+
+/**
+ * How far a single view may be walked before the search is called broken.
+ *
+ * Whether Clubworx honours `last_name` and `dob` as *filters* is unmeasured —
+ * the only contact filter ever measured here is `email` (#49). If it ignores
+ * them, every page comes back full and this is a walk through a 60,000-person
+ * database at 75 requests a minute: ~13 minutes for one student, and every row
+ * of it a stranger's name and date of birth travelling to a browser.
+ *
+ * Three pages is generous for the intended query — a surname and a birthday
+ * should match a handful — and small enough that the anomaly is caught in
+ * seconds. Hitting it means the query did not narrow, which is a refusal
+ * (`search-not-narrowed`), not a truncation flag: a flag is something a caller
+ * can ignore, and ignoring this one writes a duplicate contact.
+ */
+export const MAX_PAGES = 3;
+
+/**
+ * The fields a candidate travels with, and nothing else.
+ *
+ * The Worker is a transit, not a database (§6, D10). `contact_key`,
+ * `first_name`, `last_name` and `dob` are what `matchStudent` reads. `email`
+ * carries the `noreply+<school>@` tag, which is the only provenance signal
+ * Clubworx offers (#47: one key per gym, so attribution by key is impossible) —
+ * it is what lets an operator resolving a duplicate see which school the other
+ * record belongs to. `status` is what the row calls itself.
+ *
+ * A phone number and a home address answer no question asked here, so they do
+ * not leave the Worker.
+ */
+function projectContact(row, view) {
+  return {
+    contact_key: row.contact_key,
+    first_name: row.first_name ?? null,
+    last_name: row.last_name ?? null,
+    // Passed through exactly as Clubworx sent it, blank included. #49 measured
+    // that a hand-created contact can carry no DOB, and identity.js has a
+    // `candidate-dob-unknown` state for that row. Normalising it away here would
+    // hide the one candidate most likely to become a duplicate.
+    dob: row.dob ?? null,
+    email: row.email ?? null,
+    status: row.status ?? null,
+    // Which of the three held them. Not needed to match — a contact is in
+    // exactly one view — but it is the fact that explains a surprise, and it is
+    // free.
+    status_view: view,
+  };
+}
+
+const failure = ({ reason, message, view, upstreamStatus = null, requests }) => ({
+  ok: false,
+  reason,
+  message,
+  view,
+  upstreamStatus,
+  candidates: [],
+  requests,
+});
+
+/**
+ * Search all three status views for one student and merge the results.
+ *
+ * @param {object} opts
+ * @param {{get: (path: string, params: object) => Promise<object>}} opts.client
+ *   A `createClubworxClient` instance. Everything it sends is paced.
+ * @param {string} opts.lastName  Surname, as the operator's paste spelled it.
+ * @param {string} opts.dob       `YYYY-MM-DD`.
+ * @param {number} [opts.pageSize]
+ * @param {number} [opts.maxPages]
+ * @returns {Promise<{ok: true, candidates: object[], views: object[], requests: number}
+ *                 | {ok: false, reason: string, message: string|null, view: string,
+ *                    upstreamStatus: number|null, candidates: [], requests: number}>}
+ */
+export async function searchContacts({
+  client,
+  lastName,
+  dob,
+  pageSize = PAGE_SIZE,
+  maxPages = MAX_PAGES,
+}) {
+  // Keyed by contact_key, so a contact seen in two views — or twice across a
+  // shifting page boundary — merges instead of duplicating. First sighting wins:
+  // the views are disjoint, so a second one is a race, not new information.
+  const byKey = new Map();
+  const views = [];
+  let requests = 0;
+
+  for (const view of CONTACT_VIEWS) {
+    let pages = 0;
+    let rowsSeen = 0;
+
+    for (let page = 1; page <= maxPages; page += 1) {
+      const res = await client.get(view, {
+        last_name: lastName,
+        dob,
+        page,
+        page_size: pageSize,
+      });
+      requests += 1;
+      pages += 1;
+
+      if (!res.ok) {
+        // A throttle is told apart from everything else because it is the one
+        // failure the page answers differently: §11 pauses the whole run, and
+        // says out loud that the cause may be another system on the same
+        // gym-wide key.
+        return failure({
+          reason: res.status === 429 ? 'throttled' : 'upstream-error',
+          message: res.message ?? errorMessageOf(res.body) ?? res.bodyText ?? null,
+          view,
+          upstreamStatus: res.status,
+          requests,
+        });
+      }
+
+      // Measured: these endpoints answer with a bare array (#49, #60). Anything
+      // else is a response nobody here has seen, and reading it as "no rows" is
+      // the single wrong guess that ends in a permanent duplicate contact.
+      if (!Array.isArray(res.body)) {
+        return failure({
+          reason: 'upstream-error',
+          message: `${view} answered ${res.status} with a body that is not a list of contacts`,
+          view,
+          upstreamStatus: res.status,
+          requests,
+        });
+      }
+
+      for (const row of res.body) {
+        // A row with no key cannot be booked, cannot be given a pass, and would
+        // merge every other keyless row into one under `undefined`.
+        if (!row?.contact_key) continue;
+        if (!byKey.has(row.contact_key)) byKey.set(row.contact_key, projectContact(row, view));
+      }
+      rowsSeen += res.body.length;
+
+      // A short page is the end of the list — the only end-of-list signal there
+      // is, since #51 confirmed no total and no next-page link come back. A page
+      // that is exactly full is ambiguous, so it costs one more request to find
+      // out; that is the price of not silently truncating.
+      if (res.body.length < pageSize) break;
+
+      if (page === maxPages) {
+        // Still full at the ceiling: the query did not narrow. See MAX_PAGES.
+        return failure({
+          reason: 'search-not-narrowed',
+          message:
+            `${view} was still returning a full page of ${pageSize} at page ${maxPages} — ` +
+            'the surname and date of birth did not narrow the search, so this answer ' +
+            'cannot be told apart from a sweep of the whole contact database',
+          view,
+          upstreamStatus: res.status,
+          requests,
+        });
+      }
+    }
+
+    views.push({ view, pages, rows: rowsSeen });
+  }
+
+  return { ok: true, candidates: [...byKey.values()], views, requests };
+}

--- a/cloudflare-clubworx/src/contacts.js
+++ b/cloudflare-clubworx/src/contacts.js
@@ -48,6 +48,24 @@
  * `matchStudent` already re-checks surname *and* DOB against every candidate,
  * so an over-broad set is safe and a locally-narrowed one is not.
  *
+ * ---------------------------------------------------------------------------
+ * The unmeasured assumption underneath all of it — #92
+ * ---------------------------------------------------------------------------
+ * `dob` is passed through exactly as Clubworx sent it, and `matchStudent`
+ * compares it as a string against `parse.js`'s ISO `YYYY-MM-DD`. **Nothing has
+ * ever measured what format Clubworx returns.** #49 recorded the contact schema
+ * deliberately without values, so the field is known to exist and its shape is
+ * not.
+ *
+ * If it comes back as `02/05/1999`, every comparison is false, every student
+ * reports `new`, and a 25-student run writes 25 permanent contacts. It fails
+ * silently — nothing throws, and a school that has never climbed here before
+ * looks exactly the same.
+ *
+ * Normalising on a guess would be worse than not normalising: orientation is
+ * ambiguous, and a wrong guess is the same permanent duplicate with a confident
+ * comment above it. So this passes through and #92 measures it.
+ *
  * **It does not retry.** §11's D8 retries `429`, `5xx` and network errors — but
  * *a `429` pauses the whole run, not one row*, because the allowance is
  * gym-wide (one key per gym, #47) and backing off a single student while the
@@ -55,8 +73,6 @@
  * Worker would hide the throttle from the only layer that can act on it, so the
  * `429` is reported as itself and the page decides.
  */
-
-import { errorMessageOf } from './errors.js';
 
 /**
  * The three disjoint status views, in the order #49 measured them.
@@ -143,19 +159,11 @@ const failure = ({ reason, message, view, upstreamStatus = null, requests }) => 
  *   A `createClubworxClient` instance. Everything it sends is paced.
  * @param {string} opts.lastName  Surname, as the operator's paste spelled it.
  * @param {string} opts.dob       `YYYY-MM-DD`.
- * @param {number} [opts.pageSize]
- * @param {number} [opts.maxPages]
  * @returns {Promise<{ok: true, candidates: object[], views: object[], requests: number}
  *                 | {ok: false, reason: string, message: string|null, view: string,
  *                    upstreamStatus: number|null, candidates: [], requests: number}>}
  */
-export async function searchContacts({
-  client,
-  lastName,
-  dob,
-  pageSize = PAGE_SIZE,
-  maxPages = MAX_PAGES,
-}) {
+export async function searchContacts({ client, lastName, dob }) {
   // Keyed by contact_key, so a contact seen in two views — or twice across a
   // shifting page boundary — merges instead of duplicating. First sighting wins:
   // the views are disjoint, so a second one is a race, not new information.
@@ -167,12 +175,12 @@ export async function searchContacts({
     let pages = 0;
     let rowsSeen = 0;
 
-    for (let page = 1; page <= maxPages; page += 1) {
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
       const res = await client.get(view, {
         last_name: lastName,
         dob,
         page,
-        page_size: pageSize,
+        page_size: PAGE_SIZE,
       });
       requests += 1;
       pages += 1;
@@ -184,7 +192,11 @@ export async function searchContacts({
         // gym-wide key.
         return failure({
           reason: res.status === 429 ? 'throttled' : 'upstream-error',
-          message: res.message ?? errorMessageOf(res.body) ?? res.bodyText ?? null,
+          // `message` is the client's own contract: it runs `errorMessageOf`
+          // over every JSON body and puts the scrubbed reason there on a
+          // connection failure. `bodyText` is the leftover case — a throttle or
+          // a WAF block answering in HTML, already redacted and truncated.
+          message: res.message ?? res.bodyText ?? null,
           view,
           upstreamStatus: res.status,
           requests,
@@ -216,14 +228,14 @@ export async function searchContacts({
       // is, since #51 confirmed no total and no next-page link come back. A page
       // that is exactly full is ambiguous, so it costs one more request to find
       // out; that is the price of not silently truncating.
-      if (res.body.length < pageSize) break;
+      if (res.body.length < PAGE_SIZE) break;
 
-      if (page === maxPages) {
+      if (page === MAX_PAGES) {
         // Still full at the ceiling: the query did not narrow. See MAX_PAGES.
         return failure({
           reason: 'search-not-narrowed',
           message:
-            `${view} was still returning a full page of ${pageSize} at page ${maxPages} — ` +
+            `${view} was still returning a full page of ${PAGE_SIZE} at page ${MAX_PAGES} — ` +
             'the surname and date of birth did not narrow the search, so this answer ' +
             'cannot be told apart from a sweep of the whole contact database',
           view,

--- a/cloudflare-clubworx/src/index.js
+++ b/cloudflare-clubworx/src/index.js
@@ -220,14 +220,21 @@ export function createHandler({
         return done(
           json(
             {
-              // Verbatim, never re-worded — D6. #50 is the cautionary tale: a
-              // truthful-sounding paraphrase pointed at the wrong mechanism and
-              // cost an architectural route.
+              // A throttle gets §11's wording and never the upstream text. It is
+              // the one case where there IS no upstream message to be faithful
+              // to: a throttle answers in HTML, so `errorMessageOf` finds
+              // nothing and the client falls back to `bodyText` — up to 500
+              // characters of scrubbed markup. Letting that win would put a WAF
+              // page in front of the operator instead of the sentence that says
+              // the cause may be another system on the same gym-wide key.
+              //
+              // Everything else is verbatim, never re-worded — D6. #50 is the
+              // cautionary tale: a truthful-sounding paraphrase pointed at the
+              // wrong mechanism and cost an architectural route.
               error:
-                result.message ??
-                (result.reason === 'throttled'
+                result.reason === 'throttled'
                   ? 'Clubworx is busy — this can be caused by another system, not this page. Try again shortly.'
-                  : 'the Clubworx contact search failed'),
+                  : (result.message ?? 'the Clubworx contact search failed'),
               reason: result.reason,
               view: result.view ?? null,
               upstreamStatus: result.upstreamStatus ?? null,

--- a/cloudflare-clubworx/src/index.js
+++ b/cloudflare-clubworx/src/index.js
@@ -22,13 +22,17 @@
  *
  * **Auth is Cloudflare Access, verified rather than assumed.** See `access.js`.
  *
- * Routes are added by later tickets (#67, #68, #70). This one ships the
- * skeleton, the gate, the pacer and the request layer — deliberately, because
- * `main` is production on this repo and a page calling a route that does not
- * exist is a broken tool on the live hub (§17).
+ * Routes arrive a ticket at a time. #66 shipped the skeleton, the gate, the
+ * pacer and the request layer; #68 added `GET /contacts`. The remaining ones —
+ * events, plan, schools, student and unbook — belong to #67, #69 and #70, and
+ * answer 404 until then, deliberately: `main` is production on this repo and a
+ * page calling a route that does not exist is a broken tool on the live hub
+ * (§17).
  */
 
 import { createAccessVerifier } from './access.js';
+import { createClubworxClient } from './clubworx.js';
+import { searchContacts } from './contacts.js';
 
 export const PREFIX = '/api/clubworx';
 
@@ -65,14 +69,52 @@ function defaultMakeVerifier(env) {
 }
 
 /**
+ * `YYYY-MM-DD`, and a real day.
+ *
+ * Strict on purpose. Date orientation is the standing hazard on this map —
+ * `03/02/2009` is two different children depending on who typed it, and the
+ * damage from getting it wrong is a permanent contact keyed to the wrong
+ * birthday, which then poisons the surname + DOB key for every later term. The
+ * parser resolves orientation before anything reaches here; this route accepts
+ * one form so an unresolved date cannot slip past as a search that finds nothing.
+ */
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+function isRealDay(value) {
+  if (!ISO_DAY.test(value)) return false;
+  // `new Date('2009-02-30')` does not throw — it rolls forward to 2 March. The
+  // round-trip is what catches it.
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+/**
+ * The default search: build a paced Clubworx client from `env` and sweep the
+ * three status views. Injected in tests so the route's own behaviour — its
+ * validation, its status mapping and its log line — is asserted without a
+ * network stub standing in the way.
+ */
+const defaultSearch = ({ env, lastName, dob }) =>
+  searchContacts({
+    client: createClubworxClient({ accountKey: env.CLUBWORX_ACCOUNT_KEY }),
+    lastName,
+    dob,
+  });
+
+/**
  * Build the request handler. The seams exist so the log line and the gate can be
  * asserted directly — both are things that fail silently in production.
  *
  * @param {object} [deps]
  * @param {(env: object) => (token: string|null) => Promise<object>} [deps.makeVerifier]
  * @param {(line: string) => void} [deps.log]
+ * @param {(args: {env: object, lastName: string, dob: string}) => Promise<object>} [deps.search]
  */
-export function createHandler({ makeVerifier = defaultMakeVerifier, log = console.log } = {}) {
+export function createHandler({
+  makeVerifier = defaultMakeVerifier,
+  log = console.log,
+  search = defaultSearch,
+} = {}) {
   return async function handle(request, env) {
     const url = new URL(request.url);
 
@@ -133,7 +175,77 @@ export function createHandler({ makeVerifier = defaultMakeVerifier, log = consol
       );
     }
 
-    // events, plan, schools, contacts, student and unbook arrive with #67/#68/#70.
+    if (path === '/contacts') {
+      if (method !== 'GET') return done(json({ error: 'method not allowed' }, 405), { email });
+
+      const lastName = (url.searchParams.get('last_name') ?? '').trim();
+      const dob = (url.searchParams.get('dob') ?? '').trim();
+
+      // Both halves of the identity key or nothing. A surname-less query is a
+      // walk through ~60,000 contacts that can conclude nothing, and a query
+      // with no date of birth cannot tell siblings apart — §5. The refusal names
+      // the field and never echoes the value, because the value is the student.
+      if (!lastName) {
+        return done(json({ error: 'last_name is required', reason: 'bad-request' }, 400), { email });
+      }
+      if (!isRealDay(dob)) {
+        return done(
+          json({ error: 'dob is required, as a real YYYY-MM-DD day', reason: 'bad-request' }, 400),
+          { email },
+        );
+      }
+
+      // A missing secret is a deploy that was never finished, not a Clubworx
+      // refusal. Told apart because they send an operator to different people.
+      if (!env.CLUBWORX_ACCOUNT_KEY) {
+        return done(
+          json({ error: 'the Clubworx account key is not configured', reason: 'not-configured' }, 503),
+          { email },
+        );
+      }
+
+      const result = await search({ env, lastName, dob });
+
+      if (!result.ok) {
+        // A throttle is the one upstream status that travels as itself: §11 has
+        // the page pause the *whole run* on a 429, because the allowance is
+        // gym-wide and backing off one student while the rest continue just
+        // spends the next window failing.
+        //
+        // Everything else becomes 502. Passing Clubworx's own code through would
+        // put a 401 from Clubworx beside the 401 this Worker's Access gate
+        // returns, and send an operator to re-authenticate against a problem
+        // that is not theirs.
+        const status = result.reason === 'throttled' ? 429 : 502;
+        return done(
+          json(
+            {
+              // Verbatim, never re-worded — D6. #50 is the cautionary tale: a
+              // truthful-sounding paraphrase pointed at the wrong mechanism and
+              // cost an architectural route.
+              error:
+                result.message ??
+                (result.reason === 'throttled'
+                  ? 'Clubworx is busy — this can be caused by another system, not this page. Try again shortly.'
+                  : 'the Clubworx contact search failed'),
+              reason: result.reason,
+              view: result.view ?? null,
+              upstreamStatus: result.upstreamStatus ?? null,
+              requests: result.requests ?? 0,
+            },
+            status,
+          ),
+          { email },
+        );
+      }
+
+      return done(
+        json({ candidates: result.candidates, views: result.views, requests: result.requests }),
+        { email },
+      );
+    }
+
+    // events, plan, schools, student and unbook arrive with #67/#69/#70.
     return done(json({ error: 'not found' }, 404), { email });
   };
 }

--- a/cloudflare-clubworx/test/contacts.test.js
+++ b/cloudflare-clubworx/test/contacts.test.js
@@ -1,0 +1,352 @@
+import { describe, it, expect } from 'vitest';
+import { CONTACT_VIEWS, MAX_PAGES, PAGE_SIZE, searchContacts } from '../src/contacts.js';
+
+// The dedup read, and the trap it exists to avoid.
+//
+// `/prospects`, `/members` and `/non_attending_contacts` are three **disjoint
+// views by status**, not three indexes over one table (#49). A contact sits in
+// exactly one and moves as their status changes, so a prospect-only lookup stops
+// finding a student the moment they take a membership — which is not
+// hypothetical: it broke the #60 probe when its own test contacts were
+// converted. Every test below that looks redundant is guarding a way this search
+// could quietly stop covering one of the three.
+//
+// The second theme is that **silence is the dangerous answer here**. A search
+// that returns nothing reports the student as `new`, and `new` writes a contact
+// that Clubworx cannot delete (ACCESS.md §4). So a failed view, an unreadable
+// body and a sweep that never narrowed all refuse rather than answering with a
+// short list.
+
+const rows = {
+  amelia: {
+    contact_key: 'ck-amelia',
+    first_name: 'Amelia',
+    last_name: 'Nowak',
+    dob: '2009-03-02',
+    email: 'noreply+newman@urbanjungleirc.com',
+    status: 'Prospect',
+    phone: '0400 000 000',
+    address: '1 Somewhere St',
+  },
+  twin: {
+    contact_key: 'ck-twin',
+    first_name: 'Julia',
+    last_name: 'Nowak',
+    dob: '2009-03-02',
+    email: 'noreply+newman@urbanjungleirc.com',
+    status: 'Member',
+  },
+};
+
+/** A Clubworx client stub: one canned answer per view, plus a call recorder. */
+function clientWith(byView) {
+  const calls = [];
+  return {
+    calls,
+    get: async (path, params) => {
+      calls.push({ path, params });
+      const answer = byView[path];
+      const resolved = typeof answer === 'function' ? answer(params) : answer;
+      return {
+        ok: true,
+        status: 200,
+        url: `https://app.clubworx.com/api/v2/${path}`,
+        ms: 1,
+        body: [],
+        nonJson: false,
+        bodyText: null,
+        message: null,
+        networkError: false,
+        ...(resolved ?? {}),
+      };
+    },
+  };
+}
+
+/** Every view answers with the same empty list. */
+const emptyEverywhere = () => clientWith(Object.fromEntries(CONTACT_VIEWS.map(v => [v, { body: [] }])));
+
+const search = (client, over = {}) =>
+  searchContacts({ client, lastName: 'Nowak', dob: '2009-03-02', ...over });
+
+describe('the three status views', () => {
+  it('names all three, in the order #49 measured them', () => {
+    expect(CONTACT_VIEWS).toEqual(['prospects', 'members', 'non_attending_contacts']);
+  });
+
+  it('searches every one of them, not just prospects', async () => {
+    const client = emptyEverywhere();
+    await search(client);
+
+    expect(client.calls.map(c => c.path)).toEqual(CONTACT_VIEWS);
+  });
+
+  it('finds a student who has since become a member', async () => {
+    // The #60 failure exactly: the contact was created as a prospect, somebody
+    // converted it, and a prospect-only lookup went blind.
+    const client = clientWith({ prospects: { body: [] }, members: { body: [rows.amelia] } });
+    const result = await search(client);
+
+    expect(result.ok).toBe(true);
+    expect(result.candidates.map(c => c.contact_key)).toEqual(['ck-amelia']);
+  });
+
+  it('finds a student parked in non_attending_contacts', async () => {
+    const client = clientWith({ non_attending_contacts: { body: [rows.amelia] } });
+    const result = await search(client);
+
+    expect(result.candidates.map(c => c.contact_key)).toEqual(['ck-amelia']);
+  });
+
+  it('records which view held each contact, so a duplicate can be explained', async () => {
+    const client = clientWith({ members: { body: [rows.amelia] } });
+    const [candidate] = (await search(client)).candidates;
+
+    expect(candidate.status_view).toBe('members');
+  });
+});
+
+describe('the query', () => {
+  it('asks on surname and date of birth — the candidate-narrowing key of §5', async () => {
+    const client = emptyEverywhere();
+    await search(client);
+
+    expect(client.calls[0].params).toMatchObject({ last_name: 'Nowak', dob: '2009-03-02' });
+  });
+
+  it('always sends a page size, because the default 50 is silent truncation (#51)', async () => {
+    const client = emptyEverywhere();
+    await search(client);
+
+    for (const call of client.calls) expect(call.params.page_size).toBe(PAGE_SIZE);
+  });
+
+  it('starts at page 1 and does not page a view that came back short', async () => {
+    const client = clientWith({ prospects: { body: [rows.amelia] } });
+    await search(client);
+
+    expect(client.calls[0].params.page).toBe(1);
+    expect(client.calls.filter(c => c.path === 'prospects')).toHaveLength(1);
+  });
+
+  it('costs three requests for a student found on the first page of each view', async () => {
+    // The ticket's budget: 3 reads per student, so a 25-student list spends ~75
+    // requests here alone. A fourth request per student would be a 33% run.
+    const client = emptyEverywhere();
+    expect((await search(client)).requests).toBe(3);
+  });
+});
+
+describe('paging to exhaustion', () => {
+  /** A view that answers `total` rows across pages of `PAGE_SIZE`. */
+  const pagedView = total => params => {
+    const page = Number(params.page);
+    const from = (page - 1) * PAGE_SIZE;
+    const body = Array.from({ length: Math.max(0, Math.min(PAGE_SIZE, total - from)) }, (_, i) => ({
+      ...rows.amelia,
+      contact_key: `ck-${from + i}`,
+    }));
+    return { body };
+  };
+
+  it('fetches the next page when one comes back full — a full page is not a complete list', async () => {
+    const client = clientWith({ prospects: pagedView(PAGE_SIZE + 3) });
+    const result = await search(client);
+
+    expect(client.calls.filter(c => c.path === 'prospects').map(c => c.params.page)).toEqual([1, 2]);
+    expect(result.candidates).toHaveLength(PAGE_SIZE + 3);
+  });
+
+  it('stops at the first short page rather than walking to an empty one', async () => {
+    const client = clientWith({ prospects: pagedView(PAGE_SIZE + 3) });
+    await search(client);
+
+    // Page 2 came back short, so page 3 is a request that buys nothing and
+    // spends a gym-wide allowance the roster Worker is also drawing on.
+    expect(client.calls.filter(c => c.path === 'prospects')).toHaveLength(2);
+  });
+
+  it('stops when an exactly-full last page is followed by an empty one', async () => {
+    const client = clientWith({ prospects: pagedView(PAGE_SIZE) });
+    const result = await search(client);
+
+    expect(client.calls.filter(c => c.path === 'prospects').map(c => c.params.page)).toEqual([1, 2]);
+    expect(result.candidates).toHaveLength(PAGE_SIZE);
+  });
+
+  it('de-duplicates rows a shifting page boundary showed twice', async () => {
+    const client = clientWith({
+      prospects: params => ({ body: Number(params.page) === 1 ? Array(PAGE_SIZE).fill(rows.amelia) : [rows.amelia] }),
+    });
+
+    expect((await search(client)).candidates).toHaveLength(1);
+  });
+
+  it('de-duplicates by contact_key across the three views', async () => {
+    // A contact that moves mid-search can be seen twice. Merging is by key, not
+    // by position — #68 says de-duplicate by `contact_key`.
+    const client = clientWith({ prospects: { body: [rows.amelia] }, members: { body: [rows.amelia] } });
+
+    expect((await search(client)).candidates).toHaveLength(1);
+  });
+
+  it('drops a row with no contact_key rather than merging it under undefined', async () => {
+    const client = clientWith({ prospects: { body: [{ ...rows.amelia, contact_key: undefined }] } });
+
+    expect((await search(client)).candidates).toEqual([]);
+  });
+});
+
+describe('a sweep that never narrowed', () => {
+  const alwaysFull = () => ({ body: Array.from({ length: PAGE_SIZE }, (_, i) => ({ ...rows.amelia, contact_key: `ck-${i}` })) });
+
+  it('refuses rather than answering from a truncated sweep', async () => {
+    // Whether Clubworx honours a `last_name` filter server-side is unmeasured.
+    // If it does not, this is a walk through a 60,000-person database — and the
+    // rows it returns are strangers. Refusing is what stops that answer being
+    // mistaken for a narrow one.
+    const client = clientWith({ prospects: alwaysFull });
+    const result = await search(client);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('search-not-narrowed');
+    expect(result.view).toBe('prospects');
+  });
+
+  it('bounds the walk instead of paging a whole gym database', async () => {
+    const client = clientWith({ prospects: alwaysFull });
+    await search(client);
+
+    expect(client.calls.filter(c => c.path === 'prospects')).toHaveLength(MAX_PAGES);
+  });
+
+  it('stops the whole search at the first view that would not narrow', async () => {
+    const client = clientWith({ prospects: alwaysFull });
+    await search(client);
+
+    expect(client.calls.every(c => c.path === 'prospects')).toBe(true);
+  });
+});
+
+describe('when a view fails', () => {
+  it('refuses the whole search rather than answering from two views out of three', async () => {
+    // A partial answer is the #49 trap wearing a different hat: the missing view
+    // is exactly where the student might be, and a short candidate set reports
+    // them `new`. `new` writes a contact that cannot be deleted.
+    const client = clientWith({
+      prospects: { body: [] },
+      members: { ok: false, status: 500, body: null, message: 'Internal Server Error' },
+    });
+    const result = await search(client);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('upstream-error');
+    expect(result.view).toBe('members');
+    expect(result.upstreamStatus).toBe(500);
+  });
+
+  it('stops calling the remaining views once one has failed', async () => {
+    const client = clientWith({ prospects: { ok: false, status: 500, body: null } });
+    await search(client);
+
+    expect(client.calls).toHaveLength(1);
+  });
+
+  it('tells a throttle apart from every other failure, because a 429 pauses the run', async () => {
+    const client = clientWith({ prospects: { ok: false, status: 429, body: null } });
+    const result = await search(client);
+
+    expect(result.reason).toBe('throttled');
+    expect(result.upstreamStatus).toBe(429);
+  });
+
+  it('treats a connection failure as a failure, not as an empty view', async () => {
+    const client = clientWith({
+      prospects: { ok: false, status: 0, body: null, networkError: true, message: 'fetch failed' },
+    });
+    const result = await search(client);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('upstream-error');
+  });
+
+  it('refuses a 200 whose body is not a list, rather than reading it as zero rows', async () => {
+    // Measured: these endpoints answer with a bare array. Anything else is a
+    // response nobody has seen, and "no rows" is the one wrong guess that ends
+    // in a permanent duplicate contact.
+    const client = clientWith({ prospects: { ok: true, status: 200, body: { contacts: [] } } });
+    const result = await search(client);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('upstream-error');
+  });
+
+  it('carries the upstream message through unchanged, never re-worded (D6)', async () => {
+    const client = clientWith({
+      prospects: { ok: false, status: 400, body: null, message: "Woops! Something you've not seen before" },
+    });
+
+    expect((await search(client)).message).toContain("Woops! Something you've not seen before");
+  });
+});
+
+describe('what a candidate carries', () => {
+  it('carries the four fields the match rule reads', async () => {
+    const client = clientWith({ prospects: { body: [rows.amelia] } });
+    const [candidate] = (await search(client)).candidates;
+
+    // school-booking/identity.js matches on these and nothing else.
+    expect(candidate).toMatchObject({
+      contact_key: 'ck-amelia',
+      first_name: 'Amelia',
+      last_name: 'Nowak',
+      dob: '2009-03-02',
+    });
+  });
+
+  it('carries the email, because the noreply+<school> tag is the only provenance there is', async () => {
+    const client = clientWith({ prospects: { body: [rows.amelia] } });
+    const [candidate] = (await search(client)).candidates;
+
+    expect(candidate.email).toBe('noreply+newman@urbanjungleirc.com');
+  });
+
+  it('leaves behind the fields nothing here asks a question of', async () => {
+    // The Worker is a transit (§6, D10). A phone number and a home address are
+    // not part of deciding whether this student already exists, so they do not
+    // travel to the browser.
+    const client = clientWith({ prospects: { body: [rows.amelia] } });
+    const [candidate] = (await search(client)).candidates;
+
+    expect(candidate.phone).toBeUndefined();
+    expect(candidate.address).toBeUndefined();
+  });
+});
+
+describe('what it refuses to decide', () => {
+  it('returns both twins rather than picking one', async () => {
+    // The match state is produced by the pure school-booking/identity.js module,
+    // which stays network-free so it stays testable. This route narrows; it does
+    // not conclude.
+    const client = clientWith({ prospects: { body: [rows.amelia, rows.twin] } });
+    const result = await search(client);
+
+    expect(result.candidates.map(c => c.contact_key).sort()).toEqual(['ck-amelia', 'ck-twin']);
+  });
+
+  it('does not drop a candidate whose dob came back blank', async () => {
+    // A contact created by hand often carries no DOB (#49). identity.js has a
+    // `candidate-dob-unknown` state for exactly this row; filtering it out here
+    // would report an existing student as `new`.
+    const client = clientWith({ prospects: { body: [{ ...rows.amelia, dob: '' }] } });
+
+    expect((await search(client)).candidates).toHaveLength(1);
+  });
+
+  it('answers an empty candidate set plainly when nothing was found', async () => {
+    const result = await search(emptyEverywhere());
+
+    expect(result.ok).toBe(true);
+    expect(result.candidates).toEqual([]);
+  });
+});

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -230,3 +230,206 @@ describe('responses', () => {
     expect(res.headers.get('Cache-Control')).toContain('no-store');
   });
 });
+
+describe('GET /contacts', () => {
+  // The dedup read. What is asserted here is the *route* — validation, status
+  // mapping and the log line. The three-view search itself is pinned in
+  // contacts.test.js.
+
+  const found = {
+    ok: true,
+    candidates: [{ contact_key: 'ck-1', first_name: 'Amelia', last_name: 'Nowak', dob: '2009-03-02' }],
+    views: [{ view: 'prospects', pages: 1, rows: 1 }],
+    requests: 3,
+  };
+
+  const failed = over => ({
+    ok: false,
+    reason: 'upstream-error',
+    upstreamStatus: 500,
+    view: 'members',
+    message: null,
+    candidates: [],
+    requests: 2,
+    ...over,
+  });
+
+  /** A handler whose search is stubbed, recording what the route asked it for. */
+  function routeWith(result, { env = ENV } = {}) {
+    const asked = [];
+    const lines = [];
+    const handle = createHandler({
+      makeVerifier: () => accepts('staff@urbanjungleirc.com'),
+      log: line => lines.push(line),
+      search: async args => {
+        asked.push(args);
+        return typeof result === 'function' ? result(args) : result;
+      },
+    });
+    return {
+      asked,
+      lines,
+      call: (path, init = withJwt) => handle(new Request(`https://ujstaff.happyk.au${path}`, init), env),
+    };
+  }
+
+  const query = '/api/clubworx/contacts?last_name=Nowak&dob=2009-03-02';
+
+  it('hands back the candidate set the search merged', async () => {
+    const h = routeWith(found);
+    const res = await h.call(query);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).candidates).toHaveLength(1);
+  });
+
+  it('passes the surname and date of birth through to the search', async () => {
+    const h = routeWith(found);
+    await h.call(query);
+
+    expect(h.asked[0]).toMatchObject({ lastName: 'Nowak', dob: '2009-03-02' });
+  });
+
+  it('reports what the search cost, so a run can be held to its budget', async () => {
+    // 3 reads per student; a 25-student list spends ~75 requests on this route
+    // alone, against a measured ceiling of 75/min shared with the whole gym.
+    const h = routeWith(found);
+
+    expect((await (await h.call(query)).json()).requests).toBe(3);
+  });
+
+  it('trims the surname rather than searching for a padded one', async () => {
+    const h = routeWith(found);
+    await h.call('/api/clubworx/contacts?last_name=%20Nowak%20&dob=2009-03-02');
+
+    expect(h.asked[0].lastName).toBe('Nowak');
+  });
+
+  it('refuses a method it does not implement — this route is read-only', async () => {
+    const h = routeWith(found);
+    expect((await h.call(query, { ...withJwt, method: 'POST' })).status).toBe(405);
+  });
+
+  describe('what it refuses to ask Clubworx', () => {
+    const refuses = async path => {
+      const h = routeWith(found);
+      const res = await h.call(path);
+      return { status: res.status, body: await res.json(), asked: h.asked };
+    };
+
+    it('refuses a missing surname instead of sweeping the database', async () => {
+      // Both halves of the identity key are required (§5). A surname-less query
+      // is a walk through ~60,000 contacts, and it cannot conclude anything.
+      const { status, asked } = await refuses('/api/clubworx/contacts?dob=2009-03-02');
+
+      expect(status).toBe(400);
+      expect(asked).toHaveLength(0);
+    });
+
+    it('refuses a blank surname, which a template can produce by accident', async () => {
+      expect((await refuses('/api/clubworx/contacts?last_name=%20%20&dob=2009-03-02')).status).toBe(400);
+    });
+
+    it('refuses a missing date of birth', async () => {
+      expect((await refuses('/api/clubworx/contacts?last_name=Nowak')).status).toBe(400);
+    });
+
+    it('refuses a date that is not YYYY-MM-DD', async () => {
+      // Date orientation is the standing hazard on this map: 03/02/2009 is two
+      // different children depending on who typed it. This route takes one form.
+      expect((await refuses('/api/clubworx/contacts?last_name=Nowak&dob=02/03/2009')).status).toBe(400);
+    });
+
+    it('refuses a well-shaped date that is not a real day', async () => {
+      expect((await refuses('/api/clubworx/contacts?last_name=Nowak&dob=2009-02-30')).status).toBe(400);
+    });
+
+    it('says which field it refused, without repeating the value back', async () => {
+      const { body } = await refuses('/api/clubworx/contacts?last_name=Nowak&dob=02/03/2009');
+
+      expect(body.reason).toBe('bad-request');
+      expect(body.error).toMatch(/dob/);
+      expect(JSON.stringify(body)).not.toContain('02/03/2009');
+    });
+  });
+
+  describe('when the search cannot answer', () => {
+    it('passes a throttle through as 429, because the page pauses the whole run on it', async () => {
+      // §11: the allowance is gym-wide, so backing off one student while the
+      // others continue just spends the next window failing. The Worker does not
+      // retry — it reports, and the run decides.
+      const h = routeWith(failed({ reason: 'throttled', upstreamStatus: 429, view: 'prospects' }));
+      const res = await h.call(query);
+
+      expect(res.status).toBe(429);
+      expect((await res.json()).reason).toBe('throttled');
+    });
+
+    it('answers 502 for an upstream failure, not the upstream status', async () => {
+      // Clubworx answering 401 must not reach the browser as 401 — that is the
+      // Access gate's code on this Worker, and confusing the two sends an
+      // operator to re-authenticate against a problem that is not theirs.
+      const h = routeWith(failed({ upstreamStatus: 401, message: 'Authorization failed' }));
+      const res = await h.call(query);
+
+      expect(res.status).toBe(502);
+      expect((await res.json()).upstreamStatus).toBe(401);
+    });
+
+    it('carries the upstream message verbatim, never re-worded (D6)', async () => {
+      const h = routeWith(failed({ upstreamStatus: 400, message: 'Woops! Something new' }));
+
+      expect((await (await h.call(query)).json()).error).toContain('Woops! Something new');
+    });
+
+    it('refuses a sweep that never narrowed, rather than serving a truncated list', async () => {
+      const h = routeWith(
+        failed({ reason: 'search-not-narrowed', upstreamStatus: 200, view: 'prospects', message: 'still full at page 3' }),
+      );
+      const res = await h.call(query);
+
+      expect(res.status).toBe(502);
+      expect((await res.json()).reason).toBe('search-not-narrowed');
+    });
+
+    it('never answers 200 with an empty list when the search failed', async () => {
+      // An empty candidate set is read as `new`, and `new` writes a contact that
+      // Clubworx cannot delete. A failure must never look like "nobody found".
+      const h = routeWith(failed());
+      const res = await h.call(query);
+
+      expect(res.status).not.toBe(200);
+      expect((await res.json()).candidates).toBeUndefined();
+    });
+  });
+
+  it('says the key was never put, rather than failing as though Clubworx refused', async () => {
+    const h = routeWith(found, { env: { ...ENV, CLUBWORX_ACCOUNT_KEY: undefined } });
+    const res = await h.call(query);
+
+    expect(res.status).toBe(503);
+    expect((await res.json()).reason).toBe('not-configured');
+  });
+
+  it('keeps the student out of the log line, on every path through the route', async () => {
+    // The one rule in §6/D10 that a single debugging console.log undoes. The
+    // route's own query string is where a surname and a birthday travel.
+    const h = routeWith(failed());
+    await h.call(query);
+    await h.call('/api/clubworx/contacts?last_name=Nowak');
+
+    for (const raw of h.lines) {
+      expect(raw).not.toContain('Nowak');
+      expect(raw).not.toContain('2009-03-02');
+    }
+    expect(JSON.parse(h.lines[0]).route).toBe('/api/clubworx/contacts');
+  });
+
+  it('never lets a candidate reach the log line either', async () => {
+    const h = routeWith(found);
+    await h.call(query);
+
+    expect(h.lines[0]).not.toContain('Amelia');
+    expect(h.lines[0]).not.toContain('ck-1');
+  });
+});

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -365,6 +365,28 @@ describe('GET /contacts', () => {
       expect((await res.json()).reason).toBe('throttled');
     });
 
+    it('gives a throttle §11 wording even though the upstream body is HTML', async () => {
+      // The bug this pins: a throttle answers in HTML, so `errorMessageOf` finds
+      // nothing and clubworx.js falls back to `bodyText` — up to 500 characters
+      // of scrubbed markup, which is non-null and would win a `??` against the
+      // sentence §11 requires. The operator would meet a WAF page instead of
+      // being told the cause may be another system on the same gym-wide key.
+      const h = routeWith(
+        failed({
+          reason: 'throttled',
+          upstreamStatus: 429,
+          view: 'prospects',
+          message: '<html><head><title>429 Too Many Requests</title></head><body>…</body></html>',
+        }),
+      );
+      const body = await (await h.call(query)).json();
+
+      expect(body.error).toBe(
+        'Clubworx is busy — this can be caused by another system, not this page. Try again shortly.',
+      );
+      expect(body.error).not.toContain('html');
+    });
+
     it('answers 502 for an upstream failure, not the upstream status', async () => {
       // Clubworx answering 401 must not reach the browser as 401 — that is the
       // Access gate's code on this Worker, and confusing the two sends an


### PR DESCRIPTION
Closes #68. Part of #46. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §5, §6, §11.

`GET /api/clubworx/contacts?last_name=&dob=` — the dedup read the run makes once per student, before deciding whether to create a contact.

## What it does

Searches `/prospects`, `/members` **and** `/non_attending_contacts`, pages each to exhaustion at `page_size=200`, and merges by `contact_key`. Those three are disjoint views by status, not indexes over one table (#49) — a contact sits in exactly one and moves as their status changes, so a prospect-only lookup goes blind the moment a student takes a membership. That is not hypothetical: it broke the #60 probe when its own test contacts were converted.

It **does not decide the match**. `new` / `matched` / `name-variant` / `ambiguous` stays in the pure `school-booking/identity.js`. It does not filter the returned rows either, because matching runs on compare form and that table lives in `parse.js` — a second copy would drift, and the day the two disagree `O'Brien` stops matching `OBrien` and a second permanent contact gets written.

It **does not retry**. §11's D8 pauses the *whole run* on a 429 because the allowance is gym-wide (#47); retrying inside the Worker would hide the throttle from the only layer that can act on it. A 429 travels as itself; every other upstream failure becomes 502, so a 401 from Clubworx can't be mistaken for the Access gate's own 401.

## Every uncertain answer is a refusal

The caller reads an empty candidate set as `new`, and `new` writes a contact **Clubworx cannot delete** (ACCESS.md §4). The failure modes aren't symmetric — an over-broad set costs a human a second look, a short one costs a permanent record beside ~60,000 real people. So a failed view, a `200` whose body isn't a list, and a query that never narrowed all refuse the whole search rather than answering short.

## Two things that need your call

**1. `MAX_PAGES = 3` is a deviation from the ticket.** #68 says *"Page each view to exhaustion."* This pages to exhaustion **up to 3 pages per view**, then refuses with `search-not-narrowed`.

The reason: whether Clubworx honours `last_name`/`dob` as filters is unmeasured — only `email` has ever been measured (#49). If it ignores them, "to exhaustion" is a walk through the whole database at 75 req/min, minutes per student, every row a stranger's name and birthday going to a browser. A ceiling that *refuses* is safer than a truncation flag, because a flag is something a caller can ignore and ignoring this one writes a duplicate.

The risk in the other direction, raised by the spec review: `probes/README.md` suggests `last_name` is a **partial** match, so a common surname could legitimately exceed 600 rows and hard-stop a run that should have worked. #92 measures which it is. **Happy to raise the ceiling or make it a flag instead if you'd rather — say the word.**

**2. #92 — the DOB format is assumed, never measured.** Filed off the back of this review, and it's the highest-cost gap on the map right now.

`dob` is passed through exactly as Clubworx sent it, and `matchStudent` string-compares it against `parse.js`'s ISO. Nothing has ever measured what Clubworx actually returns — #49 recorded the schema deliberately without values. If it comes back `02/05/1999`, every comparison is false, every student reports `new`, and a 25-student run writes 25 permanent contacts. Silently: nothing throws, and it looks exactly like a school that has never climbed here.

Normalising on a guess would be worse than not normalising — orientation is ambiguous, and a wrong guess is the same duplicate with a confident comment over it. So it passes through, the soft spot is documented in both the module header and the README, and #92 measures it. **#69's write chain should not ship before #92 is answered.**

## Review

Ran `/code-review` (standards + spec, in parallel).

**Standards: no hard violations.** Acted on the judgement calls — dropped a dead `errorMessageOf` branch, dropped two never-overridden parameters, fixed AGENTS.md drift and a self-inconsistent README example. Declined one: `isRealDay` was flagged as duplicating `validDate` in `parse.js`, but that helper is private, takes three numbers rather than an ISO string, and the compareForm argument doesn't carry over — a compare-form drift silently writes a duplicate, a date-validity drift is a visible 400.

**Spec: found a real bug**, fixed in 3b29d29. The throttle path built its message as `result.message ?? <§11 wording>`, but a throttle answers in HTML, so `bodyText` was non-null and won the `??` — the operator would have met a WAF page instead of the sentence saying the cause may be another system. The existing test missed it by stubbing `message: null`, the one value the real client never produces there. New test stubs the HTML.

## Tests

376 pass in `cloudflare-clubworx` (46 new). Run with `cd cloudflare-clubworx && npm test`.

Two failures exist at the repo root in `vouchers/test/version.test.js` — byte-identical to `main`, pre-existing, untouched by this branch.

## Deploying

This Worker deploys separately; merging this PR does **not** deploy it. `cd cloudflare-clubworx && npx wrangler deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
