### PR TITLE
feat(clubworx): POST /student — the per-student write chain (#69)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,16 @@ cloudflare-clubworx/    - uj-clubworx-api, the Worker for the school-group booki
                           comes from and where it lives). Verifies the Access JWT
                           rather than trusting the header, paces at 75 req/min, and
                           stores nothing — no student name or DOB in any store or
-                          log line. GET /api/clubworx/health (#66) and
-                          GET /api/clubworx/contacts (#68) so far; events, plan,
-                          schools, student and unbook arrive with #67/#69/#70.
+                          log line. GET /api/clubworx/health (#66),
+                          GET /api/clubworx/contacts (#68) and
+                          POST /api/clubworx/student (#69) so far; events, plan,
+                          schools and unbook arrive with #67/#70.
+                          src/student.js is the ONLY code here that creates
+                          permanent records — contacts and memberships have no
+                          delete, so every write is verified by re-reading it and
+                          any failure rolls that student's bookings back. Read
+                          §10/§12 of the design spec before touching it.
+                          The full per-file roster is in CLAUDE.md.
 hvt/                    - High-volume Training tool copy
 slideshow/              - Google Drive TV slideshow tool
 sls_tv.html             - Summer Lead Series TV display

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,16 +22,34 @@ cloudflare-clubworx/    - uj-clubworx-api, the Worker for the school-group booki
                           comes from and where it lives). Verifies the Access JWT
                           rather than trusting the header, paces at 75 req/min, and
                           stores nothing — no student name or DOB in any store or
-                          log line. GET /api/clubworx/health (#66) and
-                          GET /api/clubworx/contacts (#68) so far; events, plan,
-                          schools, student and unbook arrive with #67/#69/#70.
+                          log line. GET /api/clubworx/health (#66),
+                          GET /api/clubworx/contacts (#68) and
+                          POST /api/clubworx/student (#69) so far; events, plan,
+                          schools and unbook arrive with #67/#70.
 cloudflare-clubworx/src/contacts.js - the dedup read. Searches all three disjoint
                           status views and merges, because a contact moves between
                           them (#49). Every uncertain answer is a refusal: an
                           empty candidate set means "new", and "new" writes a
                           contact Clubworx cannot delete.
-cloudflare-clubworx/src/ - the Worker. request.js and errors.js were moved here
-                          from probes/lib/ by #66 and the probes import them back.
+cloudflare-clubworx/src/student.js - the per-student write chain, and the ONLY
+                          code here that creates permanent records. Contacts and
+                          memberships have no delete, so every write is verified
+                          by re-reading it, every retry re-reads first, and any
+                          failure rolls back that student's bookings and names
+                          them stranded. Read §10/§12 of the design spec first.
+cloudflare-clubworx/src/bookings.js - book, cancel, and the error vocabulary.
+                          Three refusals share HTTP 400 and the message string is
+                          the only discriminator; "already booked" is a SUCCESS
+                          and carries no booking id, which is what stops a
+                          rollback reaching a booking this run did not create.
+cloudflare-clubworx/src/memberships.js - is the held School Pass good enough? The
+                          test is "covers the last selected session", never
+                          "active today" (ADR 0005). A live-but-short pass
+                          refuses rather than granting a second one to a live
+                          holder — #90's open question.
+cloudflare-clubworx/src/ - the Worker. request.js, errors.js and
+                          summariseMemberships were moved here from probes/lib/
+                          by #66 and #69, and the probes import them back.
 cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, and
                           what they found. Start with probes/README.md — it carries
                           the rules (no production data recorded, pace under

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -29,6 +29,7 @@ src/student.js   the per-student write chain, and D3's rollback   (#69)
 src/bookings.js  book, cancel, and the error vocabulary           (#69)
 src/memberships.js  summariseMemberships + D4's pass verdict (promoted, #69)
 src/duration.js  the plan's duration, and what a pass covers      (#69)
+src/upstream.js  what a Clubworx failure means: retry, report, neither (#69)
 src/pace.js      75 req/min, one in flight — the constant #51 measured
 src/request.js   buildUrl + redact                (promoted from probes/lib)
 src/errors.js    errorMessageOf                   (promoted from probes/lib)
@@ -364,15 +365,18 @@ rows attached.
 
 Only two things are not a `200`, and in both there is nothing to record:
 
-- **`429`** — §11 pauses the *whole run* on a throttle, because the allowance is
-  gym-wide.
+- **`429`** — a throttle **that wrote nothing**. §11 pauses the *whole run* on a
+  throttle, because the allowance is gym-wide.
 - **`400`** — a refusal that happened before any write: a session inside the
   24-hour lead time, a pass that will not cover the term, a malformed request.
 
-Everything else — including an abandoned, rolled-back student — is a `200`
-carrying the full result. A result is not an error, and D10 writes each row to
+Everything else — including an abandoned, rolled-back student, and including a
+throttle that struck *after* something permanent was written — is a `200`
+carrying the full result. **A result is not an error.** D10 writes each row to
 the browser as it lands because a page reload destroying the only record of a
-creation that cannot be undone is the specific failure that defends against.
+creation that cannot be undone is the specific failure that defends against, and
+a non-200 invites a client to throw the body away. `reason: "throttled"` is in
+the body either way, which is what the page should pause on.
 
 ### What a run costs here
 

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -5,13 +5,15 @@ the school group booking map ([#46](https://github.com/urbanjungleirc/staff-site
 Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §6.
 
 #66 shipped the **skeleton**: the Worker, the Access gate, the pacer and the
-request layer. #68 added the dedup read. The rest — `events`, `plan`, `schools`,
-`student`, `unbook` — arrive with #67, #69 and #70, and answer `404` until then.
+request layer. #68 added the dedup read, and #69 the write chain. The rest —
+`events`, `plan`, `schools`, `unbook` — arrive with #67 and #70, and answer
+`404` until then.
 
 | Route | Ticket | Does |
 |---|---|---|
 | `GET /api/clubworx/health` | #66 | Names the authenticated operator; says whether the secret was put |
 | `GET /api/clubworx/contacts?last_name=&dob=` | #68 | Searches all three status views and merges — see below |
+| `POST /api/clubworx/student` | #69 | **The only route that writes.** One student, all their sessions — see below |
 
 `ACCESS.md` in this directory is the answer to #47: where the key comes from,
 where it lives, and what is still owed. Read it first.
@@ -23,6 +25,10 @@ src/index.js     the Worker: routing, the Access gate, the log line
 src/access.js    Cloudflare Access JWT verification against the team JWKS
 src/clubworx.js  the only path to Clubworx: paced, redacted, measured shapes
 src/contacts.js  the dedup read: all three status views, merged  (#68)
+src/student.js   the per-student write chain, and D3's rollback   (#69)
+src/bookings.js  book, cancel, and the error vocabulary           (#69)
+src/memberships.js  summariseMemberships + D4's pass verdict (promoted, #69)
+src/duration.js  the plan's duration, and what a pass covers      (#69)
 src/pace.js      75 req/min, one in flight — the constant #51 measured
 src/request.js   buildUrl + redact                (promoted from probes/lib)
 src/errors.js    errorMessageOf                   (promoted from probes/lib)
@@ -30,8 +36,8 @@ test/            vitest, run by hand — this repo runs no tests in CI
 probes/          the read-only probes, and what they found
 ```
 
-`src/request.js` and `src/errors.js` were **moved** out of `probes/lib/`, not
-copied. The probes import them from here now. They were written against measured
+`src/request.js`, `src/errors.js` and `summariseMemberships` were **moved** out
+of `probes/lib/`, not copied. The probes import them from here now. They were written against measured
 Clubworx behaviour and carry their own test files; a second copy would re-derive
 their bugs, and the two would drift on the first fix that only landed in one.
 
@@ -253,6 +259,129 @@ response so a run can be held to that budget.
 [#51]: https://github.com/urbanjungleirc/staff-site/issues/51
 [#60]: https://github.com/urbanjungleirc/staff-site/issues/60
 [#92]: https://github.com/urbanjungleirc/staff-site/issues/92
+
+## `POST /student` — the per-student write chain
+
+**The only route in this Worker that creates permanent records.** Read
+[§12 of the design spec](../docs/superpowers/specs/2026-08-19-school-group-booking-design.md)
+before changing any of it.
+
+```jsonc
+POST /api/clubworx/student
+{
+  "student": { "first_name": "…", "last_name": "…", "dob": "2012-03-04",
+               "email": "noreply+stbedes@urbanjungleirc.com" },
+  "contact_key": null,              // null means "new" — this call creates them
+  "membership_plan_id": 64189,      // from GET /plan
+  "membership_duration": "26 weeks",// the plan's own string, raw
+  "events": [{ "event_id": 101, "starts_at": "2026-09-03T10:00:00+08:00" }]
+}
+```
+
+```
+matched → re-read membership → ensure School Pass → book ×N → verify
+new     → create contact WITH the pass ───────────→ book ×N → verify
+```
+
+### The unit is one student, and it is all-or-nothing
+
+**D2** — a student is the only unit whose failure boundary is a sentence staff
+can say out loud: *"the first six are in, the rest are not."* Per-event strands
+a child who turns up to session 4 and is not on the list.
+
+**D3** — any failure abandons the student and **cancels the bookings this run
+already made for them**. The rollback runs the same code path as the human
+"Cancel bookings from this run" control, with no human present, so it honours
+the same interlock: act on `booked`, **never** on `already booked`.
+
+It leaves a **stranded student** — a permanent contact and pass, no bookings —
+which the response names in `stranded` and `strandedDetail`. Under D3 an
+abandoned student is *guaranteed* to be stranded, so it is a routine outcome and
+not an edge case.
+
+### `ensure School Pass` means *covers the last session*, not *active today*
+
+The check compares the held pass's `expiration_date` against the **latest
+selected session**, inclusive. *Active today* is the answer that hid the original
+bug: every booking in a run is written on a day the pass is active, so an
+insufficient pass looks perfect at write time and fails weeks later at a session
+nobody is watching ([ADR 0005](../docs/adr/0005-school-pass-runs-26-weeks.md)).
+
+| Case | What happens |
+|---|---|
+| New contact | `POST /members` carrying `membership_plan_id` — one call, pass starts today |
+| Returning, pass **covers** the term | skip the grant |
+| Returning, pass **expired** | grant |
+| Returning, pass **active but not covering** | **`needs-confirmation`** — never a silent second grant |
+
+That last row is [#90](https://github.com/urbanjungleirc/staff-site/issues/90)'s
+open question. Granting there means putting a second School Pass on a live
+holder, which has deliberately never been probed because memberships have no
+delete. Until it is answered the row refuses and a human decides.
+
+**The number 26 is nowhere in the code.** `membership_duration` is read off the
+plan and `expiration_date` off the granted pass. The duration is a *human string*
+— parsed best-effort, and an unparseable one produces a `warnings` entry naming
+the raw value rather than a silently skipped check.
+
+### The error vocabulary
+
+Three distinct refusals share HTTP `400` and `{"error": "…"}`. **The message
+string is the only discriminator.**
+
+| Clubworx says | Row outcome |
+|---|---|
+| *"Woops! You've already booked into this class!"* | **success** — `already booked`. It *is* the idempotency guarantee |
+| *"Sorry! This class is now closed for bookings."* | permanent for that event; the lead-time stop should pre-empt it |
+| *"Sorry, this class has no free spaces available."* | ambiguous **by construction** — shown as *"Refused — check the session"*, **never** "class full" |
+| anything else | `unknown` — **verbatim**, attributed to Clubworx, never retried, never re-worded |
+
+**D6** — paraphrasing an unrecognised message is what makes new Clubworx
+behaviour invisible. [#50] is the cautionary tale.
+
+### Every write is verified by re-reading it
+
+Never by the status code. An accepted-but-silent failure and a success are the
+same `200`, and this is how [#60] established booking idempotency in the first
+place — by counting either side.
+
+- **Contact** — re-read from `/members`; the `contact_key` the chain uses comes
+  from that read, not from the create response.
+- **Pass** — re-read and re-judged; a grant that produced a pass expiring
+  mid-term answers `200` exactly like one that did not.
+- **Bookings** — one `GET /bookings?contact_key=` at the end, checked against
+  every event attempted.
+
+A retry always re-reads first. A connection error on `POST /members` may have
+landed, and retrying blind is how one student becomes two permanent records.
+
+A failed *verification read* is the one case that does **not** roll back: it is
+not a failed write, and cancelling good bookings because a read timed out would
+destroy the thing being checked. It answers `outcome: "unverified"` with the
+rows attached.
+
+### Which statuses leave
+
+Only two things are not a `200`, and in both there is nothing to record:
+
+- **`429`** — §11 pauses the *whole run* on a throttle, because the allowance is
+  gym-wide.
+- **`400`** — a refusal that happened before any write: a session inside the
+  24-hour lead time, a pass that will not cover the term, a malformed request.
+
+Everything else — including an abandoned, rolled-back student — is a `200`
+carrying the full result. A result is not an error, and D10 writes each row to
+the browser as it lands because a page reload destroying the only record of a
+creation that cannot be undone is the specific failure that defends against.
+
+### What a run costs here
+
+Per student: 1 membership read (matched only) + 1 write + 1 verification read
++ one booking per event + 1 verification read. A 25-student, 6-session list is
+roughly **250 requests** against a 75/min ceiling shared with the roster Worker
+and n8n — about four minutes of gym-wide slowdown. `requests` is on every
+response.
+
 
 ## Pacing
 

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -598,71 +598,16 @@ export function findPlanByName(body, name, { requestedPageSize = null } = {}) {
 }
 
 /**
- * Reduce a memberships response to something publishable.
+ * `summariseMemberships` moved to `src/memberships.js` (staff-site#69).
  *
- * `GET /memberships?contact_key=` is how a probe answers "does this contact
- * already hold the pass?" before assigning another one. Memberships have no
- * delete endpoint, so search-first is not a courtesy here — it is the only
- * thing standing between a re-run and a pile of duplicate permanent records.
- *
- * **There is no `status` field.** A membership record carries `start_date` and
- * `expiration_date` and nothing that says "active" — verified against a real
- * record on 2026-08-18. Whether a School Pass is active, which is what a School
- * Session actually checks, has to be derived from those two dates. A caller
- * looking for `status` would find `undefined` and could read a live pass as
- * inactive.
- *
- * @param {unknown} body
- * @param {string|number} [planId] The plan being looked for.
- * @param {{on?: string}} [opts] The date to judge activity against.
+ * The Worker's write chain needs the same derivation the probes needed — a
+ * membership has no `status` field, so "active" comes from `start_date` and
+ * `expiration_date` — and #69 also needs a second question answered against the
+ * same rows: does the held pass reach the last selected session? Both live
+ * beside each other in `src/memberships.js` now, the same way `errorMessageOf`
+ * and `buildUrl` were promoted out of here before it. Probes import it from
+ * there; there is one definition.
  */
-export function summariseMemberships(body, planId = null, { on = null } = {}) {
-  if (!Array.isArray(body)) {
-    return { count: 0, fields: [], holdsPlan: false, holdsActivePlan: false, planStates: [], notAnArray: true };
-  }
-
-  const today = (on ?? new Date().toISOString()).slice(0, 10);
-  const fields = new Set();
-  const planStates = [];
-  let holdsPlan = false;
-  let holdsActivePlan = false;
-
-  for (const row of body) {
-    for (const key of Object.keys(row ?? {})) fields.add(key);
-
-    if (planId !== null && String(row?.membership_plan_id) === String(planId)) {
-      holdsPlan = true;
-
-      const start = row?.start_date ?? null;
-      const expires = row?.expiration_date ?? null;
-      // Dates are plain `YYYY-MM-DD`, so string comparison is the date
-      // comparison — no timezone to get wrong. Inclusive at both ends: a pass
-      // starting today is usable today.
-      const active =
-        (!start || start <= today) && (!expires || expires >= today);
-
-      if (active) holdsActivePlan = true;
-
-      planStates.push({
-        start_date: start,
-        expiration_date: expires,
-        active,
-        classes_booked: row?.classes_booked ?? null,
-        classes_remaining: row?.classes_remaining ?? null,
-        class_access: row?.class_access ?? null,
-      });
-    }
-  }
-
-  return {
-    count: body.length,
-    fields: [...fields],
-    holdsPlan,
-    holdsActivePlan,
-    planStates,
-    notAnArray: false,
-  };
-}
 
 /**
  * How long until an event starts, and whether a lead-time rule would allow it.

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -17,7 +17,6 @@ import {
   describeCancellation,
   pickBookableEvents,
   findPlanByName,
-  summariseMemberships,
   describeLeadTime,
   describeMemberCreation,
   describeCreatedPass,
@@ -681,58 +680,6 @@ describe('findPlanByName', () => {
 
   it('survives a non-array body', () => {
     expect(findPlanByName(null, 'School Pass').notAnArray).toBe(true);
-  });
-});
-
-describe('summariseMemberships', () => {
-  it('reports whether the contact already holds the plan', () => {
-    const v = summariseMemberships(
-      [{ membership_plan_id: 64189, start_date: '2026-08-18', expiration_date: '2026-11-09' }],
-      64189,
-      { on: '2026-08-18' },
-    );
-    expect(v.holdsPlan).toBe(true);
-    expect(v.holdsActivePlan).toBe(true);
-  });
-
-  it('derives active from the dates, since the record carries no status field', () => {
-    // Verified against a real record 2026-08-18: start_date and
-    // expiration_date, and nothing that says "active".
-    const rows = [{ membership_plan_id: 64189, start_date: '2026-08-18', expiration_date: '2026-11-09' }];
-    expect(summariseMemberships(rows, 64189, { on: '2026-11-10' }).holdsActivePlan).toBe(false);
-    expect(summariseMemberships(rows, 64189, { on: '2026-08-17' }).holdsActivePlan).toBe(false);
-    // Inclusive at both ends: a pass starting today is usable today.
-    expect(summariseMemberships(rows, 64189, { on: '2026-11-09' }).holdsActivePlan).toBe(true);
-  });
-
-  it('separates holding an expired pass from holding an active one', () => {
-    const v = summariseMemberships(
-      [{ membership_plan_id: 64189, start_date: '2026-01-01', expiration_date: '2026-03-01' }],
-      64189,
-      { on: '2026-08-18' },
-    );
-    expect(v.holdsPlan).toBe(true);
-    expect(v.holdsActivePlan).toBe(false);
-  });
-
-  it('does not confuse a different plan for the one being looked for', () => {
-    const v = summariseMemberships([{ membership_plan_id: 1, status: 'active' }], 64189);
-    expect(v.holdsPlan).toBe(false);
-    expect(v.count).toBe(1);
-  });
-
-  it('compares ids as strings, so 64189 and "64189" agree', () => {
-    expect(summariseMemberships([{ membership_plan_id: '64189' }], 64189).holdsPlan).toBe(true);
-  });
-
-  it('reports field names without values', () => {
-    const v = summariseMemberships([{ membership_plan_id: 1, member_name: 'A Real Person' }], 1);
-    expect(v.fields).toContain('member_name');
-    expect(JSON.stringify(v)).not.toContain('A Real Person');
-  });
-
-  it('survives a non-array body', () => {
-    expect(summariseMemberships(null, 1).notAnArray).toBe(true);
   });
 });
 

--- a/cloudflare-clubworx/probes/run-60.mjs
+++ b/cloudflare-clubworx/probes/run-60.mjs
@@ -50,7 +50,6 @@ import { errorMessageOf } from '../src/errors.js';
 import {
   summariseContacts,
   summariseBookings,
-  summariseMemberships,
   summariseEvents,
   classifyWrite,
   describeDuplicateBooking,
@@ -58,6 +57,7 @@ import {
   findPlanByName,
   describeLeadTime,
 } from './lib/report.mjs';
+import { summariseMemberships } from '../src/memberships.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(HERE, 'out');

--- a/cloudflare-clubworx/probes/run-63.mjs
+++ b/cloudflare-clubworx/probes/run-63.mjs
@@ -69,7 +69,6 @@ import { errorMessageOf } from '../src/errors.js';
 import {
   summariseContacts,
   summariseBookings,
-  summariseMemberships,
   classifyWrite,
   describeMemberCreation,
   describeCreatedPass,
@@ -78,6 +77,7 @@ import {
   describeLeadTime,
   summariseEvents,
 } from './lib/report.mjs';
+import { summariseMemberships } from '../src/memberships.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(HERE, 'out');

--- a/cloudflare-clubworx/src/bookings.js
+++ b/cloudflare-clubworx/src/bookings.js
@@ -53,6 +53,23 @@
  */
 
 import { errorMessageOf } from './errors.js';
+import { isRetryable, upstreamReason, upstreamMessage } from './upstream.js';
+
+/**
+ * The row states, as constants rather than as literals typed twice.
+ *
+ * `BOOKED` and `ALREADY_BOOKED_STATE` differ from the refusal *kind*
+ * `'already-booked'` by one character — a space against a hyphen — and the
+ * consequence of confusing them is not cosmetic: `cancelRunBookings` acts on
+ * `BOOKED` and the chain treats `ALREADY_BOOKED_STATE` as a success, so a slip
+ * either abandons a complete student or points the rollback at a booking this
+ * run did not create. Two near-identical strings compared by hand across three
+ * files is exactly the shape that eventually gets one of them wrong.
+ */
+export const BOOKED = 'booked';
+export const ALREADY_BOOKED_STATE = 'already booked';
+export const REFUSED = 'refused';
+export const FAILED = 'failed';
 
 /** The three measured 400s, verbatim, as the reference points for matching. */
 export const ALREADY_BOOKED = "Woops! You've already booked into this class!";
@@ -176,9 +193,14 @@ export async function bookEvent({ client, contactKey, eventId, spacesAvailable =
 
   const row = {
     event_id: eventId,
-    state: 'failed',
+    state: FAILED,
+    // The contact this row belongs to travels WITH the row, so a later cancel
+    // takes the contact key from the booking rather than from whoever is asking.
+    // `DELETE /bookings/:id` needs it, and #50 spent a week on the 401 that a
+    // missing one produces; taking it from the row is what makes it impossible
+    // to omit or to mismatch against a different student's booking.
+    contact_key: contactKey,
     booking_id: null,
-    bookingId: null,
     refusal: null,
     message: res.message ?? errorMessageOf(res.body) ?? null,
     shown: null,
@@ -190,9 +212,8 @@ export async function bookEvent({ client, contactKey, eventId, spacesAvailable =
     const id = bookingIdOf(res.body);
     return {
       ...row,
-      state: 'booked',
+      state: BOOKED,
       booking_id: id,
-      bookingId: id,
       message: null,
       // A 200 with no id anywhere is a shape nobody here has seen. The booking
       // is reported as made — the status says so — but it is flagged, because a
@@ -207,12 +228,11 @@ export async function bookEvent({ client, contactKey, eventId, spacesAvailable =
     if (kind === 'already-booked') {
       return {
         ...row,
-        state: 'already booked',
+        state: ALREADY_BOOKED_STATE,
         refusal: kind,
         // No id, deliberately. This booking was not made by this run, so
         // nothing here may cancel it.
         booking_id: null,
-        bookingId: null,
         shown: describeRefusal(kind),
       };
     }
@@ -221,7 +241,7 @@ export async function bookEvent({ client, contactKey, eventId, spacesAvailable =
     // attempt, and the fourth kind is unknown by definition.
     return {
       ...row,
-      state: 'refused',
+      state: REFUSED,
       refusal: kind,
       retryable: false,
       shown: describeRefusal(kind, { message: row.message, spacesAvailable }),
@@ -230,13 +250,12 @@ export async function bookEvent({ client, contactKey, eventId, spacesAvailable =
 
   // 429, 5xx and network errors are the only retryable outcomes (D8). A throttle
   // is told apart because it does not pause a row — it pauses the run.
-  const throttled = res.status === 429;
   return {
     ...row,
-    state: 'failed',
-    retryable: throttled || res.networkError || res.status >= 500 || res.status === 0,
-    reason: throttled ? 'throttled' : res.networkError ? 'network' : 'upstream-error',
-    message: row.message ?? res.bodyText ?? null,
+    state: FAILED,
+    retryable: isRetryable(res),
+    reason: upstreamReason(res),
+    message: row.message ?? upstreamMessage(res),
     upstreamStatus: res.status,
   };
 }
@@ -290,16 +309,19 @@ export async function cancelBooking({ client, bookingId, contactKey }) {
  *
  * @param {object} opts
  * @param {{del: Function}} opts.client
- * @param {string} opts.contactKey
- * @param {Array<{event_id: any, state: string, booking_id: string|null}>} opts.rows
+ * @param {string} [opts.contactKey] The student being rolled back. Used only to
+ *   **reject** a row belonging to somebody else; the key actually sent comes
+ *   from the row.
+ * @param {Array<{event_id: any, state: string, booking_id: string|null,
+ *   contact_key: string|null}>} opts.rows
  */
-export async function cancelRunBookings({ client, contactKey, rows = [] }) {
+export async function cancelRunBookings({ client, contactKey = null, rows = [] }) {
   const failed = [];
   let cancelled = 0;
   let skipped = 0;
 
   for (const row of rows) {
-    if (row?.state !== 'booked') {
+    if (row?.state !== BOOKED) {
       // Includes `already booked`, `refused` and anything else. Only a row this
       // run put there may be taken away.
       skipped += 1;
@@ -317,7 +339,37 @@ export async function cancelRunBookings({ client, contactKey, rows = [] }) {
       continue;
     }
 
-    const res = await cancelBooking({ client, bookingId: row.booking_id, contactKey });
+    // The contact comes from the **booking row**, not from the caller — the
+    // property #70 asks for, and the one `probes/lib/booking.mjs` holds by
+    // keeping the contact beside the id it may cancel. A caller-supplied key can
+    // be omitted (the 401 that cost #50 a week) or, worse, be a different
+    // student's, which would point a DELETE at somebody else's class.
+    const rowKey = row.contact_key ?? null;
+    if (!rowKey) {
+      failed.push({
+        event_id: row.event_id,
+        booking_id: row.booking_id,
+        reason:
+          'this booking carries no contact_key of its own, and a cancel will not be sent on a ' +
+          'contact key supplied from outside the row',
+      });
+      continue;
+    }
+    if (contactKey && rowKey !== contactKey) {
+      // A row belonging to a different contact has no business in this student's
+      // rollback. Refusing is the only safe reading of a set that should not
+      // have been mixed.
+      failed.push({
+        event_id: row.event_id,
+        booking_id: row.booking_id,
+        reason:
+          'this booking belongs to a different contact than the one being rolled back, so it ' +
+          'has not been cancelled',
+      });
+      continue;
+    }
+
+    const res = await cancelBooking({ client, bookingId: row.booking_id, contactKey: rowKey });
     if (res.ok) cancelled += 1;
     else failed.push({ event_id: row.event_id, booking_id: row.booking_id, reason: res.reason });
   }
@@ -343,8 +395,8 @@ export async function readBookings({ client, contactKey }) {
   if (!res.ok) {
     return {
       ok: false,
-      reason: res.status === 429 ? 'throttled' : 'upstream-error',
-      message: res.message ?? res.bodyText ?? null,
+      reason: upstreamReason(res),
+      message: upstreamMessage(res),
       upstreamStatus: res.status,
       eventIds: [],
       bookingIds: [],

--- a/cloudflare-clubworx/src/bookings.js
+++ b/cloudflare-clubworx/src/bookings.js
@@ -1,0 +1,374 @@
+/**
+ * Booking, cancelling, and the error vocabulary that tells them apart.
+ *
+ * staff-site#69. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+ * §11 (refusals and retries) and §12 (irreversibility, and the interlock).
+ *
+ * ---------------------------------------------------------------------------
+ * Three refusals share HTTP 400. The message string is the only discriminator
+ * ---------------------------------------------------------------------------
+ * There is no code, no field, no header that separates them — only `{"error":
+ * "..."}` — and they mean entirely different things:
+ *
+ * | Clubworx says | Means |
+ * |---|---|
+ * | already booked into this class | **success**. It *is* the idempotency guarantee |
+ * | now closed for bookings | permanent for that event; the lead-time stop should pre-empt it |
+ * | no free spaces available | the **prospect allowance**, not capacity (#50) |
+ * | anything else | unknown — verbatim, never retried, never re-worded |
+ *
+ * **D6 — an unrecognised message is never paraphrased.** #50 is the cautionary
+ * tale: `"Sorry, this class has no free spaces available."` arrived on an event
+ * reporting 25 spaces free and `event_full: false`, and reading it as a capacity
+ * problem pointed the whole effort at the wrong mechanism for a week. So the
+ * spaces refusal is shown as *"Refused — check the session"* with
+ * `spaces_available` beside it, and **never** as "class full".
+ *
+ * ---------------------------------------------------------------------------
+ * The cancel interlock is a safety property, not a display distinction
+ * ---------------------------------------------------------------------------
+ * Because booking is idempotent, a re-run marks rows `already booked`. A cancel
+ * scoped to the whole row set would therefore delete bookings **this run did not
+ * create** — possibly a session a real member booked themselves, which #50
+ * identified as the worst outcome available on this map.
+ *
+ * So `cancelRunBookings` acts on `booked` and never on `already booked`, and it
+ * carries no override. Both callers need it: the human "Cancel bookings from
+ * this run" control, and **D3's automatic rollback, which runs the same path
+ * with no human present**.
+ *
+ * The interlock is enforced twice on purpose — `bookEvent` never returns a
+ * booking id on an already-booked row, and `cancelRunBookings` refuses the state
+ * outright. Either alone would hold; the one that fails silently is the one
+ * worth doubling.
+ *
+ * ---------------------------------------------------------------------------
+ * `POST /bookings` sends JSON
+ * ---------------------------------------------------------------------------
+ * Measured — `probes/lib/booking.mjs` sent a JSON body and got the 200 that
+ * created booking `63510241` (#60). §2's summary table says `/bookings` is
+ * form-encoded; that line does not match what was run, and **what was run is
+ * what is implemented here**. `/memberships` genuinely is form-encoded, which is
+ * probably where the line came from. The encoding is per-endpoint.
+ */
+
+import { errorMessageOf } from './errors.js';
+
+/** The three measured 400s, verbatim, as the reference points for matching. */
+export const ALREADY_BOOKED = "Woops! You've already booked into this class!";
+export const CLASS_CLOSED = 'Sorry! This class is now closed for bookings.';
+export const NO_FREE_SPACES = 'Sorry, this class has no free spaces available.';
+
+/**
+ * Normalise only what cannot change the meaning: case, whitespace and the shape
+ * of an apostrophe.
+ *
+ * The apostrophe is not hypothetical — `You've` is one HTML-entity round trip
+ * away from `You’ve`, and an exact-match classifier would quietly demote the
+ * success-equivalent refusal to `unknown`, which turns a clean idempotent re-run
+ * into an abandoned student and a rollback.
+ */
+const normalise = text =>
+  String(text ?? '')
+    .replace(/[‘’ʼ]/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+
+/**
+ * Matched on the distinctive clause rather than the whole sentence.
+ *
+ * Wide enough that punctuation drift does not reclassify a known message;
+ * narrow enough that it cannot swallow a new one. `"Sorry, this class is full."`
+ * — a message nobody has seen — must come out `unknown`, not `no-spaces`.
+ */
+const SIGNATURES = [
+  ['already-booked', 'already booked into this class'],
+  ['closed', 'now closed for bookings'],
+  ['no-spaces', 'no free spaces available'],
+];
+
+/**
+ * Which of the four a refusal is.
+ *
+ * @param {unknown} message The message Clubworx sent, exactly as it sent it.
+ * @returns {'already-booked'|'closed'|'no-spaces'|'unknown'}
+ */
+export function classifyRefusal(message) {
+  const text = normalise(message);
+  if (!text) return 'unknown';
+  for (const [kind, signature] of SIGNATURES) {
+    if (text.includes(signature)) return kind;
+  }
+  return 'unknown';
+}
+
+/**
+ * What an operator is shown for a refusal.
+ *
+ * @param {'closed'|'no-spaces'|'unknown'|'already-booked'} kind
+ * @param {{message?: string|null, spacesAvailable?: number|null}} [opts]
+ * @returns {string}
+ */
+export function describeRefusal(kind, { message = null, spacesAvailable = null } = {}) {
+  if (kind === 'already-booked') return 'Already booked — nothing to do.';
+
+  if (kind === 'closed') {
+    return (
+      'Refused — Clubworx has closed this session for bookings. ' +
+      'It starts too soon; it should have been caught before the run started.'
+    );
+  }
+
+  if (kind === 'no-spaces') {
+    // Deliberately not "class full". The message is about a per-contact
+    // allowance, and it has arrived on an event with 25 spaces free.
+    return (
+      'Refused — check the session' +
+      (spacesAvailable === null ? '' : ` (Clubworx reports ${spacesAvailable} spaces available)`) +
+      '. Clubworx refuses this booking without saying why; it is not necessarily capacity.'
+    );
+  }
+
+  const raw = message === null || message === '' ? null : String(message);
+  return raw === null
+    ? 'Refused by Clubworx, with no message.'
+    : `Refused by Clubworx: "${raw}"`;
+}
+
+/**
+ * A booking id out of a create response, wherever this API chose to put it.
+ *
+ * Tolerant because the shape of a create response is not something to guess at
+ * from a reference that has been wrong twice here. Returned as a string so the
+ * id that goes into a URL is the id that came back.
+ *
+ * @param {unknown} body
+ * @returns {string|null}
+ */
+export function bookingIdOf(body) {
+  const id =
+    body?.booking_id ??
+    body?.id ??
+    body?.booking?.booking_id ??
+    body?.booking?.id ??
+    (Array.isArray(body) ? (body[0]?.booking_id ?? body[0]?.id) : null) ??
+    null;
+  return id === null || id === undefined || id === '' ? null : String(id);
+}
+
+/**
+ * Book one student into one event. **One attempt** — retries are the caller's,
+ * because a 429 pauses the whole run rather than one row (§11).
+ *
+ * @param {object} opts
+ * @param {{post: Function}} opts.client
+ * @param {string} opts.contactKey
+ * @param {string|number} opts.eventId
+ * @param {number|null} [opts.spacesAvailable] For the spaces refusal's wording.
+ * @returns {Promise<{state: 'booked'|'already booked'|'refused'|'failed', event_id: any,
+ *   booking_id: string|null, bookingId: string|null, refusal: string|null,
+ *   message: string|null, shown: string|null, retryable: boolean,
+ *   reason: string|null, unverifiable?: boolean}>}
+ */
+export async function bookEvent({ client, contactKey, eventId, spacesAvailable = null }) {
+  const res = await client.post('bookings', { contact_key: contactKey, event_id: eventId });
+
+  const row = {
+    event_id: eventId,
+    state: 'failed',
+    booking_id: null,
+    bookingId: null,
+    refusal: null,
+    message: res.message ?? errorMessageOf(res.body) ?? null,
+    shown: null,
+    retryable: false,
+    reason: null,
+  };
+
+  if (res.ok) {
+    const id = bookingIdOf(res.body);
+    return {
+      ...row,
+      state: 'booked',
+      booking_id: id,
+      bookingId: id,
+      message: null,
+      // A 200 with no id anywhere is a shape nobody here has seen. The booking
+      // is reported as made — the status says so — but it is flagged, because a
+      // row with no id cannot be cancelled, by the rollback or by a human.
+      ...(id === null ? { unverifiable: true } : {}),
+    };
+  }
+
+  if (res.status === 400) {
+    const kind = classifyRefusal(row.message);
+
+    if (kind === 'already-booked') {
+      return {
+        ...row,
+        state: 'already booked',
+        refusal: kind,
+        // No id, deliberately. This booking was not made by this run, so
+        // nothing here may cancel it.
+        booking_id: null,
+        bookingId: null,
+        shown: describeRefusal(kind),
+      };
+    }
+
+    // D8 — never retry a 400. All three known ones are permanent for that
+    // attempt, and the fourth kind is unknown by definition.
+    return {
+      ...row,
+      state: 'refused',
+      refusal: kind,
+      retryable: false,
+      shown: describeRefusal(kind, { message: row.message, spacesAvailable }),
+    };
+  }
+
+  // 429, 5xx and network errors are the only retryable outcomes (D8). A throttle
+  // is told apart because it does not pause a row — it pauses the run.
+  const throttled = res.status === 429;
+  return {
+    ...row,
+    state: 'failed',
+    retryable: throttled || res.networkError || res.status >= 500 || res.status === 0,
+    reason: throttled ? 'throttled' : res.networkError ? 'network' : 'upstream-error',
+    message: row.message ?? res.bodyText ?? null,
+    upstreamStatus: res.status,
+  };
+}
+
+/**
+ * Cancel one booking.
+ *
+ * `contact_key` is required, not optional. Without it Clubworx answers
+ * `401 "Authorization failed"` — indistinguishable from a key with no delete
+ * permission, and misdiagnosed as exactly that for a week in #50. So a missing
+ * contact key is refused **here**, before the network, rather than rediscovered
+ * as a mystery 401.
+ *
+ * @param {object} opts
+ * @param {{del: Function}} opts.client
+ * @param {string} opts.bookingId
+ * @param {string} opts.contactKey
+ */
+export async function cancelBooking({ client, bookingId, contactKey }) {
+  const id = String(bookingId ?? '');
+  if (!id) return { ok: false, bookingId: null, reason: 'no booking id to cancel' };
+  if (!contactKey) {
+    return {
+      ok: false,
+      bookingId: id,
+      reason:
+        'refusing to cancel without a contact_key — Clubworx answers 401 "Authorization failed" ' +
+        'to that request, which reads like a permissions problem and is not one',
+    };
+  }
+
+  const res = await client.del(`bookings/${id}`, { contact_key: contactKey });
+  return {
+    ok: res.ok === true,
+    bookingId: id,
+    upstreamStatus: res.status ?? null,
+    reason: res.ok ? null : (res.message ?? res.bodyText ?? `HTTP ${res.status}`),
+  };
+}
+
+/**
+ * Cancel the bookings **this run** made for one student.
+ *
+ * The interlock: acts on `booked`, never on `already booked`. See the header.
+ * There is no flag to relax it, because D3's rollback runs this with no human
+ * present and a flag is the thing a rollback path would set.
+ *
+ * One failed cancel does not stop the rest. A student half-rolled-back is worse
+ * than one fully rolled back, and the failures are reported so a human can
+ * finish it.
+ *
+ * @param {object} opts
+ * @param {{del: Function}} opts.client
+ * @param {string} opts.contactKey
+ * @param {Array<{event_id: any, state: string, booking_id: string|null}>} opts.rows
+ */
+export async function cancelRunBookings({ client, contactKey, rows = [] }) {
+  const failed = [];
+  let cancelled = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    if (row?.state !== 'booked') {
+      // Includes `already booked`, `refused` and anything else. Only a row this
+      // run put there may be taken away.
+      skipped += 1;
+      continue;
+    }
+
+    if (!row.booking_id) {
+      failed.push({
+        event_id: row.event_id,
+        booking_id: null,
+        reason:
+          'booked, but Clubworx returned no booking id, so there is no booking id to cancel — ' +
+          'this one has to be undone by hand',
+      });
+      continue;
+    }
+
+    const res = await cancelBooking({ client, bookingId: row.booking_id, contactKey });
+    if (res.ok) cancelled += 1;
+    else failed.push({ event_id: row.event_id, booking_id: row.booking_id, reason: res.reason });
+  }
+
+  return { cancelled, skipped, failed };
+}
+
+/**
+ * Read a contact's own bookings — how a booking write is verified.
+ *
+ * §16: verify a write by re-reading the resource, never by the status code. An
+ * accepted-but-silent duplicate looks identical to an idempotent server from the
+ * response alone, and this is how #60 established the idempotency in the first
+ * place — by counting either side.
+ *
+ * @param {object} opts
+ * @param {{get: Function}} opts.client
+ * @param {string} opts.contactKey
+ */
+export async function readBookings({ client, contactKey }) {
+  const res = await client.get('bookings', { contact_key: contactKey });
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      reason: res.status === 429 ? 'throttled' : 'upstream-error',
+      message: res.message ?? res.bodyText ?? null,
+      upstreamStatus: res.status,
+      eventIds: [],
+      bookingIds: [],
+    };
+  }
+
+  if (!Array.isArray(res.body)) {
+    return {
+      ok: false,
+      reason: 'upstream-error',
+      message: `bookings answered ${res.status} with a body that is not a list`,
+      upstreamStatus: res.status,
+      eventIds: [],
+      bookingIds: [],
+    };
+  }
+
+  return {
+    ok: true,
+    // Strings on both sides of every later comparison — Clubworx has sent ids
+    // as numbers and as strings, and `42 !== '42'` would report a booking that
+    // landed as one that did not.
+    eventIds: res.body.map(r => (r?.event_id === undefined ? null : String(r.event_id))),
+    bookingIds: res.body.map(r => bookingIdOf(r)).filter(Boolean),
+    count: res.body.length,
+  };
+}

--- a/cloudflare-clubworx/src/clubworx.js
+++ b/cloudflare-clubworx/src/clubworx.js
@@ -161,14 +161,45 @@ export function createClubworxClient({ accountKey, fetchImpl = fetch, pacer = sh
     });
   };
 
+  /**
+   * The measured form-encoded shape carries `account_key` **in the body as well
+   * as the query**, and both calls that use it were measured that way — the
+   * `POST /memberships` that worked (#60) and the `DELETE /bookings/:id` that
+   * worked (#60) after #50 had spent a week reporting that deletes were
+   * forbidden.
+   *
+   * Sending it in the query alone has never been tried. It might well be
+   * enough; the point is that nobody knows, and the cost of finding out the hard
+   * way is asymmetric — the failure looks like `401 "Authorization failed"`,
+   * which is indistinguishable from a key without permission and has already
+   * cost this effort an architectural route once.
+   *
+   * Injected here rather than passed in, so no caller has to hold the account
+   * key to send a form body. That is the property that keeps the key inside this
+   * module.
+   */
+  const withKey = form => ({ account_key: accountKey, ...form });
+
   return {
     /** @param {string} path @param {Record<string, string|number|undefined>} [params] */
     get: (path, params = {}) => send({ method: 'GET', path, params }),
 
-    /** A create or a booking. JSON body; Clubworx answers 200, not 201. */
+    /**
+     * A contact create or a booking. **JSON** body; Clubworx answers 200, not 201.
+     *
+     * The encoding is per-endpoint, not per-API: `/members` and `/bookings` take
+     * JSON (#49, #60, #63); `/memberships` takes a form. Do not unify them.
+     */
     post: (path, payload, params = {}) => send({ method: 'POST', path, params, json: payload }),
 
+    /**
+     * A membership assignment. **Form-encoded** — measured on `POST /memberships`
+     * (#60), and deliberately not the same shape as `post`.
+     */
+    postForm: (path, form, params = {}) =>
+      send({ method: 'POST', path, params, form: withKey(form) }),
+
     /** Form-encoded, and `contact_key` is not optional. */
-    del: (path, form, params = {}) => send({ method: 'DELETE', path, params, form }),
+    del: (path, form, params = {}) => send({ method: 'DELETE', path, params, form: withKey(form) }),
   };
 }

--- a/cloudflare-clubworx/src/duration.js
+++ b/cloudflare-clubworx/src/duration.js
@@ -1,0 +1,147 @@
+/**
+ * The plan's duration, and the day a pass granted today stops covering.
+ *
+ * staff-site#69. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+ * §3, §10 (D4) and §11; [ADR 0005](../../docs/adr/0005-school-pass-runs-26-weeks.md).
+ *
+ * ---------------------------------------------------------------------------
+ * Why the number 26 is not in this file, or in any other
+ * ---------------------------------------------------------------------------
+ * The School Pass ran 12 weeks until 2026-08-20 and runs 26 now, and the change
+ * needed no code because nothing here holds the number. The duration is read off
+ * the plan (`membership_duration`) and the expiry is read off the granted pass
+ * (`expiration_date`); this module only turns the first into a date so the run
+ * can be stopped *before* a permanent write when the pass would not reach the
+ * last session.
+ *
+ * A constant here would be a second copy of a number that lives in Clubworx's
+ * configuration, and the failure it causes is the one ADR 0005 exists to fix:
+ * silent, weeks late, at a session nobody is watching.
+ *
+ * ---------------------------------------------------------------------------
+ * `membership_duration` is a human string
+ * ---------------------------------------------------------------------------
+ * `"12 weeks"`, `"26 weeks"` — prose typed into a plan editor, not an interval
+ * type. So it is parsed best-effort, and **an unparseable value is a warning
+ * that names the raw string, never a silent skip** (§11). The coverage check is
+ * the only thing standing between a shortened plan and a term whose last
+ * sessions quietly fall outside the pass; skipping it without saying so
+ * reproduces exactly the bug ADR 0005 was written for.
+ *
+ * A value this cannot parse also cannot be *guessed*. `parsePlanDuration`
+ * refuses rather than falling back to a default, because a wrong default is
+ * indistinguishable from a right one until a term is half over.
+ *
+ * ---------------------------------------------------------------------------
+ * The arithmetic is inclusive at both ends, because Clubworx's is
+ * ---------------------------------------------------------------------------
+ * Measured (#60, #63): a 12-week pass starting 2026-08-20 came back with
+ * `expiration_date 2026-11-11` — 84 days of access, 83 days of difference. So
+ * the last covered day is `start + days - 1`, and a one-day pass covers its own
+ * start day. Off by one here is off by one session.
+ */
+
+/**
+ * `YYYY-MM-DD`, and a real day.
+ *
+ * Shared with the route's own validation. `new Date('2009-02-30')` does not
+ * throw — it rolls forward to 2 March — so the round-trip is what catches it.
+ * A date that rolls is the standing hazard on this map (§7): `03/02/2009` is two
+ * different children, and a wrong one is a permanent contact keyed to the wrong
+ * birthday.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isRealDay(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+/**
+ * Add whole days to an ISO day, in UTC.
+ *
+ * UTC on purpose. These are plain dates with no time and no zone — Clubworx
+ * stores `start_date` and `expiration_date` as `YYYY-MM-DD` — so doing the
+ * arithmetic in the runtime's local zone would make the answer depend on where
+ * the isolate happens to be, and a Worker's local zone is UTC anyway while a
+ * developer's is AWST. One of those two would be silently wrong.
+ *
+ * @param {string} day `YYYY-MM-DD`.
+ * @param {number} count
+ * @returns {string|null} `YYYY-MM-DD`, or null if the input was not a real day.
+ */
+export function addDays(day, count) {
+  if (!isRealDay(day) || !Number.isInteger(count)) return null;
+  const at = new Date(`${day}T00:00:00Z`);
+  at.setUTCDate(at.getUTCDate() + count);
+  return at.toISOString().slice(0, 10);
+}
+
+/** What a duration may be counted in. Singular; the parser strips the plural. */
+const UNITS = new Set(['day', 'week', 'month', 'year']);
+
+/**
+ * Read `membership_duration` off a plan.
+ *
+ * @param {unknown} raw The plan's `membership_duration`, exactly as Clubworx sent it.
+ * @returns {{ok: true, count: number, unit: 'day'|'week'|'month'|'year', raw: string}
+ *        | {ok: false, raw: string}}
+ */
+export function parsePlanDuration(raw) {
+  const text = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  const failed = { ok: false, raw: typeof raw === 'string' ? raw : String(raw ?? '') };
+
+  // A whole number and a unit, in that order, and nothing else. Deliberately
+  // narrow: "3 to 6 months" and "a term" must land in the warning, not in an
+  // arithmetic that half-understood them.
+  const match = /^(\d+)\s*(day|week|month|year)s?$/.exec(text);
+  if (!match) return failed;
+
+  const count = Number(match[1]);
+  const unit = match[2];
+  // Zero is not a short pass, it is a misconfigured plan — and it would make
+  // every coverage check fail in a way that reads like a lead-time problem.
+  if (!Number.isInteger(count) || count <= 0 || !UNITS.has(unit)) return failed;
+
+  return { ok: true, count, unit, raw: String(raw) };
+}
+
+/**
+ * The last day a pass granted on `startDay` still covers.
+ *
+ * Inclusive at both ends, matching the measured `expiration_date` (see the
+ * header). Months and years use calendar arithmetic rather than a 30- or
+ * 365-day approximation, so a plan configured in months does not drift.
+ *
+ * Returns **null** rather than a plausible date when the duration did not parse
+ * or the start day is not real. A caller that treats null as "no limit" has
+ * skipped the check silently, which §11 forbids — every caller here turns null
+ * into a named warning instead.
+ *
+ * @param {string} startDay `YYYY-MM-DD` — the day the pass starts, which for a
+ *   pass this tool grants is the day of the run (#63: Clubworx chooses today).
+ * @param {ReturnType<typeof parsePlanDuration>} duration
+ * @returns {string|null}
+ */
+export function passCoverageEnd(startDay, duration) {
+  if (!duration?.ok || !isRealDay(startDay)) return null;
+
+  const { count, unit } = duration;
+  if (unit === 'day') return addDays(startDay, count - 1);
+  if (unit === 'week') return addDays(startDay, count * 7 - 1);
+
+  const at = new Date(`${startDay}T00:00:00Z`);
+  // Clamp rather than let setUTCMonth roll: 31 January plus one month is not
+  // 3 March. Clamping shortens the window, which is the safe direction — this
+  // number decides whether a run is allowed to write anything permanent.
+  const targetMonth = at.getUTCMonth() + (unit === 'month' ? count : count * 12);
+  const dayOfMonth = at.getUTCDate();
+  at.setUTCDate(1);
+  at.setUTCMonth(targetMonth);
+  const lastOfTarget = new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth() + 1, 0)).getUTCDate();
+  at.setUTCDate(Math.min(dayOfMonth, lastOfTarget));
+
+  return addDays(at.toISOString().slice(0, 10), -1);
+}

--- a/cloudflare-clubworx/src/duration.js
+++ b/cloudflare-clubworx/src/duration.js
@@ -44,11 +44,15 @@
 /**
  * `YYYY-MM-DD`, and a real day.
  *
- * Shared with the route's own validation. `new Date('2009-02-30')` does not
- * throw — it rolls forward to 2 March — so the round-trip is what catches it.
- * A date that rolls is the standing hazard on this map (§7): `03/02/2009` is two
- * different children, and a wrong one is a permanent contact keyed to the wrong
- * birthday.
+ * The one definition in this Worker — `index.js` and `memberships.js` both
+ * import it rather than carrying a second regex, because three copies of a date
+ * rule drift and the drift here is a permanent contact keyed to a wrong
+ * birthday. `new Date('2009-02-30')` does not throw — it rolls forward to
+ * 2 March — so the round-trip is what catches it.
+ *
+ * Date orientation is the standing hazard on this map (§7): `03/02/2009` is two
+ * different children depending on who typed it. The parser resolves orientation
+ * before anything reaches here; this only insists the result is one real day.
  *
  * @param {unknown} value
  * @returns {boolean}
@@ -98,7 +102,7 @@ const AWST_OFFSET_MS = 8 * 60 * 60 * 1000;
  * where it decides a permanent write.
  *
  * @param {string|Date} [now] An instant. Defaults to the real one.
- * @returns {string} `YYYY-MM-DD` at the gym.
+ * @returns {string|null} `YYYY-MM-DD` at the gym, or null if `now` is unreadable.
  */
 export function perthDay(now = new Date()) {
   const at = now instanceof Date ? now : new Date(now);
@@ -150,7 +154,7 @@ export function parsePlanDuration(raw) {
  * @param {string} startDay `YYYY-MM-DD` — the day the pass starts, which for a
  *   pass this tool grants is the day of the run (#63: Clubworx chooses today).
  * @param {ReturnType<typeof parsePlanDuration>} duration
- * @returns {string|null}
+ * @returns {string|null} `YYYY-MM-DD`, or null when it cannot be computed.
  */
 export function passCoverageEnd(startDay, duration) {
   if (!duration?.ok || !isRealDay(startDay)) return null;

--- a/cloudflare-clubworx/src/duration.js
+++ b/cloudflare-clubworx/src/duration.js
@@ -79,6 +79,33 @@ export function addDays(day, count) {
   return at.toISOString().slice(0, 10);
 }
 
+/**
+ * Perth is **UTC+8 with no daylight saving**, so the offset is a constant and
+ * not a timezone database lookup. Western Australia last observed DST in 2009.
+ */
+const AWST_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+/**
+ * What day it is at the gym.
+ *
+ * Not what day it is in UTC. A Worker isolate runs on UTC and the gym runs on
+ * AWST, so for the eight hours after Perth midnight the two disagree — and the
+ * day this returns is the day a granted pass starts, the day the coverage window
+ * is measured from, and the `start_date` sent to Clubworx. Getting it wrong
+ * there is one day of pass coverage, which at the end of a term is one session.
+ *
+ * Every UJ and CAWA workflow uses `Australia/Perth`; this is that rule, applied
+ * where it decides a permanent write.
+ *
+ * @param {string|Date} [now] An instant. Defaults to the real one.
+ * @returns {string} `YYYY-MM-DD` at the gym.
+ */
+export function perthDay(now = new Date()) {
+  const at = now instanceof Date ? now : new Date(now);
+  if (Number.isNaN(at.getTime())) return null;
+  return new Date(at.getTime() + AWST_OFFSET_MS).toISOString().slice(0, 10);
+}
+
 /** What a duration may be counted in. Singular; the parser strips the plural. */
 const UNITS = new Set(['day', 'week', 'month', 'year']);
 

--- a/cloudflare-clubworx/src/index.js
+++ b/cloudflare-clubworx/src/index.js
@@ -33,6 +33,7 @@
 import { createAccessVerifier } from './access.js';
 import { createClubworxClient } from './clubworx.js';
 import { searchContacts } from './contacts.js';
+import { runStudentChain } from './student.js';
 
 export const PREFIX = '/api/clubworx';
 
@@ -102,6 +103,20 @@ const defaultSearch = ({ env, lastName, dob }) =>
   });
 
 /**
+ * The default write chain: one paced client for the whole student, so the
+ * membership read, the writes and the bookings all queue behind each other.
+ *
+ * Injected in tests for the same reason `search` is — the route's own job is
+ * validation, status mapping and the log line, and every one of those fails
+ * silently if a network stub is standing in the way.
+ */
+const defaultRunStudent = ({ env, ...args }) =>
+  runStudentChain({
+    client: createClubworxClient({ accountKey: env.CLUBWORX_ACCOUNT_KEY }),
+    ...args,
+  });
+
+/**
  * Build the request handler. The seams exist so the log line and the gate can be
  * asserted directly — both are things that fail silently in production.
  *
@@ -109,11 +124,13 @@ const defaultSearch = ({ env, lastName, dob }) =>
  * @param {(env: object) => (token: string|null) => Promise<object>} [deps.makeVerifier]
  * @param {(line: string) => void} [deps.log]
  * @param {(args: {env: object, lastName: string, dob: string}) => Promise<object>} [deps.search]
+ * @param {(args: object) => Promise<object>} [deps.runStudent]
  */
 export function createHandler({
   makeVerifier = defaultMakeVerifier,
   log = console.log,
   search = defaultSearch,
+  runStudent = defaultRunStudent,
 } = {}) {
   return async function handle(request, env) {
     const url = new URL(request.url);
@@ -130,7 +147,7 @@ export function createHandler({
     const route = url.pathname;
     const method = request.method;
 
-    const done = (response, { email = null, reason = null } = {}) => {
+    const done = (response, { email = null, reason = null, outcome = null } = {}) => {
       log(
         JSON.stringify({
           worker: WORKER,
@@ -140,6 +157,12 @@ export function createHandler({
           email,
           ms: Date.now() - started,
           ...(reason ? { reason } : {}),
+          // `outcome` is one of a closed set of words — complete, abandoned,
+          // needs-confirmation — and never a value out of the request or the
+          // response. It is here because "did this call create a permanent
+          // record?" is the question an operational log has to be able to
+          // answer, and a 200 alone does not.
+          ...(outcome ? { outcome } : {}),
         }),
       );
       return response;
@@ -252,7 +275,67 @@ export function createHandler({
       );
     }
 
-    // events, plan, schools, student and unbook arrive with #67/#69/#70.
+    if (path === '/student') {
+      if (method !== 'POST') return done(json({ error: 'method not allowed' }, 405), { email });
+
+      // A missing secret is a deploy that was never finished, not a Clubworx
+      // refusal — and on this route the difference matters more than anywhere
+      // else, because the caller is about to be told a student was not created.
+      if (!env.CLUBWORX_ACCOUNT_KEY) {
+        return done(
+          json({ error: 'the Clubworx account key is not configured', reason: 'not-configured' }, 503),
+          { email },
+        );
+      }
+
+      let payload = null;
+      try {
+        payload = await request.json();
+      } catch {
+        payload = null;
+      }
+      if (!payload || typeof payload !== 'object') {
+        return done(
+          json({ error: 'a JSON body describing one student is required', reason: 'bad-request' }, 400),
+          { email },
+        );
+      }
+
+      const result = await runStudent({
+        env,
+        student: payload.student,
+        contactKey: payload.contact_key ?? null,
+        membershipPlanId: payload.membership_plan_id,
+        membershipDuration: payload.membership_duration,
+        events: payload.events,
+      });
+
+      // **A result is not an error, even when the student was abandoned.**
+      //
+      // §12's result table has to show every outcome — created, already booked,
+      // refused, rolled back, stranded — and D10 writes each row to the
+      // browser's localStorage as it lands, because a page reload destroying the
+      // only record of a creation that cannot be undone is the specific failure
+      // that design defends against. A 4xx or 5xx invites a client to throw the
+      // body away, and the body is the record.
+      //
+      // So only two things leave as a non-200, and both are conditions in which
+      // there is nothing to record:
+      //
+      //   - **429**, because §11 pauses the *whole run* on a throttle. The
+      //     allowance is gym-wide, so backing off one row while the rest
+      //     continue just spends the next window failing, and the page needs
+      //     that signal where it cannot be missed.
+      //   - **400** for a refusal that happened before any write — a lead-time
+      //     session, a pass that will not cover the term, a malformed request.
+      //     Nothing was attempted, so there is no row.
+      const status =
+        result.reason === 'throttled' ? 429 : result.outcome === 'refused' ? 400 : 200;
+
+      return done(json(result, status), { email, outcome: result.outcome });
+    }
+
+    // events, plan, schools and unbook arrive with #67/#70.
     return done(json({ error: 'not found' }, 404), { email });
   };
 }

--- a/cloudflare-clubworx/src/index.js
+++ b/cloudflare-clubworx/src/index.js
@@ -23,17 +23,18 @@
  * **Auth is Cloudflare Access, verified rather than assumed.** See `access.js`.
  *
  * Routes arrive a ticket at a time. #66 shipped the skeleton, the gate, the
- * pacer and the request layer; #68 added `GET /contacts`. The remaining ones —
- * events, plan, schools, student and unbook — belong to #67, #69 and #70, and
- * answer 404 until then, deliberately: `main` is production on this repo and a
- * page calling a route that does not exist is a broken tool on the live hub
- * (§17).
+ * pacer and the request layer; #68 added `GET /contacts`; #69 added
+ * `POST /student`, the only route here that writes. The remaining ones —
+ * events, plan, schools and unbook — belong to #67 and #70, and answer 404
+ * until then, deliberately: `main` is production on this repo and a page
+ * calling a route that does not exist is a broken tool on the live hub (§17).
  */
 
 import { createAccessVerifier } from './access.js';
 import { createClubworxClient } from './clubworx.js';
 import { searchContacts } from './contacts.js';
 import { runStudentChain } from './student.js';
+import { isRealDay } from './duration.js';
 
 export const PREFIX = '/api/clubworx';
 
@@ -69,25 +70,13 @@ function defaultMakeVerifier(env) {
   return cachedVerifier;
 }
 
-/**
- * `YYYY-MM-DD`, and a real day.
- *
- * Strict on purpose. Date orientation is the standing hazard on this map —
- * `03/02/2009` is two different children depending on who typed it, and the
- * damage from getting it wrong is a permanent contact keyed to the wrong
- * birthday, which then poisons the surname + DOB key for every later term. The
- * parser resolves orientation before anything reaches here; this route accepts
- * one form so an unresolved date cannot slip past as a search that finds nothing.
- */
-const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
-
-function isRealDay(value) {
-  if (!ISO_DAY.test(value)) return false;
-  // `new Date('2009-02-30')` does not throw — it rolls forward to 2 March. The
-  // round-trip is what catches it.
-  const parsed = new Date(`${value}T00:00:00Z`);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
-}
+// `isRealDay` is imported rather than restated. It is strict on purpose: date
+// orientation is the standing hazard on this map — `03/02/2009` is two different
+// children depending on who typed it, and the damage is a permanent contact
+// keyed to the wrong birthday, which then poisons the surname + DOB key for
+// every later term. The parser resolves orientation before anything reaches
+// here; the routes accept one form so an unresolved date cannot slip past as a
+// search that finds nothing.
 
 /**
  * The default search: build a paced Clubworx client from `env` and sweep the
@@ -329,8 +318,15 @@ export function createHandler({
       //   - **400** for a refusal that happened before any write — a lead-time
       //     session, a pass that will not cover the term, a malformed request.
       //     Nothing was attempted, so there is no row.
-      const status =
-        result.reason === 'throttled' ? 429 : result.outcome === 'refused' ? 400 : 200;
+      // A throttle leaves as a 429 **only when nothing was written**. Once this
+      // call has created a contact, granted a pass or rolled bookings back,
+      // there is a row to record, and a non-200 invites a client to throw the
+      // body away — which is the body D10 writes to localStorage precisely
+      // because a lost record of an un-deletable creation is unrecoverable. The
+      // page still sees `reason: "throttled"` in the body and pauses the run on
+      // that, which is the signal §11 actually asks for.
+      const throttled = result.reason === 'throttled' && result.written !== true;
+      const status = throttled ? 429 : result.outcome === 'refused' ? 400 : 200;
 
       return done(json(result, status), { email, outcome: result.outcome });
     }

--- a/cloudflare-clubworx/src/memberships.js
+++ b/cloudflare-clubworx/src/memberships.js
@@ -1,0 +1,224 @@
+/**
+ * Does this student already hold a School Pass that reaches the last session?
+ *
+ * staff-site#69. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+ * §10 (D4, D14), §13; ADR 0005 (`docs/adr/0005-school-pass-runs-26-weeks.md`).
+ *
+ * `summariseMemberships` is **promoted from `probes/lib/report.mjs`**, not
+ * re-implemented — the same treatment `errorMessageOf` and `buildUrl` had before
+ * it (§6). It was written against a real membership record read live on
+ * 2026-08-18, and re-deriving it would re-derive the one thing it exists to
+ * prevent:
+ *
+ * ---------------------------------------------------------------------------
+ * A membership has no `status` field
+ * ---------------------------------------------------------------------------
+ * Verified against a live record. There is `start_date` and `expiration_date`
+ * and nothing that says "active". Code that reaches for `status` reads
+ * `undefined`, decides the pass is inactive, and grants a **second permanent
+ * membership** to somebody who already holds a live one — and memberships have
+ * no delete (§12). So activity is derived from the two dates, inclusive at both
+ * ends, in exactly one place.
+ *
+ * ---------------------------------------------------------------------------
+ * "Active today" is the wrong question — and it is the question that hid a bug
+ * ---------------------------------------------------------------------------
+ * `assessPass` compares the held pass against the **latest selected session**,
+ * never against today. Every booking in a run is written on the day of the run,
+ * when the pass is unambiguously active, so a pass that expires mid-term looks
+ * perfect at write time and fails weeks later at a session nobody is watching.
+ * That is the whole of ADR 0005.
+ *
+ * The 26-week pass does not remove the trap — it makes it **more** common. Under
+ * 12 weeks a returning student's pass had usually lapsed, so the grant was
+ * clean; at 26 weeks the tool regularly finds one that is live and expires
+ * before the term ends.
+ *
+ * ---------------------------------------------------------------------------
+ * Why a live-but-short pass refuses instead of granting
+ * ---------------------------------------------------------------------------
+ * Granting the covering pass to a live holder means putting a **second** School
+ * Pass on an active member — the one thing on this effort deliberately never
+ * probed, because memberships have no delete and the probe would leave the
+ * permanent record it was testing for (§15, staff-site#90).
+ *
+ * D4 closed that question for free while *active* meant "active today". It does
+ * not any more. Until #90 answers, this returns `needs-confirmation` and a human
+ * decides — §11's standing posture: refuse and let the human fix it, rather than
+ * silently adjust.
+ */
+
+/**
+ * Reduce a `GET /memberships?contact_key=` body to the pass states on one plan.
+ *
+ * Bounded on purpose: a membership row carries `member_name` and other record
+ * fields, and this Worker is a transit, not a database (§6, D10). Only the plan
+ * dates and the class counters leave here.
+ *
+ * `fields` is the exception, and it is names only, never values. It is how the
+ * probes established that **no `status` field exists** — the finding this whole
+ * module turns on — and the probe write-ups still print it, so a future schema
+ * change is visible rather than inferred.
+ *
+ * @param {unknown} body
+ * @param {string|number|null} [planId] The plan being looked for.
+ * @param {{on?: string}} [opts] The day to judge activity against.
+ */
+export function summariseMemberships(body, planId = null, { on = null } = {}) {
+  if (!Array.isArray(body)) {
+    return {
+      count: 0,
+      fields: [],
+      holdsPlan: false,
+      holdsActivePlan: false,
+      planStates: [],
+      notAnArray: true,
+    };
+  }
+
+  const today = (on ?? new Date().toISOString()).slice(0, 10);
+  const fields = new Set();
+  const planStates = [];
+  let holdsPlan = false;
+  let holdsActivePlan = false;
+
+  for (const row of body) {
+    // Names only. A value here would be a student's, and this Worker writes
+    // nothing down — but knowing which fields exist is what caught the missing
+    // `status`.
+    for (const key of Object.keys(row ?? {})) fields.add(key);
+
+    // String on both sides: Clubworx has sent this id as a number and as a
+    // string, and `64189 !== '64189'` would read a held pass as not held.
+    if (planId === null || String(row?.membership_plan_id) !== String(planId)) continue;
+    holdsPlan = true;
+
+    const start = row?.start_date ?? null;
+    const expires = row?.expiration_date ?? null;
+    // Plain `YYYY-MM-DD`, so string comparison IS the date comparison and there
+    // is no timezone to get wrong. Inclusive at both ends: a pass starting today
+    // is usable today.
+    const active = (!start || start <= today) && (!expires || expires >= today);
+    if (active) holdsActivePlan = true;
+
+    planStates.push({
+      start_date: start,
+      expiration_date: expires,
+      active,
+      classes_booked: row?.classes_booked ?? null,
+      classes_remaining: row?.classes_remaining ?? null,
+      class_access: row?.class_access ?? null,
+    });
+  }
+
+  return {
+    count: body.length,
+    fields: [...fields],
+    holdsPlan,
+    holdsActivePlan,
+    planStates,
+    notAnArray: false,
+  };
+}
+
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Unbounded sorts last, so a row with no expiry is the best one held. */
+const UNBOUNDED = '9999-12-31';
+
+/**
+ * D4's verdict: grant a School Pass, skip it, or stop and ask a human.
+ *
+ * | State | Grant? | Why |
+ * |---|---|---|
+ * | `none` | yes | Holds nothing on this plan |
+ * | `expired` | yes | Every held pass ended before today — a clean grant |
+ * | `covering` | no | A live pass already reaches the last selected session |
+ * | `needs-confirmation` | no | Live but short, or not started — a second pass on a live holder (#90) |
+ * | `unknown` | no | A date this cannot compare. Never guess before a permanent write |
+ *
+ * @param {object} opts
+ * @param {Array<{start_date: string|null, expiration_date: string|null, active: boolean}>} opts.states
+ *   `planStates` from `summariseMemberships`, so the no-`status` rule applies once.
+ * @param {string} opts.lastSession `YYYY-MM-DD` — the latest selected session.
+ * @param {string} opts.on `YYYY-MM-DD` — the day of the run.
+ */
+export function assessPass({ states = [], lastSession, on }) {
+  const held = (Array.isArray(states) ? states : []).filter(Boolean);
+
+  if (!ISO_DAY.test(String(lastSession)) || !ISO_DAY.test(String(on))) {
+    return {
+      state: 'unknown',
+      grant: false,
+      expirationDate: null,
+      lastSession: lastSession ?? null,
+      detail:
+        'the pass cannot be assessed: the run date or the last session date is not a YYYY-MM-DD day, ' +
+        'and a pass is not granted on a date this cannot compare',
+    };
+  }
+
+  if (held.length === 0) {
+    return {
+      state: 'none',
+      grant: true,
+      expirationDate: null,
+      lastSession,
+      detail: 'no School Pass on this plan',
+    };
+  }
+
+  // Best first, so several held rows cannot let a lapsed one speak for a live one.
+  const byExpiry = [...held].sort((a, b) =>
+    String(b.expiration_date ?? UNBOUNDED).localeCompare(String(a.expiration_date ?? UNBOUNDED)),
+  );
+
+  const covering = byExpiry.find(
+    s =>
+      (!s.start_date || s.start_date <= on) &&
+      (!s.expiration_date || s.expiration_date >= lastSession),
+  );
+  if (covering) {
+    return {
+      state: 'covering',
+      grant: false,
+      expirationDate: covering.expiration_date ?? null,
+      lastSession,
+      detail:
+        'holds a School Pass to ' +
+        (covering.expiration_date ?? 'no expiry') +
+        ', which covers the last session on ' +
+        lastSession,
+    };
+  }
+
+  // Live today, or dated to start later. Either way granting now puts a second
+  // pass on a holder whose first one has not run out — the unprobed case (#90).
+  const live = byExpiry.find(s => s.active || (s.start_date && s.start_date > on));
+  if (live) {
+    return {
+      state: 'needs-confirmation',
+      grant: false,
+      expirationDate: live.expiration_date ?? null,
+      lastSession,
+      detail:
+        'holds a School Pass that runs ' +
+        (live.start_date ?? 'no start') +
+        ' to ' +
+        (live.expiration_date ?? 'no expiry') +
+        ', which does not reach the last selected session on ' +
+        lastSession +
+        '. Granting a second pass to a live holder has never been tested and cannot be undone — ' +
+        'a human decides this one.',
+    };
+  }
+
+  const latest = byExpiry[0]?.expiration_date ?? null;
+  return {
+    state: 'expired',
+    grant: true,
+    expirationDate: latest,
+    lastSession,
+    detail: 'holds a School Pass that expired on ' + (latest ?? 'an unknown date'),
+  };
+}

--- a/cloudflare-clubworx/src/memberships.js
+++ b/cloudflare-clubworx/src/memberships.js
@@ -48,6 +48,8 @@
  * silently adjust.
  */
 
+import { isRealDay } from './duration.js';
+
 /**
  * Reduce a `GET /memberships?contact_key=` body to the pass states on one plan.
  *
@@ -121,8 +123,6 @@ export function summariseMemberships(body, planId = null, { on = null } = {}) {
   };
 }
 
-const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
-
 /** Unbounded sorts last, so a row with no expiry is the best one held. */
 const UNBOUNDED = '9999-12-31';
 
@@ -146,7 +146,7 @@ const UNBOUNDED = '9999-12-31';
 export function assessPass({ states = [], lastSession, on }) {
   const held = (Array.isArray(states) ? states : []).filter(Boolean);
 
-  if (!ISO_DAY.test(String(lastSession)) || !ISO_DAY.test(String(on))) {
+  if (!isRealDay(lastSession) || !isRealDay(on)) {
     return {
       state: 'unknown',
       grant: false,

--- a/cloudflare-clubworx/src/student.js
+++ b/cloudflare-clubworx/src/student.js
@@ -77,7 +77,16 @@
 
 import { assessPass, summariseMemberships } from './memberships.js';
 import { isRealDay, parsePlanDuration, passCoverageEnd, perthDay } from './duration.js';
-import { bookEvent, cancelRunBookings, readBookings } from './bookings.js';
+import {
+  ALREADY_BOOKED_STATE,
+  BOOKED,
+  FAILED,
+  bookEvent,
+  cancelRunBookings,
+  readBookings,
+} from './bookings.js';
+import { PAGE_SIZE } from './contacts.js';
+import { isRetryable, upstreamMessage, upstreamReason } from './upstream.js';
 
 /**
  * UJ's School Sessions refuse a booking made inside a day of the start. The
@@ -92,27 +101,25 @@ export const MIN_LEAD_HOURS = 24;
 export const RETRY_BACKOFF_MS = 20_000;
 export const MAX_ATTEMPTS = 2;
 
-/** Never the default 50 — a full page is silent truncation (#51). */
-const PAGE_SIZE = 200;
-
 const MS_PER_HOUR = 60 * 60 * 1000;
+
+/**
+ * The only fields that may be sent to `POST /members`.
+ *
+ * An allowlist, not a spread of whatever the caller passed. `probes/lib/write.mjs`
+ * makes the same point about its own bookkeeping fields: *"posting it would put a
+ * field Clubworx never asked for onto a record nobody can delete."* The request
+ * body arrives over HTTP from a page this Worker does not control, and an extra
+ * key in it would be written onto a permanent contact — silently, since Clubworx
+ * answered 200 either way.
+ *
+ * `membership_plan_id` is added separately, from the resolved plan rather than
+ * from the request's student object.
+ */
+const MEMBER_FIELDS = ['first_name', 'last_name', 'dob', 'email'];
 
 /** Case- and whitespace-insensitive, for comparing a field against what we sent. */
 const same = (a, b) => String(a ?? '').trim().toLowerCase() === String(b ?? '').trim().toLowerCase();
-
-/**
- * A 429, a 5xx and a connection failure are the only retryable outcomes — D8.
- * **Never a 400.** All three known 400s are permanent for that attempt, and the
- * fourth kind is unknown by definition.
- */
-const retryable = res =>
-  res.networkError === true || res.status === 429 || res.status === 0 || res.status >= 500;
-
-const upstreamReason = res =>
-  res.status === 429 ? 'throttled' : res.networkError ? 'network' : 'upstream-error';
-
-/** What a caller may safely print: never a body, never a student field. */
-const upstreamMessage = res => res.message ?? res.bodyText ?? null;
 
 /**
  * Wrap the client so every call it makes is counted.
@@ -220,7 +227,8 @@ async function findCreatedContact({ client, student }) {
  * happen once a read has proved the previous attempt did not land.
  */
 async function createContactWithPass({ client, student, membershipPlanId, sleep }) {
-  const payload = { ...student, membership_plan_id: membershipPlanId };
+  const payload = { membership_plan_id: membershipPlanId };
+  for (const field of MEMBER_FIELDS) payload[field] = student[field];
   let last = null;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
@@ -239,7 +247,7 @@ async function createContactWithPass({ client, student, membershipPlanId, sleep 
       };
     }
 
-    if (!retryable(last)) break;
+    if (!isRetryable(last)) break;
     if (attempt < MAX_ATTEMPTS) await sleep(RETRY_BACKOFF_MS);
   }
 
@@ -251,7 +259,7 @@ async function createContactWithPass({ client, student, membershipPlanId, sleep 
         'book against or to create again'
       : upstreamMessage(last),
     upstreamStatus: last.status,
-    mayHaveWritten: !last.ok && retryable(last),
+    mayHaveWritten: !last.ok && isRetryable(last),
   };
 }
 
@@ -316,7 +324,7 @@ async function grantPass({ client, contactKey, membershipPlanId, lastSession, to
       };
     }
     // Read cleanly, and the pass still does not cover the term.
-    if (!retryable(last)) {
+    if (!isRetryable(last)) {
       return {
         ok: false,
         reason: 'pass-unverified',
@@ -356,7 +364,7 @@ async function bookWithRetry({ client, contactKey, event, sleep }) {
       eventId: event.event_id,
       spacesAvailable: event.spaces_available ?? null,
     });
-    if (row.state !== 'failed' || !row.retryable) break;
+    if (row.state !== FAILED || !row.retryable) break;
     if (attempt < MAX_ATTEMPTS) await sleep(RETRY_BACKOFF_MS);
   }
   return row;
@@ -508,7 +516,7 @@ export async function runStudentChain({
     const created = await createContactWithPass({ client, student, membershipPlanId, sleep });
     if (!created.ok) {
       return result({
-        outcome: created.reason === 'throttled' ? 'failed' : 'failed',
+        outcome: 'failed',
         reason: created.reason,
         message: created.message,
         written: created.mayHaveWritten === true,
@@ -611,7 +619,7 @@ export async function runStudentChain({
   for (const event of events) {
     const row = await bookWithRetry({ client, contactKey: key, event, sleep });
     rows.push(row);
-    if (row.state !== 'booked' && row.state !== 'already booked') {
+    if (row.state !== BOOKED && row.state !== ALREADY_BOOKED_STATE) {
       failure = row;
       break;
     }

--- a/cloudflare-clubworx/src/student.js
+++ b/cloudflare-clubworx/src/student.js
@@ -1,0 +1,702 @@
+/**
+ * The per-student write chain — the only code in this repo that creates
+ * permanent records.
+ *
+ * staff-site#69. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+ * §10 (the write chain), §11 (refusals and retries), §12 (irreversibility).
+ *
+ * ---------------------------------------------------------------------------
+ * Read this before changing anything below
+ * ---------------------------------------------------------------------------
+ * **Contacts and memberships cannot be deleted.** Not by this Worker, not by
+ * the API at all — 42 endpoints reviewed, no delete on either (§12). A contact
+ * written by mistake sits beside ~60,000 real people until somebody removes it
+ * by hand in the Clubworx UI. Bookings are the one reversal there is.
+ *
+ * Everything odd-looking in here follows from that asymmetry:
+ *
+ *   - **Every write is verified by re-reading the resource, never by the status
+ *     code.** An accepted-but-silent failure and a success are the same 200. It
+ *     is how #60 established booking idempotency — by counting either side.
+ *   - **A retry re-reads first.** A connection error on `POST /members` may have
+ *     landed; retrying blind is how one student becomes two permanent records.
+ *   - **Anything uncertain refuses.** A read that fails, a body that is not a
+ *     list, a date that will not parse — none of them are guessed past, because
+ *     the cheap-looking guess is the one that writes.
+ *
+ * ---------------------------------------------------------------------------
+ * The unit is one student, and it is all-or-nothing
+ * ---------------------------------------------------------------------------
+ * **D2** — the student is the only unit whose failure boundary is a sentence
+ * staff can say out loud: *"the first six are in, the rest are not."* Per-event
+ * strands a child who turns up to session 4 and is not on the list.
+ *
+ * **D3** — any failure abandons the student and **cancels the bookings this run
+ * already made for them**. A student is in every session or in none, never
+ * half-booked. The rollback is what makes that true rather than nominal.
+ *
+ * It leaves a **stranded student**: a permanent contact and pass, no bookings.
+ * That is a routine outcome under D3, not an edge case, and the result names it
+ * so staff can finish it by hand.
+ *
+ * ---------------------------------------------------------------------------
+ * The chain
+ * ---------------------------------------------------------------------------
+ * ```
+ * matched → re-read membership → ensure School Pass → book ×N → verify
+ * new     → create contact WITH the pass ───────────→ book ×N → verify
+ * ```
+ *
+ * **D4 — no membership read for a contact we just created**, which provably
+ * holds none, and **read at Apply for matched contacts**. The read is only ever
+ * wasted on a contact we just created; for a student who already holds a
+ * covering pass, reading and assigning cost the same single request, so blind
+ * assignment buys nothing in exactly the case where it would duplicate.
+ *
+ * **D14 — the membership is re-read immediately before its own write**, not at
+ * preview. Contact and booking both have server-side idempotency to fall back
+ * on; the membership has none. Nothing else is re-validated.
+ *
+ * ---------------------------------------------------------------------------
+ * What this deliberately does not do
+ * ---------------------------------------------------------------------------
+ * **It does not decide the match.** `contactKey` arrives from the page, which
+ * got it from `GET /contacts` (#68) and resolved it in `school-booking/
+ * identity.js`. A null key means `new`, and `new` creates a contact — so the
+ * Worker re-reads after the create rather than trusting that decision blindly.
+ *
+ * **It does not re-validate the event list.** D14 is explicit that only the
+ * membership is re-read. The lead-time and pass-coverage gates below run
+ * against the dates the page sends; they are a backstop at the point of writing,
+ * not a second source of truth.
+ *
+ * **It does not run the circuit breaker.** D7 halts a *run* after 3 consecutive
+ * failures, and a run is many students across many calls — the page's job. This
+ * handles one student and reports honestly enough for the page to count.
+ */
+
+import { assessPass, summariseMemberships } from './memberships.js';
+import { isRealDay, parsePlanDuration, passCoverageEnd, perthDay } from './duration.js';
+import { bookEvent, cancelRunBookings, readBookings } from './bookings.js';
+
+/**
+ * UJ's School Sessions refuse a booking made inside a day of the start. The
+ * rule lives in Clubworx's configuration and no endpoint exposes it, so it is
+ * pre-empted here rather than met as Clubworx's own message — *"Sorry! This
+ * class is now closed for bookings."* — which names no cause and reads like a
+ * capacity problem (D9).
+ */
+export const MIN_LEAD_HOURS = 24;
+
+/** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
+export const RETRY_BACKOFF_MS = 20_000;
+export const MAX_ATTEMPTS = 2;
+
+/** Never the default 50 — a full page is silent truncation (#51). */
+const PAGE_SIZE = 200;
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+/** Case- and whitespace-insensitive, for comparing a field against what we sent. */
+const same = (a, b) => String(a ?? '').trim().toLowerCase() === String(b ?? '').trim().toLowerCase();
+
+/**
+ * A 429, a 5xx and a connection failure are the only retryable outcomes — D8.
+ * **Never a 400.** All three known 400s are permanent for that attempt, and the
+ * fourth kind is unknown by definition.
+ */
+const retryable = res =>
+  res.networkError === true || res.status === 429 || res.status === 0 || res.status >= 500;
+
+const upstreamReason = res =>
+  res.status === 429 ? 'throttled' : res.networkError ? 'network' : 'upstream-error';
+
+/** What a caller may safely print: never a body, never a student field. */
+const upstreamMessage = res => res.message ?? res.bodyText ?? null;
+
+/**
+ * Wrap the client so every call it makes is counted.
+ *
+ * The allowance is gym-wide (one key per gym, #47) and a school import is
+ * already a four-minute slowdown for everyone else, so the number a student
+ * costs is worth reporting rather than estimating.
+ */
+function counted(client) {
+  const state = { requests: 0 };
+  const tick = fn => (...args) => {
+    state.requests += 1;
+    return fn(...args);
+  };
+  return {
+    state,
+    client: {
+      get: tick(client.get.bind(client)),
+      post: tick(client.post.bind(client)),
+      postForm: tick(client.postForm.bind(client)),
+      del: tick(client.del.bind(client)),
+    },
+  };
+}
+
+/**
+ * Find the contact this run just created, by re-reading `/members`.
+ *
+ * The verdict on a create comes from here, never from the status code (#63 did
+ * exactly this, and it is why the probe could tell a create that worked from
+ * one that did not). It also supplies the `contact_key` the rest of the chain
+ * uses — the create response's own key is not trusted, because a response shape
+ * this reference has been wrong about twice is not evidence.
+ *
+ * @returns {Promise<{state: 'found'|'absent'|'ambiguous'|'error', contactKey?: string,
+ *   reason?: string, message?: string|null, upstreamStatus?: number|null}>}
+ */
+async function findCreatedContact({ client, student }) {
+  const res = await client.get('members', {
+    last_name: student.last_name,
+    dob: student.dob,
+    page_size: PAGE_SIZE,
+  });
+
+  if (!res.ok) {
+    return {
+      state: 'error',
+      reason: upstreamReason(res),
+      message: upstreamMessage(res),
+      upstreamStatus: res.status,
+    };
+  }
+  if (!Array.isArray(res.body)) {
+    return {
+      state: 'error',
+      reason: 'upstream-error',
+      message: `members answered ${res.status} with a body that is not a list of contacts`,
+      upstreamStatus: res.status,
+    };
+  }
+  // A page that came back exactly full is indistinguishable from a complete
+  // list, so "not found" on one is not an answer (#51).
+  if (res.body.length >= PAGE_SIZE) {
+    return {
+      state: 'error',
+      reason: 'search-not-narrowed',
+      message:
+        `members returned a full page of ${PAGE_SIZE}, so this cannot be told apart from a ` +
+        'truncated list, and a create cannot be confirmed against it',
+      upstreamStatus: res.status,
+    };
+  }
+
+  const mine = res.body.filter(
+    row =>
+      row?.contact_key &&
+      same(row.first_name, student.first_name) &&
+      same(row.last_name, student.last_name) &&
+      String(row.dob ?? '') === String(student.dob) &&
+      same(row.email, student.email),
+  );
+
+  if (mine.length === 1) return { state: 'found', contactKey: mine[0].contact_key };
+  if (mine.length === 0) return { state: 'absent' };
+  return {
+    state: 'ambiguous',
+    reason: 'contact-ambiguous',
+    message:
+      `${mine.length} contacts now match this student exactly. Either the dedup search missed one ` +
+      'or this run has created a duplicate — and contacts cannot be deleted through the API, so ' +
+      'this needs a person in the Clubworx UI before the student is booked into anything.',
+  };
+}
+
+/**
+ * Create the contact and its School Pass in one request, then prove it landed.
+ *
+ * `POST /members`, **JSON**, with `membership_plan_id` riding along — measured
+ * in #63, which answered 200 on the first attempt. The reference calls this
+ * endpoint form-encoded and that shape has never been tested; do not "correct"
+ * it on the reference's word. (`/memberships` genuinely is form-encoded. The
+ * encoding is per-endpoint, not per-API.)
+ *
+ * The re-read between attempts is the whole safety property: a retry can only
+ * happen once a read has proved the previous attempt did not land.
+ */
+async function createContactWithPass({ client, student, membershipPlanId, sleep }) {
+  const payload = { ...student, membership_plan_id: membershipPlanId };
+  let last = null;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    last = await client.post('members', payload);
+
+    const check = await findCreatedContact({ client, student });
+    if (check.state === 'found') return { ok: true, contactKey: check.contactKey };
+    if (check.state === 'ambiguous' || check.state === 'error') {
+      return {
+        ok: false,
+        reason: check.state === 'ambiguous' ? 'contact-ambiguous' : 'contact-unverified',
+        message: check.message,
+        // The create may well have landed. Saying otherwise would be a guess
+        // about a record nobody can delete.
+        mayHaveWritten: true,
+      };
+    }
+
+    if (!retryable(last)) break;
+    if (attempt < MAX_ATTEMPTS) await sleep(RETRY_BACKOFF_MS);
+  }
+
+  return {
+    ok: false,
+    reason: last.ok ? 'contact-unverified' : upstreamReason(last),
+    message: last.ok
+      ? 'Clubworx accepted the contact but a re-read cannot find it, so it is not safe to ' +
+        'book against or to create again'
+      : upstreamMessage(last),
+    upstreamStatus: last.status,
+    mayHaveWritten: !last.ok && retryable(last),
+  };
+}
+
+/** Read the pass a matched student holds, and judge it against the last session. */
+async function readPass({ client, contactKey, membershipPlanId, lastSession, today }) {
+  const res = await client.get('memberships', { contact_key: contactKey });
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      reason: upstreamReason(res),
+      message: upstreamMessage(res),
+      upstreamStatus: res.status,
+    };
+  }
+
+  const summary = summariseMemberships(res.body, membershipPlanId, { on: today });
+  if (summary.notAnArray) {
+    return {
+      ok: false,
+      reason: 'upstream-error',
+      message: `memberships answered ${res.status} with a body that is not a list`,
+      upstreamStatus: res.status,
+    };
+  }
+
+  return { ok: true, verdict: assessPass({ states: summary.planStates, lastSession, on: today }) };
+}
+
+/**
+ * Grant a School Pass, then prove it covers the term.
+ *
+ * Form-encoded — measured on `POST /memberships` (#60). Verified the same way
+ * the create is: by re-reading and re-judging, because a 200 on a grant that
+ * produced a pass expiring mid-term looks exactly like a 200 on one that did
+ * not.
+ */
+async function grantPass({ client, contactKey, membershipPlanId, lastSession, today, sleep }) {
+  let last = null;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    last = await client.postForm('memberships', {
+      contact_key: contactKey,
+      membership_plan_id: String(membershipPlanId),
+      // Clubworx chooses today anyway (#63) — sending it makes the record say
+      // what this tool intended rather than what it inherited.
+      start_date: today,
+    });
+
+    const check = await readPass({ client, contactKey, membershipPlanId, lastSession, today });
+    if (check.ok && check.verdict.state === 'covering') {
+      return { ok: true, verdict: check.verdict };
+    }
+    if (!check.ok) {
+      return {
+        ok: false,
+        reason: 'pass-unverified',
+        message:
+          'the School Pass was sent but could not be re-read, so whether it landed is unknown: ' +
+          (check.message ?? `HTTP ${check.upstreamStatus}`),
+        mayHaveWritten: true,
+      };
+    }
+    // Read cleanly, and the pass still does not cover the term.
+    if (!retryable(last)) {
+      return {
+        ok: false,
+        reason: 'pass-unverified',
+        message:
+          'the School Pass was accepted but re-reading it shows it does not cover the last ' +
+          `selected session: ${check.verdict.detail}`,
+        mayHaveWritten: true,
+        verdict: check.verdict,
+      };
+    }
+    if (attempt < MAX_ATTEMPTS) await sleep(RETRY_BACKOFF_MS);
+  }
+
+  return {
+    ok: false,
+    reason: 'pass-unverified',
+    message: upstreamMessage(last),
+    upstreamStatus: last.status,
+    mayHaveWritten: true,
+  };
+}
+
+/**
+ * Book one event, retrying only what D8 allows.
+ *
+ * A booking retry is safe in a way a contact retry is not: Clubworx refuses its
+ * own duplicate with *"Woops! You've already booked into this class!"*, which
+ * this reads as a success. That is the idempotency guarantee, and it is also
+ * why D5's whole recovery story is "re-run it".
+ */
+async function bookWithRetry({ client, contactKey, event, sleep }) {
+  let row = null;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    row = await bookEvent({
+      client,
+      contactKey,
+      eventId: event.event_id,
+      spacesAvailable: event.spaces_available ?? null,
+    });
+    if (row.state !== 'failed' || !row.retryable) break;
+    if (attempt < MAX_ATTEMPTS) await sleep(RETRY_BACKOFF_MS);
+  }
+  return row;
+}
+
+/** The instant an event starts, or null if it is not readable as one. */
+const startOf = event => {
+  const raw = event?.starts_at ?? event?.event_start_at ?? null;
+  const at = raw === null ? NaN : Date.parse(raw);
+  return Number.isNaN(at) ? null : at;
+};
+
+/**
+ * Run the whole chain for one student.
+ *
+ * @param {object} opts
+ * @param {object} opts.client A `createClubworxClient` instance. Everything is paced.
+ * @param {{first_name: string, last_name: string, dob: string, email: string}} opts.student
+ * @param {string|null} opts.contactKey Null means `new` — this call creates the contact.
+ * @param {string|number} opts.membershipPlanId The School Pass plan, resolved by `GET /plan`.
+ * @param {string} opts.membershipDuration The plan's `membership_duration`, raw.
+ * @param {Array<{event_id: any, starts_at: string, spaces_available?: number}>} opts.events
+ * @param {string} [opts.now] The instant of the run. Injected so tests are not clock-dependent.
+ * @param {(ms: number) => Promise<void>} [opts.sleep]
+ */
+export async function runStudentChain({
+  client: rawClient,
+  student,
+  contactKey = null,
+  membershipPlanId,
+  membershipDuration,
+  events = [],
+  now = new Date().toISOString(),
+  sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+}) {
+  const { client, state } = counted(rawClient);
+  const warnings = [];
+
+  const result = over => ({
+    ok: false,
+    outcome: 'failed',
+    written: false,
+    contact: { contact_key: contactKey, state: contactKey ? 'matched' : null },
+    pass: { state: null, expiration_date: null, detail: null },
+    bookings: [],
+    rollback: null,
+    stranded: false,
+    strandedDetail: null,
+    warnings,
+    requests: state.requests,
+    reason: null,
+    message: null,
+    ...over,
+  });
+
+  // -------------------------------------------------------------------------
+  // Gates. Everything here runs before a single request, because after the
+  // first write there is no way back.
+  // -------------------------------------------------------------------------
+  const startedAt = Date.parse(now);
+  const today = perthDay(now);
+  if (Number.isNaN(startedAt) || !today) {
+    return result({ outcome: 'refused', reason: 'bad-request', message: 'the run time is not a readable instant' });
+  }
+
+  if (!student?.first_name || !student?.last_name || !isRealDay(student?.dob) || !student?.email) {
+    return result({
+      outcome: 'refused',
+      reason: 'bad-request',
+      message: 'a student needs a first name, a last name, an email and a YYYY-MM-DD date of birth',
+    });
+  }
+
+  if (!membershipPlanId) {
+    return result({
+      outcome: 'refused',
+      reason: 'bad-request',
+      message: 'the School Pass plan id is required; a run without it cannot grant a pass',
+    });
+  }
+
+  if (!Array.isArray(events) || events.length === 0) {
+    return result({ outcome: 'refused', reason: 'bad-request', message: 'no sessions were selected' });
+  }
+
+  const starts = events.map(startOf);
+  if (starts.some(at => at === null) || events.some(e => e?.event_id === undefined || e?.event_id === null)) {
+    return result({
+      outcome: 'refused',
+      reason: 'bad-request',
+      message:
+        'every session needs an event id and a readable start time — a session whose start ' +
+        'cannot be read cannot be checked against the lead time',
+    });
+  }
+
+  const tooSoon = events.filter((_, i) => starts[i] - startedAt < MIN_LEAD_HOURS * MS_PER_HOUR);
+  if (tooSoon.length > 0) {
+    // D9 — dropping the event automatically was rejected as a silent
+    // adjustment. Staff must never meet Clubworx's own message here.
+    return result({
+      outcome: 'refused',
+      reason: 'lead-time',
+      message:
+        `${tooSoon.length} selected session(s) start within ${MIN_LEAD_HOURS} hours. ` +
+        'Clubworx refuses those, with a message that reads like a capacity problem. ' +
+        'Remove them and run again.',
+      leadTimeEventIds: tooSoon.map(e => e.event_id),
+    });
+  }
+
+  const lastSession = perthDay(new Date(Math.max(...starts)));
+
+  const duration = parsePlanDuration(membershipDuration);
+  if (!duration.ok) {
+    // §11: warn on screen naming the raw value. Never skip the coverage check
+    // silently — a plan whose duration is later shortened must produce a visible
+    // refusal, not a quiet tail of missing bookings.
+    warnings.push(
+      `The School Pass plan reports its duration as ${JSON.stringify(duration.raw)}, which this ` +
+        'tool cannot read. The pass-coverage check has been skipped, so nothing here has ' +
+        'confirmed that the pass reaches the last selected session.',
+    );
+  } else {
+    const coversTo = passCoverageEnd(today, duration);
+    if (!coversTo || lastSession > coversTo) {
+      return result({
+        outcome: 'refused',
+        reason: 'pass-coverage',
+        message:
+          `A School Pass granted today runs ${duration.raw} and covers to ${coversTo}, but the ` +
+          `last selected session is ${lastSession}. Every booking would be written on a day the ` +
+          'pass is active and the last sessions would fail weeks later. Nothing has been written.',
+        coversTo,
+        lastSession,
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // The pass. Two shapes, per D4.
+  // -------------------------------------------------------------------------
+  let key = contactKey;
+  let contactState = contactKey ? 'matched' : 'created';
+  let pass = { state: null, expiration_date: null, detail: null };
+  let passAssured = false;
+
+  if (!key) {
+    const created = await createContactWithPass({ client, student, membershipPlanId, sleep });
+    if (!created.ok) {
+      return result({
+        outcome: created.reason === 'throttled' ? 'failed' : 'failed',
+        reason: created.reason,
+        message: created.message,
+        written: created.mayHaveWritten === true,
+        contact: { contact_key: null, state: null },
+        // A contact that may exist with a pass and no bookings is exactly the
+        // stranded shape, and it is the case a human has to resolve by hand.
+        stranded: created.mayHaveWritten === true,
+        strandedDetail:
+          created.mayHaveWritten === true
+            ? 'A contact may have been created for this student, with a School Pass and no ' +
+              'bookings. Contacts cannot be deleted through the API — check Clubworx before ' +
+              're-running this student.'
+            : null,
+      });
+    }
+
+    key = created.contactKey;
+    // D4: no membership read for a contact we just created. It provably held
+    // none, and the pass rode along on the create — one request that either
+    // happened or did not (#63), which the contact re-read has just confirmed.
+    pass = {
+      state: 'created-with-contact',
+      expiration_date: null,
+      detail: 'created with the contact, in one request, starting today',
+    };
+    passAssured = true;
+  } else {
+    // D14 — read immediately before the write it guards, not at preview.
+    const held = await readPass({ client, contactKey: key, membershipPlanId, lastSession, today });
+    if (!held.ok) {
+      return result({
+        outcome: 'failed',
+        reason: held.reason,
+        message: held.message,
+        // Nothing written: the read is the first thing the matched branch does.
+        written: false,
+      });
+    }
+
+    const verdict = held.verdict;
+    pass = {
+      state: verdict.state,
+      expiration_date: verdict.expirationDate,
+      detail: verdict.detail,
+    };
+
+    if (verdict.state === 'needs-confirmation' || verdict.state === 'unknown') {
+      // §11's posture, and #90's open question: granting a second pass to a live
+      // holder has never been tested and memberships have no delete.
+      return result({
+        outcome: 'needs-confirmation',
+        reason: verdict.state === 'unknown' ? 'pass-indeterminate' : 'pass-not-covering',
+        message: verdict.detail,
+        contact: { contact_key: key, state: 'matched' },
+        pass,
+        written: false,
+      });
+    }
+
+    if (verdict.grant) {
+      const granted = await grantPass({
+        client,
+        contactKey: key,
+        membershipPlanId,
+        lastSession,
+        today,
+        sleep,
+      });
+      if (!granted.ok) {
+        return result({
+          outcome: 'failed',
+          reason: granted.reason,
+          message: granted.message,
+          written: granted.mayHaveWritten === true,
+          contact: { contact_key: key, state: 'matched' },
+          pass: { ...pass, state: 'grant-failed' },
+          stranded: granted.mayHaveWritten === true,
+          strandedDetail:
+            granted.mayHaveWritten === true
+              ? 'A School Pass may have been assigned to this student, with no bookings. ' +
+                'Memberships cannot be deleted through the API — check Clubworx before re-running.'
+              : null,
+        });
+      }
+      pass = {
+        state: 'granted',
+        expiration_date: granted.verdict.expirationDate,
+        detail: granted.verdict.detail,
+      };
+    }
+    passAssured = true;
+  }
+
+  // -------------------------------------------------------------------------
+  // The bookings, and D3's rollback.
+  // -------------------------------------------------------------------------
+  const rows = [];
+  let failure = null;
+
+  for (const event of events) {
+    const row = await bookWithRetry({ client, contactKey: key, event, sleep });
+    rows.push(row);
+    if (row.state !== 'booked' && row.state !== 'already booked') {
+      failure = row;
+      break;
+    }
+  }
+
+  const abandon = async ({ reason, message }) => {
+    // The same code path as the human "Cancel bookings from this run" control,
+    // with no human present — so it honours the same interlock: act on `booked`,
+    // never on `already booked`.
+    const rollback = await cancelRunBookings({ client, contactKey: key, rows });
+    const leftover = rollback.failed.length;
+
+    return result({
+      outcome: 'abandoned',
+      reason,
+      message,
+      written: true,
+      contact: { contact_key: key, state: contactState },
+      pass,
+      bookings: rows,
+      rollback,
+      stranded: passAssured,
+      strandedDetail: passAssured
+        ? 'This student has a contact and a School Pass and no bookings from this run' +
+          (leftover > 0
+            ? `, and ${leftover} booking(s) could not be cancelled — they need removing by hand.`
+            : '. Finish them by hand, or fix the session and run the list again.')
+        : null,
+      requests: state.requests,
+    });
+  };
+
+  if (failure) {
+    return abandon({
+      reason: failure.reason ?? failure.refusal ?? 'booking-refused',
+      message: failure.shown ?? failure.message ?? 'a booking failed',
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Verify by re-reading, never by the status code.
+  // -------------------------------------------------------------------------
+  const held = await readBookings({ client, contactKey: key });
+
+  if (!held.ok) {
+    // Nothing is rolled back here on purpose. A failed *read* is not a failed
+    // write, and cancelling good bookings because a verification request
+    // timed out would destroy the very thing being checked. The row set is
+    // handed back so the human control can act on it.
+    return result({
+      ok: false,
+      outcome: 'unverified',
+      reason: 'bookings-unread',
+      message:
+        'every booking was accepted but they could not be re-read to confirm: ' +
+        (held.message ?? `HTTP ${held.upstreamStatus}`) +
+        '. Nothing has been cancelled — check this student in Clubworx.',
+      written: true,
+      contact: { contact_key: key, state: contactState },
+      pass,
+      bookings: rows,
+      requests: state.requests,
+    });
+  }
+
+  const heldEvents = new Set(held.eventIds);
+  const missing = rows.filter(row => !heldEvents.has(String(row.event_id)));
+  if (missing.length > 0) {
+    return abandon({
+      reason: 'bookings-unverified',
+      message:
+        `${missing.length} session(s) were accepted by Clubworx but are not there on a re-read. ` +
+        'A booking that reports success and does not exist is the one failure a status code ' +
+        'cannot show, so this student has been rolled back rather than reported as done.',
+    });
+  }
+
+  return result({
+    ok: true,
+    outcome: 'complete',
+    written: true,
+    contact: { contact_key: key, state: contactState },
+    pass,
+    bookings: rows,
+    stranded: false,
+    requests: state.requests,
+  });
+}

--- a/cloudflare-clubworx/src/upstream.js
+++ b/cloudflare-clubworx/src/upstream.js
@@ -1,0 +1,68 @@
+/**
+ * What a Clubworx answer means: retry it, report it, or neither.
+ *
+ * staff-site#69. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §11.
+ *
+ * One definition, because the write chain and the booking module were each
+ * carrying their own copy of the same cascade and the two would drift on the
+ * first fix that only landed in one. The way that drift shows up is not a test
+ * failure — it is a `400` retried against a database that cannot delete what the
+ * retry creates.
+ *
+ * **D8 — retry only `429`, network errors and `5xx`. Never a `400`.** All three
+ * known 400s are permanent for that attempt, and the fourth kind is unknown by
+ * definition, so retrying it is spending the gym's allowance to be told the same
+ * thing again.
+ *
+ * A **`429` is told apart from the rest** everywhere it appears, because §11
+ * pauses the *whole run* on a throttle rather than one row: the allowance is
+ * gym-wide (one key per gym, #47), so backing off a single student while the
+ * others continue just spends the next window failing.
+ */
+
+/**
+ * May this be tried again?
+ *
+ * `status === 0` is the client's own marker for a connection failure that never
+ * reached an answer — see `clubworx.js`, which uses 0 rather than null so a
+ * caller comparing statuses cannot mistake it for an upstream reply it simply
+ * did not read.
+ *
+ * @param {{status?: number, networkError?: boolean}} res
+ */
+export function isRetryable(res) {
+  return (
+    res?.networkError === true || res?.status === 429 || res?.status === 0 || res?.status >= 500
+  );
+}
+
+/**
+ * The machine-readable name for a failure, for the page to switch on.
+ *
+ * @param {{status?: number, networkError?: boolean}} res
+ * @returns {'throttled'|'network'|'upstream-error'}
+ */
+export function upstreamReason(res) {
+  if (res?.status === 429) return 'throttled';
+  if (res?.networkError === true) return 'network';
+  return 'upstream-error';
+}
+
+/**
+ * The most faithful text available about a failure, and never a body.
+ *
+ * `message` is the client's own contract — it runs `errorMessageOf` over every
+ * JSON body, and puts the scrubbed reason there on a connection failure.
+ * `bodyText` is the leftover case: a throttle or a WAF block answering in HTML,
+ * already redacted and truncated by the client.
+ *
+ * Both are safe to show. Neither is a record field, so no student travels in
+ * one — the extraction is bounded to the `error`-shaped fields on purpose
+ * (`errors.js`).
+ *
+ * @param {{message?: string|null, bodyText?: string|null}} res
+ * @returns {string|null}
+ */
+export function upstreamMessage(res) {
+  return res?.message ?? res?.bodyText ?? null;
+}

--- a/cloudflare-clubworx/test/bookings.test.js
+++ b/cloudflare-clubworx/test/bookings.test.js
@@ -131,7 +131,10 @@ describe('bookEvent', () => {
     const client = clientReturning(ok({ booking_id: 63510241 }));
     expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
       state: 'booked',
-      bookingId: '63510241',
+      booking_id: '63510241',
+      // The row carries the contact it belongs to, so a later cancel takes the
+      // key from the booking rather than from whoever is asking.
+      contact_key: 'ck-1',
     });
   });
 
@@ -141,14 +144,14 @@ describe('bookEvent', () => {
     expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
       state: 'already booked',
       refusal: 'already-booked',
-      bookingId: null,
+      booking_id: null,
     });
   });
 
   it('carries no booking id on an already-booked row, which is the cancel interlock', async () => {
     const client = clientReturning(refused(ALREADY_BOOKED));
     const row = await bookEvent({ client, contactKey: 'ck-1', eventId: 42 });
-    expect(row.bookingId).toBeNull();
+    expect(row.booking_id).toBeNull();
   });
 
   it('reports the closed-for-bookings refusal as permanent for that event', async () => {
@@ -199,7 +202,7 @@ describe('bookEvent', () => {
     const client = clientReturning(ok({ success: true }));
     expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
       state: 'booked',
-      bookingId: null,
+      booking_id: null,
       unverifiable: true,
     });
   });
@@ -227,10 +230,11 @@ describe('cancelBooking', () => {
 });
 
 describe('cancelRunBookings — the safety interlock', () => {
-  const bookedRow = (eventId, bookingId) => ({
+  const bookedRow = (eventId, bookingId, contactKey = 'ck-1') => ({
     event_id: eventId,
     state: 'booked',
     booking_id: bookingId,
+    contact_key: contactKey,
   });
 
   it('cancels the rows this run booked', async () => {
@@ -253,7 +257,7 @@ describe('cancelRunBookings — the safety interlock', () => {
       client,
       contactKey: 'ck-1',
       rows: [
-        { event_id: 1, state: 'already booked', booking_id: 'b-somebody-elses' },
+        { event_id: 1, state: 'already booked', booking_id: 'b-somebody-elses', contact_key: 'ck-1' },
         bookedRow(2, 'b2'),
       ],
     });
@@ -267,7 +271,7 @@ describe('cancelRunBookings — the safety interlock', () => {
     const out = await cancelRunBookings({
       client,
       contactKey: 'ck-1',
-      rows: [{ event_id: 1, state: 'already booked', booking_id: 'b1' }],
+      rows: [{ event_id: 1, state: 'already booked', booking_id: 'b1', contact_key: 'ck-1' }],
     });
 
     expect(client.calls).toHaveLength(0);
@@ -279,12 +283,44 @@ describe('cancelRunBookings — the safety interlock', () => {
     const out = await cancelRunBookings({
       client,
       contactKey: 'ck-1',
-      rows: [{ event_id: 1, state: 'booked', booking_id: null }],
+      rows: [{ event_id: 1, state: 'booked', booking_id: null, contact_key: 'ck-1' }],
     });
 
     expect(client.calls).toHaveLength(0);
     expect(out.failed).toHaveLength(1);
     expect(out.failed[0].reason).toContain('no booking id');
+  });
+
+  it('sends the contact key off the booking row, not the one the caller passed', async () => {
+    const client = clientReturning(ok({ success: true }));
+    await cancelRunBookings({ client, contactKey: undefined, rows: [bookedRow(1, 'b1', 'ck-row')] });
+
+    expect(client.calls[0].form).toMatchObject({ contact_key: 'ck-row' });
+  });
+
+  it('refuses a row belonging to a different contact than the one being rolled back', async () => {
+    // A DELETE aimed at somebody else's class is the worst outcome on this map.
+    const client = clientReturning(ok({ success: true }));
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [bookedRow(1, 'b1', 'ck-someone-else')],
+    });
+
+    expect(client.calls).toHaveLength(0);
+    expect(out.failed[0].reason).toContain('different contact');
+  });
+
+  it('refuses a booked row carrying no contact key of its own', async () => {
+    const client = clientReturning(ok({ success: true }));
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [{ event_id: 1, state: 'booked', booking_id: 'b1', contact_key: null }],
+    });
+
+    expect(client.calls).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
   });
 
   it('keeps going when one cancel fails, and reports which one', async () => {

--- a/cloudflare-clubworx/test/bookings.test.js
+++ b/cloudflare-clubworx/test/bookings.test.js
@@ -1,0 +1,326 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALREADY_BOOKED,
+  CLASS_CLOSED,
+  NO_FREE_SPACES,
+  classifyRefusal,
+  describeRefusal,
+  bookingIdOf,
+  bookEvent,
+  cancelBooking,
+  cancelRunBookings,
+  readBookings,
+} from '../src/bookings.js';
+
+/** A stub with the shape `createClubworxClient` hands back. */
+const reply = over => ({
+  ok: false,
+  status: 400,
+  url: 'https://app.clubworx.com/api/v2/bookings',
+  ms: 1,
+  body: null,
+  nonJson: false,
+  bodyText: null,
+  message: null,
+  networkError: false,
+  ...over,
+});
+
+const ok = body => reply({ ok: true, status: 200, body });
+const refused = message => reply({ status: 400, body: { error: message }, message });
+
+const clientReturning = (...responses) => {
+  const calls = [];
+  const next = () => responses[Math.min(calls.length - 1, responses.length - 1)];
+  return {
+    calls,
+    get: async (path, params) => {
+      calls.push({ method: 'GET', path, params });
+      return next();
+    },
+    post: async (path, payload) => {
+      calls.push({ method: 'POST', path, payload });
+      return next();
+    },
+    del: async (path, form) => {
+      calls.push({ method: 'DELETE', path, form });
+      return next();
+    },
+  };
+};
+
+describe('classifyRefusal — the message string is the only discriminator', () => {
+  it('recognises the three measured 400s', () => {
+    expect(classifyRefusal(ALREADY_BOOKED)).toBe('already-booked');
+    expect(classifyRefusal(CLASS_CLOSED)).toBe('closed');
+    expect(classifyRefusal(NO_FREE_SPACES)).toBe('no-spaces');
+  });
+
+  it('survives a curly apostrophe, which is one HTML entity away from arriving', () => {
+    expect(classifyRefusal('Woops! You’ve already booked into this class!')).toBe(
+      'already-booked',
+    );
+  });
+
+  it('survives case and whitespace drift without widening to a different message', () => {
+    expect(classifyRefusal('  sorry, this class has NO FREE SPACES available.  ')).toBe('no-spaces');
+  });
+
+  it('calls anything it does not recognise unknown, rather than the nearest match', () => {
+    // D6: paraphrasing an unrecognised message is what makes new Clubworx
+    // behaviour invisible. #50 is the cautionary tale.
+    expect(classifyRefusal('Sorry, this class is full.')).toBe('unknown');
+    expect(classifyRefusal('Contact has no active membership.')).toBe('unknown');
+    expect(classifyRefusal('')).toBe('unknown');
+    expect(classifyRefusal(null)).toBe('unknown');
+  });
+});
+
+describe('describeRefusal', () => {
+  it('never says "class full" for the spaces refusal — it is not a capacity message', () => {
+    const shown = describeRefusal('no-spaces', { message: NO_FREE_SPACES, spacesAvailable: 25 });
+    expect(shown.toLowerCase()).not.toContain('full');
+    expect(shown).toContain('check the session');
+  });
+
+  it('puts spaces_available beside the spaces refusal, since it has been misleading', () => {
+    expect(describeRefusal('no-spaces', { message: NO_FREE_SPACES, spacesAvailable: 25 })).toContain(
+      '25',
+    );
+  });
+
+  it('repeats an unknown message verbatim and attributes it to Clubworx', () => {
+    const raw = 'Something nobody here has seen before.';
+    const shown = describeRefusal('unknown', { message: raw });
+    expect(shown).toContain(raw);
+    expect(shown).toContain('Clubworx');
+  });
+
+  it('does not invent a message when Clubworx sent none', () => {
+    expect(describeRefusal('unknown', { message: null })).toContain('no message');
+  });
+});
+
+describe('bookingIdOf', () => {
+  it('finds the id wherever this API chose to put it', () => {
+    expect(bookingIdOf({ booking_id: 63510241 })).toBe('63510241');
+    expect(bookingIdOf({ id: 7 })).toBe('7');
+    expect(bookingIdOf({ booking: { booking_id: 8 } })).toBe('8');
+    expect(bookingIdOf([{ id: 9 }])).toBe('9');
+  });
+
+  it('answers null rather than a guess when there is no id', () => {
+    expect(bookingIdOf({ success: true })).toBeNull();
+    expect(bookingIdOf(null)).toBeNull();
+  });
+});
+
+describe('bookEvent', () => {
+  it('sends JSON to /bookings — the measured shape, not the form the spec text claims', async () => {
+    const client = clientReturning(ok({ booking_id: 63510241 }));
+    await bookEvent({ client, contactKey: 'ck-1', eventId: 42 });
+
+    expect(client.calls[0]).toMatchObject({
+      method: 'POST',
+      path: 'bookings',
+      payload: { contact_key: 'ck-1', event_id: 42 },
+    });
+  });
+
+  it('reads a 200 as booked and keeps the id, because cancelling needs it', async () => {
+    const client = clientReturning(ok({ booking_id: 63510241 }));
+    expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
+      state: 'booked',
+      bookingId: '63510241',
+    });
+  });
+
+  it('treats "already booked" as a success, never as an error', async () => {
+    // It IS the idempotency guarantee — the thing that makes D5's re-run safe.
+    const client = clientReturning(refused(ALREADY_BOOKED));
+    expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
+      state: 'already booked',
+      refusal: 'already-booked',
+      bookingId: null,
+    });
+  });
+
+  it('carries no booking id on an already-booked row, which is the cancel interlock', async () => {
+    const client = clientReturning(refused(ALREADY_BOOKED));
+    const row = await bookEvent({ client, contactKey: 'ck-1', eventId: 42 });
+    expect(row.bookingId).toBeNull();
+  });
+
+  it('reports the closed-for-bookings refusal as permanent for that event', async () => {
+    const client = clientReturning(refused(CLASS_CLOSED));
+    expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
+      state: 'refused',
+      refusal: 'closed',
+      retryable: false,
+    });
+  });
+
+  it('never retries a 400, including one it does not recognise', async () => {
+    const client = clientReturning(refused('A brand new complaint.'));
+    expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
+      state: 'refused',
+      refusal: 'unknown',
+      retryable: false,
+      message: 'A brand new complaint.',
+    });
+  });
+
+  it('marks a 429 as throttled, and as the one thing that pauses the whole run', async () => {
+    const client = clientReturning(reply({ status: 429, bodyText: '<html>too many</html>' }));
+    expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
+      state: 'failed',
+      reason: 'throttled',
+      retryable: true,
+    });
+  });
+
+  it('marks a 5xx and a network error as retryable failures', async () => {
+    const server = clientReturning(reply({ status: 503 }));
+    expect(await bookEvent({ client: server, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
+      state: 'failed',
+      retryable: true,
+    });
+
+    const dead = clientReturning(reply({ status: 0, networkError: true, message: 'ECONNRESET' }));
+    expect(await bookEvent({ client: dead, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
+      state: 'failed',
+      retryable: true,
+    });
+  });
+
+  it('refuses a 200 whose body is not a booking, rather than reporting a booking', async () => {
+    // A 200 with no id anywhere is a shape nobody here has seen. Calling it
+    // booked would put a row in the result table that cannot be cancelled.
+    const client = clientReturning(ok({ success: true }));
+    expect(await bookEvent({ client, contactKey: 'ck-1', eventId: 42 })).toMatchObject({
+      state: 'booked',
+      bookingId: null,
+      unverifiable: true,
+    });
+  });
+});
+
+describe('cancelBooking', () => {
+  it('form-encodes contact_key, the parameter that made #50 wrong', async () => {
+    const client = clientReturning(ok({ success: true }));
+    await cancelBooking({ client, bookingId: '63510241', contactKey: 'ck-1' });
+
+    expect(client.calls[0]).toMatchObject({
+      method: 'DELETE',
+      path: 'bookings/63510241',
+      form: { contact_key: 'ck-1' },
+    });
+  });
+
+  it('refuses to send a cancel with no contact key rather than discovering the 401 again', async () => {
+    const client = clientReturning(ok({ success: true }));
+    const res = await cancelBooking({ client, bookingId: '1', contactKey: null });
+
+    expect(res.ok).toBe(false);
+    expect(client.calls).toHaveLength(0);
+  });
+});
+
+describe('cancelRunBookings — the safety interlock', () => {
+  const bookedRow = (eventId, bookingId) => ({
+    event_id: eventId,
+    state: 'booked',
+    booking_id: bookingId,
+  });
+
+  it('cancels the rows this run booked', async () => {
+    const client = clientReturning(ok({ success: true }));
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [bookedRow(1, 'b1'), bookedRow(2, 'b2')],
+    });
+
+    expect(out.cancelled).toBe(2);
+    expect(client.calls.map(c => c.path)).toEqual(['bookings/b1', 'bookings/b2']);
+  });
+
+  it('NEVER cancels a row marked already booked', async () => {
+    // The worst outcome available on this map: deleting a booking this run did
+    // not create, possibly a session a real member booked themselves (#50).
+    const client = clientReturning(ok({ success: true }));
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [
+        { event_id: 1, state: 'already booked', booking_id: 'b-somebody-elses' },
+        bookedRow(2, 'b2'),
+      ],
+    });
+
+    expect(client.calls.map(c => c.path)).toEqual(['bookings/b2']);
+    expect(out.skipped).toBe(1);
+  });
+
+  it('holds the interlock even when the caller hands it an id on the already-booked row', async () => {
+    const client = clientReturning(ok({ success: true }));
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [{ event_id: 1, state: 'already booked', booking_id: 'b1' }],
+    });
+
+    expect(client.calls).toHaveLength(0);
+    expect(out.cancelled).toBe(0);
+  });
+
+  it('skips a booked row that has no id, and says so rather than silently dropping it', async () => {
+    const client = clientReturning(ok({ success: true }));
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [{ event_id: 1, state: 'booked', booking_id: null }],
+    });
+
+    expect(client.calls).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0].reason).toContain('no booking id');
+  });
+
+  it('keeps going when one cancel fails, and reports which one', async () => {
+    let n = 0;
+    const client = {
+      calls: [],
+      del: async path => {
+        client.calls.push({ path });
+        n += 1;
+        return n === 1 ? reply({ status: 500 }) : ok({ success: true });
+      },
+    };
+
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [bookedRow(1, 'b1'), bookedRow(2, 'b2')],
+    });
+
+    expect(out.cancelled).toBe(1);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0].booking_id).toBe('b1');
+  });
+});
+
+describe('readBookings', () => {
+  it('reads a contact own bookings, which is how a write is verified', async () => {
+    const client = clientReturning(ok([{ booking_id: 1, event_id: 42 }]));
+    const out = await readBookings({ client, contactKey: 'ck-1' });
+
+    expect(client.calls[0]).toMatchObject({ path: 'bookings', params: { contact_key: 'ck-1' } });
+    expect(out).toMatchObject({ ok: true, eventIds: ['42'] });
+  });
+
+  it('refuses a body that is not a list rather than reading it as no bookings', async () => {
+    const client = clientReturning(ok({ error: 'nope' }));
+    expect((await readBookings({ client, contactKey: 'ck-1' })).ok).toBe(false);
+  });
+});

--- a/cloudflare-clubworx/test/clubworx.test.js
+++ b/cloudflare-clubworx/test/clubworx.test.js
@@ -122,8 +122,72 @@ describe('DELETE — measured as form-encoded, and it needs contact_key', () => 
     const sent = fetchImpl.sent[0];
     expect(sent.method).toBe('DELETE');
     expect(sent.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
-    expect(sent.body).toBe('contact_key=ck-1');
+    expect(sent.body).toBe(`account_key=${KEY}&contact_key=ck-1`);
     expect(sent.url).toContain(`account_key=${KEY}`);
+  });
+
+  it('puts account_key in the body too, which is the shape that was measured', async () => {
+    // The working #60 call sent it in both places. The query alone has never
+    // been tried, and the way this fails is a 401 that reads like a permissions
+    // problem — the exact misdiagnosis that cost #50 a week.
+    const fetchImpl = recorder(() => json({ success: true }));
+    const client = clientWith(fetchImpl);
+
+    await client.del('bookings/bk-1', { contact_key: 'ck-1' });
+
+    expect(fetchImpl.sent[0].body).toContain(`account_key=${KEY}`);
+  });
+
+  it('takes the account key from the client, so no caller ever holds it', async () => {
+    const fetchImpl = recorder(() => json({ success: true }));
+    const client = clientWith(fetchImpl);
+
+    // No account_key passed in — the client supplies its own.
+    await client.postForm('memberships', { contact_key: 'ck-1', membership_plan_id: '64189' });
+
+    expect(fetchImpl.sent[0].body).toContain(`account_key=${KEY}`);
+  });
+});
+
+describe('POST with a form body — the measured shape for /memberships', () => {
+  it('form-encodes, because the encoding is per-endpoint and this one is not JSON', async () => {
+    // `/members` and `/bookings` take JSON; `/memberships` takes a form (#60).
+    // Sending one endpoint's shape to the other is how this API answers with a
+    // status that describes something else entirely.
+    const fetchImpl = recorder(() => json({ id: 2627746 }));
+    const client = clientWith(fetchImpl);
+
+    await client.postForm('memberships', {
+      contact_key: 'ck-1',
+      membership_plan_id: '64189',
+      start_date: '2026-08-20',
+    });
+
+    const sent = fetchImpl.sent[0];
+    expect(sent.method).toBe('POST');
+    expect(sent.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    expect(sent.body).toContain('contact_key=ck-1');
+    expect(sent.body).toContain('membership_plan_id=64189');
+    expect(sent.body).toContain('start_date=2026-08-20');
+  });
+
+  it('never puts the query string on the endpoint it hands back', async () => {
+    const fetchImpl = recorder(() => json({}));
+    const client = clientWith(fetchImpl);
+
+    const res = await client.postForm('memberships', { contact_key: 'ck-1' });
+
+    expect(res.url).not.toContain('?');
+    expect(res.url).not.toContain(KEY);
+  });
+
+  it('goes through the pacer like everything else', async () => {
+    const pacer = instantPacer();
+    const client = clientWith(recorder(() => json({})), { pacer });
+
+    await client.postForm('memberships', { contact_key: 'ck-1' });
+
+    expect(pacer.calls).toBe(1);
   });
 });
 

--- a/cloudflare-clubworx/test/duration.test.js
+++ b/cloudflare-clubworx/test/duration.test.js
@@ -1,5 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { parsePlanDuration, passCoverageEnd, addDays, isRealDay } from '../src/duration.js';
+import { parsePlanDuration, passCoverageEnd, addDays, isRealDay, perthDay } from '../src/duration.js';
+
+describe('perthDay', () => {
+  it('is the gym day, not the UTC day', () => {
+    // 23:00 UTC on the 20th is 07:00 on the 21st in Perth. A Worker isolate runs
+    // on UTC; the pass starts on the gym's day.
+    expect(perthDay('2026-08-20T23:00:00Z')).toBe('2026-08-21');
+    expect(perthDay('2026-08-20T15:59:00Z')).toBe('2026-08-20');
+    expect(perthDay('2026-08-20T16:00:00Z')).toBe('2026-08-21');
+  });
+
+  it('agrees with an instant already expressed in AWST', () => {
+    expect(perthDay('2026-08-21T07:00:00+08:00')).toBe('2026-08-21');
+  });
+
+  it('answers null for an instant it cannot read', () => {
+    expect(perthDay('not a time')).toBeNull();
+  });
+});
 
 describe('parsePlanDuration', () => {
   it('parses the plan UJ actually runs', () => {

--- a/cloudflare-clubworx/test/duration.test.js
+++ b/cloudflare-clubworx/test/duration.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { parsePlanDuration, passCoverageEnd, addDays, isRealDay } from '../src/duration.js';
+
+describe('parsePlanDuration', () => {
+  it('parses the plan UJ actually runs', () => {
+    expect(parsePlanDuration('26 weeks')).toMatchObject({ ok: true, count: 26, unit: 'week' });
+  });
+
+  it('parses the duration the pass ran before ADR 0005', () => {
+    expect(parsePlanDuration('12 weeks')).toMatchObject({ ok: true, count: 12, unit: 'week' });
+  });
+
+  it('parses a singular unit', () => {
+    expect(parsePlanDuration('1 week')).toMatchObject({ ok: true, count: 1, unit: 'week' });
+    expect(parsePlanDuration('1 month')).toMatchObject({ ok: true, count: 1, unit: 'month' });
+  });
+
+  it('parses days, months and years', () => {
+    expect(parsePlanDuration('84 days')).toMatchObject({ ok: true, count: 84, unit: 'day' });
+    expect(parsePlanDuration('3 months')).toMatchObject({ ok: true, count: 3, unit: 'month' });
+    expect(parsePlanDuration('1 year')).toMatchObject({ ok: true, count: 1, unit: 'year' });
+  });
+
+  it('tolerates case and surrounding whitespace, because it is a human string', () => {
+    expect(parsePlanDuration('  26 Weeks ')).toMatchObject({ ok: true, count: 26, unit: 'week' });
+  });
+
+  it('refuses rather than guessing at anything it does not recognise', () => {
+    for (const raw of ['a term', '', null, undefined, 'weeks', '26', 'twenty-six weeks', {}]) {
+      expect(parsePlanDuration(raw).ok).toBe(false);
+    }
+  });
+
+  it('keeps the raw value on a refusal, because the warning has to name it', () => {
+    expect(parsePlanDuration('a term')).toMatchObject({ ok: false, raw: 'a term' });
+  });
+
+  it('refuses a zero or negative count — a pass covering nothing is a misconfiguration', () => {
+    expect(parsePlanDuration('0 weeks').ok).toBe(false);
+    expect(parsePlanDuration('-4 weeks').ok).toBe(false);
+  });
+});
+
+describe('passCoverageEnd', () => {
+  // Measured, #60/#63: a 12-week pass starting 2026-08-20 expires 2026-11-11 —
+  // 84 days of access, inclusive at both ends, so 83 days of difference.
+  it('reproduces the measured 12-week expiry exactly', () => {
+    expect(passCoverageEnd('2026-08-20', parsePlanDuration('12 weeks'))).toBe('2026-11-11');
+  });
+
+  it('gives the 26-week plan 182 days of access, inclusive', () => {
+    expect(passCoverageEnd('2026-08-20', parsePlanDuration('26 weeks'))).toBe('2027-02-17');
+  });
+
+  it('counts a one-day pass as covering its own start day', () => {
+    expect(passCoverageEnd('2026-08-20', parsePlanDuration('1 day'))).toBe('2026-08-20');
+  });
+
+  it('does calendar arithmetic for months and years, not 30-day approximations', () => {
+    expect(passCoverageEnd('2026-01-31', parsePlanDuration('1 month'))).toBe('2026-02-27');
+    expect(passCoverageEnd('2026-08-20', parsePlanDuration('1 year'))).toBe('2027-08-19');
+  });
+
+  it('answers null for a duration that did not parse, rather than a plausible date', () => {
+    expect(passCoverageEnd('2026-08-20', parsePlanDuration('a term'))).toBeNull();
+    expect(passCoverageEnd('not-a-day', parsePlanDuration('26 weeks'))).toBeNull();
+  });
+});
+
+describe('addDays', () => {
+  it('crosses a month boundary', () => {
+    expect(addDays('2026-08-30', 3)).toBe('2026-09-02');
+  });
+
+  it('crosses a year boundary', () => {
+    expect(addDays('2026-12-30', 3)).toBe('2027-01-02');
+  });
+
+  it('handles a leap day', () => {
+    expect(addDays('2028-02-28', 1)).toBe('2028-02-29');
+  });
+});
+
+describe('isRealDay', () => {
+  it('accepts an ISO day', () => {
+    expect(isRealDay('2026-08-20')).toBe(true);
+  });
+
+  it('rejects a day that rolls forward rather than throwing', () => {
+    // new Date('2009-02-30') silently becomes 2 March.
+    expect(isRealDay('2009-02-30')).toBe(false);
+  });
+
+  it('rejects anything that is not YYYY-MM-DD', () => {
+    for (const value of ['20/08/2026', '2026-8-20', '2026-08-20T00:00:00Z', '', null, 20260820]) {
+      expect(isRealDay(value)).toBe(false);
+    }
+  });
+});

--- a/cloudflare-clubworx/test/memberships.test.js
+++ b/cloudflare-clubworx/test/memberships.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { summariseMemberships, assessPass } from '../src/memberships.js';
+
+// The real shape, from #60's live read. Note what is NOT here: a `status` field.
+const SCHOOL_PASS = 64189;
+const heldPass = (start, expires) => ({
+  id: 2627746,
+  membership_plan_id: SCHOOL_PASS,
+  name: 'School Pass',
+  start_date: start,
+  expiration_date: expires,
+  class_access: 'Unlimited classes',
+  classes_booked: 0,
+  classes_remaining: null,
+});
+
+describe('summariseMemberships', () => {
+  it('derives active from the two dates, because there is no status field', () => {
+    const rows = [heldPass('2026-08-18', '2026-11-09')];
+    expect(summariseMemberships(rows, SCHOOL_PASS, { on: '2026-09-01' })).toMatchObject({
+      holdsPlan: true,
+      holdsActivePlan: true,
+    });
+  });
+
+  it('is inclusive at both ends — a pass is usable on its first and last day', () => {
+    const rows = [heldPass('2026-08-18', '2026-11-09')];
+    expect(summariseMemberships(rows, SCHOOL_PASS, { on: '2026-08-18' }).holdsActivePlan).toBe(true);
+    expect(summariseMemberships(rows, SCHOOL_PASS, { on: '2026-11-09' }).holdsActivePlan).toBe(true);
+    expect(summariseMemberships(rows, SCHOOL_PASS, { on: '2026-11-10' }).holdsActivePlan).toBe(false);
+    expect(summariseMemberships(rows, SCHOOL_PASS, { on: '2026-08-17' }).holdsActivePlan).toBe(false);
+  });
+
+  it('counts an expired pass as held — an expired row still comes back', () => {
+    const rows = [heldPass('2026-01-01', '2026-03-25')];
+    expect(summariseMemberships(rows, SCHOOL_PASS, { on: '2026-08-20' })).toMatchObject({
+      holdsPlan: true,
+      holdsActivePlan: false,
+    });
+  });
+
+  it('ignores a status field if one ever appears, rather than trusting it', () => {
+    const v = summariseMemberships(
+      [{ membership_plan_id: SCHOOL_PASS, status: 'active' }],
+      SCHOOL_PASS,
+      { on: '2026-08-20' },
+    );
+    // No dates at all reads as unbounded, which is the only safe reading of a
+    // row with neither end — but it is derived, not read off `status`.
+    expect(v.planStates[0]).not.toHaveProperty('status');
+  });
+
+  it('compares the plan id as a string, since Clubworx has sent both', () => {
+    expect(summariseMemberships([{ membership_plan_id: '64189' }], 64189).holdsPlan).toBe(true);
+  });
+
+  it('refuses a body that is not a list rather than reading it as no memberships', () => {
+    expect(summariseMemberships(null, SCHOOL_PASS).notAnArray).toBe(true);
+    expect(summariseMemberships({ error: 'nope' }, SCHOOL_PASS).notAnArray).toBe(true);
+  });
+
+  it('reports field names without their values — how the missing status was found', () => {
+    const v = summariseMemberships(
+      [{ membership_plan_id: SCHOOL_PASS, member_name: 'A Real Person' }],
+      SCHOOL_PASS,
+    );
+    expect(v.fields).toContain('member_name');
+    expect(JSON.stringify(v)).not.toContain('A Real Person');
+  });
+
+  it('does not confuse a different plan for the one being looked for', () => {
+    const v = summariseMemberships([{ membership_plan_id: 1 }], SCHOOL_PASS);
+    expect(v.holdsPlan).toBe(false);
+    expect(v.count).toBe(1);
+  });
+});
+
+describe('assessPass', () => {
+  const on = '2026-08-20';
+
+  it('says grant when the student holds no pass on this plan', () => {
+    expect(assessPass({ states: [], lastSession: '2026-10-01', on })).toMatchObject({
+      state: 'none',
+      grant: true,
+    });
+  });
+
+  it('says skip when the held pass reaches the last selected session', () => {
+    const states = summariseMemberships([heldPass('2026-08-01', '2027-01-28')], SCHOOL_PASS, { on })
+      .planStates;
+    expect(assessPass({ states, lastSession: '2026-10-01', on })).toMatchObject({
+      state: 'covering',
+      grant: false,
+    });
+  });
+
+  it('covers a session that lands exactly on the expiration date', () => {
+    const states = summariseMemberships([heldPass('2026-08-01', '2026-10-01')], SCHOOL_PASS, { on })
+      .planStates;
+    expect(assessPass({ states, lastSession: '2026-10-01', on }).state).toBe('covering');
+  });
+
+  it('says grant when the held pass has already expired', () => {
+    const states = summariseMemberships([heldPass('2026-01-01', '2026-03-25')], SCHOOL_PASS, { on })
+      .planStates;
+    expect(assessPass({ states, lastSession: '2026-10-01', on })).toMatchObject({
+      state: 'expired',
+      grant: true,
+    });
+  });
+
+  // The row ADR 0005 created. Under a 12-week pass this was rare; at 26 weeks a
+  // returning student regularly holds one that is live and expires mid-term.
+  it('refuses rather than granting a second pass to a live holder', () => {
+    const states = summariseMemberships([heldPass('2026-08-01', '2026-09-15')], SCHOOL_PASS, { on })
+      .planStates;
+    const verdict = assessPass({ states, lastSession: '2026-10-01', on });
+    expect(verdict).toMatchObject({ state: 'needs-confirmation', grant: false });
+    // The operator has to be able to see the two dates that disagree.
+    expect(verdict.expirationDate).toBe('2026-09-15');
+    expect(verdict.lastSession).toBe('2026-10-01');
+  });
+
+  it('names the shortfall in a sentence an operator can act on', () => {
+    const states = summariseMemberships([heldPass('2026-08-01', '2026-09-15')], SCHOOL_PASS, { on })
+      .planStates;
+    const { detail } = assessPass({ states, lastSession: '2026-10-01', on });
+    expect(detail).toContain('2026-09-15');
+    expect(detail).toContain('2026-10-01');
+  });
+
+  it('refuses a pass that has not started yet rather than granting alongside it', () => {
+    const states = summariseMemberships([heldPass('2026-09-01', '2027-03-01')], SCHOOL_PASS, { on })
+      .planStates;
+    expect(assessPass({ states, lastSession: '2026-10-01', on })).toMatchObject({
+      state: 'needs-confirmation',
+      grant: false,
+    });
+  });
+
+  it('treats a pass with no expiration as covering, not as expired', () => {
+    const states = summariseMemberships([heldPass('2026-08-01', null)], SCHOOL_PASS, { on })
+      .planStates;
+    expect(assessPass({ states, lastSession: '2027-10-01', on }).state).toBe('covering');
+  });
+
+  it('picks the best of several held passes rather than the first', () => {
+    const states = summariseMemberships(
+      [heldPass('2026-01-01', '2026-03-25'), heldPass('2026-08-01', '2027-01-28')],
+      SCHOOL_PASS,
+      { on },
+    ).planStates;
+    expect(assessPass({ states, lastSession: '2026-10-01', on }).state).toBe('covering');
+  });
+
+  it('refuses when the last session is not a real day — it decides a permanent write', () => {
+    expect(assessPass({ states: [], lastSession: 'soon', on }).state).toBe('unknown');
+    expect(assessPass({ states: [], lastSession: '2026-10-01', on: 'today' }).state).toBe('unknown');
+  });
+});

--- a/cloudflare-clubworx/test/student.test.js
+++ b/cloudflare-clubworx/test/student.test.js
@@ -1,0 +1,609 @@
+import { describe, it, expect } from 'vitest';
+import { runStudentChain } from '../src/student.js';
+import { ALREADY_BOOKED, CLASS_CLOSED, NO_FREE_SPACES } from '../src/bookings.js';
+
+const PLAN = 64189;
+const NOW = '2026-08-20T02:00:00Z'; // 10:00 in Perth, on the 20th.
+const TODAY = '2026-08-20';
+
+const STUDENT = {
+  first_name: 'Ada',
+  last_name: 'Wayfinder',
+  dob: '2012-03-04',
+  email: 'noreply+stbedes@urbanjungleirc.com',
+};
+
+/** Two sessions, both comfortably outside the 24-hour lead time. */
+const EVENTS = [
+  { event_id: 101, starts_at: '2026-09-03T02:00:00Z' },
+  { event_id: 102, starts_at: '2026-09-10T02:00:00Z' },
+];
+
+const res = over => ({
+  ok: false,
+  status: 400,
+  url: 'https://app.clubworx.com/api/v2/x',
+  ms: 1,
+  body: null,
+  nonJson: false,
+  bodyText: null,
+  message: null,
+  networkError: false,
+  ...over,
+});
+const ok = body => res({ ok: true, status: 200, body });
+const refused = message => res({ status: 400, body: { error: message }, message });
+
+const pass = (start, expires) => ({
+  membership_plan_id: PLAN,
+  start_date: start,
+  expiration_date: expires,
+});
+
+/** A contact row as the three status views return it. */
+const contactRow = () => ({ ...STUDENT, contact_key: 'ck-new', status: 'Active' });
+
+/**
+ * A client whose responses are chosen by a dispatcher over `${method} ${path}`.
+ * `nth` is 1-based per route, so a re-read can differ from the read before it.
+ */
+function makeClient(routes) {
+  const calls = [];
+  const counts = new Map();
+
+  const handle = async call => {
+    calls.push(call);
+    const key = `${call.method} ${call.path.replace(/\/[^/]+$/, m => (call.path.startsWith('bookings/') ? '/:id' : m))}`;
+    const route =
+      routes[key] ??
+      routes[`${call.method} ${call.path}`] ??
+      routes[call.method === 'DELETE' ? 'DELETE bookings/:id' : ''];
+    if (!route) throw new Error(`no scripted response for ${call.method} ${call.path}`);
+    const nth = (counts.get(key) ?? 0) + 1;
+    counts.set(key, nth);
+    return typeof route === 'function' ? route(nth, call) : route;
+  };
+
+  return {
+    calls,
+    get: (path, params) => handle({ method: 'GET', path, params }),
+    post: (path, payload) => handle({ method: 'POST', path, payload }),
+    postForm: (path, form) => handle({ method: 'POSTFORM', path, form }),
+    del: (path, form) => handle({ method: 'DELETE', path, form }),
+  };
+}
+
+const run = (client, over = {}) =>
+  runStudentChain({
+    client,
+    student: STUDENT,
+    contactKey: null,
+    membershipPlanId: PLAN,
+    membershipDuration: '26 weeks',
+    events: EVENTS,
+    now: NOW,
+    sleep: async () => {},
+    ...over,
+  });
+
+// ---------------------------------------------------------------------------
+// Gates that must fire before anything permanent is written
+// ---------------------------------------------------------------------------
+
+describe('refusals before any permanent write', () => {
+  it('stops on an event inside the 24-hour lead time, and touches nothing', async () => {
+    const client = makeClient({});
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: '2026-08-20T12:00:00Z' }],
+    });
+
+    expect(out).toMatchObject({ ok: false, outcome: 'refused', reason: 'lead-time', written: false });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('stops when the last session falls outside the plan duration', async () => {
+    // A 26-week pass granted 2026-08-20 covers to 2027-02-17. A session in March
+    // is past that, and every booking would still be written on a day the pass
+    // is active — the exact shape of the bug ADR 0005 fixed.
+    const client = makeClient({});
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: '2027-03-01T02:00:00Z' }],
+    });
+
+    expect(out).toMatchObject({ ok: false, outcome: 'refused', reason: 'pass-coverage' });
+    expect(out.message).toContain('2027-02-17');
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('allows a last session landing exactly on the coverage end', async () => {
+    const client = makeClient({
+      'POST members': ok({ contact_key: 'ck-new' }),
+      'GET members': ok([contactRow()]),
+      'POST bookings': ok({ booking_id: 'b1' }),
+      'GET bookings': ok([{ booking_id: 'b1', event_id: 101 }]),
+    });
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: '2027-02-17T02:00:00Z' }],
+    });
+
+    expect(out.outcome).toBe('complete');
+  });
+
+  it('warns rather than stopping when membership_duration will not parse — and names it', async () => {
+    const client = makeClient({
+      'POST members': ok({ contact_key: 'ck-new' }),
+      'GET members': ok([contactRow()]),
+      'POST bookings': ok({ booking_id: 'b1' }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+    const out = await run(client, { membershipDuration: 'a term' });
+
+    expect(out.outcome).toBe('complete');
+    expect(out.warnings.join(' ')).toContain('a term');
+    // Never skipped silently — §11.
+    expect(out.warnings.join(' ').toLowerCase()).toContain('coverage');
+  });
+
+  it('stops on no events at all', async () => {
+    const client = makeClient({});
+    const out = await run(client, { events: [] });
+    expect(out).toMatchObject({ outcome: 'refused', reason: 'bad-request' });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('stops on an event whose start it cannot read, rather than assuming it is far off', async () => {
+    const client = makeClient({});
+    const out = await run(client, { events: [{ event_id: 101, starts_at: 'sometime' }] });
+    expect(out.outcome).toBe('refused');
+    expect(client.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The new-student branch: one call creates the contact and the pass
+// ---------------------------------------------------------------------------
+
+describe('a new student', () => {
+  const happy = () =>
+    makeClient({
+      'POST members': ok({ contact_key: 'ck-new' }),
+      'GET members': ok([contactRow()]),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+
+  it('creates the contact and the pass in one JSON call', async () => {
+    const client = happy();
+    await run(client);
+
+    const create = client.calls.find(c => c.method === 'POST' && c.path === 'members');
+    expect(create.payload).toMatchObject({ ...STUDENT, membership_plan_id: PLAN });
+  });
+
+  it('never reads memberships for a contact it just created — D4', async () => {
+    const client = happy();
+    await run(client);
+    expect(client.calls.some(c => c.path === 'memberships')).toBe(false);
+  });
+
+  it('takes the contact key from the re-read, not from the create response', async () => {
+    const client = makeClient({
+      // A create response with no key at all, which #49 had to tolerate.
+      'POST members': ok({ success: true }),
+      'GET members': ok([{ ...contactRow(), contact_key: 'ck-from-read' }]),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+    const out = await run(client);
+
+    expect(out.contact).toMatchObject({ contact_key: 'ck-from-read', state: 'created' });
+  });
+
+  it('books every event and reports the run complete', async () => {
+    const out = await run(happy());
+    expect(out).toMatchObject({ ok: true, outcome: 'complete', stranded: false });
+    expect(out.bookings.map(b => b.state)).toEqual(['booked', 'booked']);
+    expect(out.pass.state).toBe('created-with-contact');
+  });
+
+  it('reports the create as unverified when the re-read cannot find the contact', async () => {
+    // A 200 that did not land is indistinguishable from one that did by the
+    // status alone. The re-read is the verdict.
+    const client = makeClient({
+      'POST members': ok({ contact_key: 'ck-new' }),
+      'GET members': ok([]),
+    });
+    const out = await run(client);
+
+    expect(out).toMatchObject({ ok: false, outcome: 'failed', reason: 'contact-unverified' });
+    expect(client.calls.some(c => c.path === 'bookings')).toBe(false);
+  });
+
+  it('continues when the create errored but the re-read proves it landed', async () => {
+    // The dangerous retry: a connection failure on a write that cannot be
+    // deleted. Re-reading before retrying is what stops a second permanent
+    // contact.
+    const client = makeClient({
+      'POST members': res({ status: 0, networkError: true, message: 'ECONNRESET' }),
+      'GET members': ok([contactRow()]),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+    const out = await run(client);
+
+    expect(out.outcome).toBe('complete');
+    expect(client.calls.filter(c => c.method === 'POST' && c.path === 'members')).toHaveLength(1);
+  });
+
+  it('retries a create only after a re-read shows it did not land', async () => {
+    const client = makeClient({
+      'POST members': nth => (nth === 1 ? res({ status: 503 }) : ok({ contact_key: 'ck-new' })),
+      'GET members': nth => (nth === 1 ? ok([]) : ok([contactRow()])),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+    const out = await run(client);
+
+    expect(out.outcome).toBe('complete');
+    expect(client.calls.filter(c => c.method === 'POST' && c.path === 'members')).toHaveLength(2);
+  });
+
+  it('refuses when two contacts match what it just created', async () => {
+    // Either the dedup read missed one, or this run has just made a duplicate.
+    // Both need a human, and neither may be booked past.
+    const client = makeClient({
+      'POST members': ok({ contact_key: 'ck-new' }),
+      'GET members': ok([contactRow(), { ...contactRow(), contact_key: 'ck-other' }]),
+    });
+    const out = await run(client);
+
+    expect(out).toMatchObject({ ok: false, reason: 'contact-ambiguous' });
+    expect(client.calls.some(c => c.path === 'bookings')).toBe(false);
+  });
+
+  it('never retries a 400 on the create', async () => {
+    const client = makeClient({
+      'POST members': refused('email is invalid'),
+      'GET members': ok([]),
+    });
+    await run(client);
+
+    expect(client.calls.filter(c => c.method === 'POST' && c.path === 'members')).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The matched-student branch: D14's re-read, then D4's verdict
+// ---------------------------------------------------------------------------
+
+describe('a matched student', () => {
+  const matched = { contactKey: 'ck-known' };
+
+  it('re-reads the membership immediately before the write it guards — D14', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+    await run(client, matched);
+
+    expect(client.calls[0]).toMatchObject({
+      method: 'GET',
+      path: 'memberships',
+      params: { contact_key: 'ck-known' },
+    });
+  });
+
+  it('skips the grant when the held pass reaches the last session', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+    const out = await run(client, matched);
+
+    expect(out.pass.state).toBe('covering');
+    expect(client.calls.some(c => c.method === 'POSTFORM')).toBe(false);
+    expect(out.outcome).toBe('complete');
+  });
+
+  it('grants a pass when the held one has expired, form-encoded, starting today', async () => {
+    const client = makeClient({
+      'GET memberships': nth =>
+        nth === 1
+          ? ok([pass('2026-01-01', '2026-03-25')])
+          : ok([pass('2026-01-01', '2026-03-25'), pass(TODAY, '2027-02-17')]),
+      'POSTFORM memberships': ok({ id: 2627746 }),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+    const out = await run(client, matched);
+
+    const grant = client.calls.find(c => c.method === 'POSTFORM');
+    expect(grant.form).toMatchObject({
+      contact_key: 'ck-known',
+      membership_plan_id: String(PLAN),
+      start_date: TODAY,
+    });
+    expect(out.pass).toMatchObject({ state: 'granted', expiration_date: '2027-02-17' });
+  });
+
+  it('verifies the granted pass by re-reading it, never by the status code', async () => {
+    // A 200 whose pass does not cover the term is a grant that did not do the
+    // job, and it looks identical to one that did from the response alone.
+    const client = makeClient({
+      'GET memberships': nth =>
+        nth === 1 ? ok([]) : ok([pass(TODAY, '2026-09-05')]),
+      'POSTFORM memberships': ok({ id: 1 }),
+    });
+    const out = await run(client, matched);
+
+    expect(out).toMatchObject({ ok: false, reason: 'pass-unverified' });
+    expect(client.calls.some(c => c.path === 'bookings')).toBe(false);
+  });
+
+  it('REFUSES to grant a second pass to a live holder whose pass is short — #90', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2026-09-05')]),
+    });
+    const out = await run(client, matched);
+
+    expect(out).toMatchObject({
+      ok: false,
+      outcome: 'needs-confirmation',
+      written: false,
+      stranded: false,
+    });
+    expect(out.pass.state).toBe('needs-confirmation');
+    // Nothing permanent, and nothing booked.
+    expect(client.calls).toHaveLength(1);
+  });
+
+  it('names both dates on the needs-confirmation row so a human can decide', async () => {
+    const client = makeClient({ 'GET memberships': ok([pass('2026-08-01', '2026-09-05')]) });
+    const out = await run(client, matched);
+
+    expect(out.pass.detail).toContain('2026-09-05');
+    expect(out.pass.detail).toContain('2026-09-10');
+  });
+
+  it('refuses the whole student when the membership read fails', async () => {
+    const client = makeClient({ 'GET memberships': res({ status: 500 }) });
+    const out = await run(client, matched);
+
+    expect(out).toMatchObject({ ok: false, outcome: 'failed', written: false });
+    expect(client.calls.some(c => c.path === 'bookings')).toBe(false);
+  });
+
+  it('reports a throttle as itself, so the page can pause the whole run', async () => {
+    const client = makeClient({
+      'GET memberships': res({ status: 429, bodyText: '<html>slow down</html>' }),
+    });
+    const out = await run(client, matched);
+
+    expect(out.reason).toBe('throttled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D3 — all-or-nothing per student, with rollback
+// ---------------------------------------------------------------------------
+
+describe('all-or-nothing, with rollback', () => {
+  const matchedCovering = {
+    contactKey: 'ck-known',
+    // Three sessions, so there is something to roll back when the third fails.
+    events: [
+      { event_id: 101, starts_at: '2026-09-03T02:00:00Z' },
+      { event_id: 102, starts_at: '2026-09-10T02:00:00Z' },
+      { event_id: 103, starts_at: '2026-09-17T02:00:00Z' },
+    ],
+  };
+
+  const withBookings = booking =>
+    makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': booking,
+      'GET bookings': ok([]),
+      'DELETE bookings/:id': ok({ success: true }),
+    });
+
+  it('cancels the bookings it already made when a later one is refused', async () => {
+    const client = withBookings(nth =>
+      nth < 3 ? ok({ booking_id: `b${nth}` }) : refused(NO_FREE_SPACES),
+    );
+    const out = await run(client, matchedCovering);
+
+    expect(out.outcome).toBe('abandoned');
+    expect(out.rollback).toMatchObject({ cancelled: 2 });
+    expect(client.calls.filter(c => c.method === 'DELETE').map(c => c.path)).toEqual([
+      'bookings/b1',
+      'bookings/b2',
+    ]);
+  });
+
+  it('names the student as stranded, because an abandoned one always is', async () => {
+    const client = withBookings(nth =>
+      nth < 3 ? ok({ booking_id: `b${nth}` }) : refused(CLASS_CLOSED),
+    );
+    const out = await run(client, matchedCovering);
+
+    expect(out.stranded).toBe(true);
+    expect(out.strandedDetail).toBeTruthy();
+  });
+
+  it('never cancels a row Clubworx said was already booked', async () => {
+    // The interlock, with no human present. That booking belongs to a previous
+    // run or to the member themselves.
+    const client = withBookings(nth => {
+      if (nth === 1) return refused(ALREADY_BOOKED);
+      if (nth === 2) return ok({ booking_id: 'b2' });
+      return refused(NO_FREE_SPACES);
+    });
+    const out = await run(client, matchedCovering);
+
+    expect(client.calls.filter(c => c.method === 'DELETE').map(c => c.path)).toEqual(['bookings/b2']);
+    expect(out.rollback.skipped).toBeGreaterThan(0);
+  });
+
+  it('does not abandon a student whose rows are merely already booked', async () => {
+    // D5's restart-safe re-run: every row already booked is a complete student.
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': refused(ALREADY_BOOKED),
+      'GET bookings': ok([
+        { booking_id: 'x1', event_id: 101 },
+        { booking_id: 'x2', event_id: 102 },
+        { booking_id: 'x3', event_id: 103 },
+      ]),
+    });
+    const out = await run(client, matchedCovering);
+
+    expect(out).toMatchObject({ ok: true, outcome: 'complete', stranded: false });
+    expect(client.calls.some(c => c.method === 'DELETE')).toBe(false);
+  });
+
+  it('rolls back when the verification read shows a booking did not land', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      // Only two of the three are actually there.
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+      'DELETE bookings/:id': ok({ success: true }),
+    });
+    const out = await run(client, matchedCovering);
+
+    expect(out).toMatchObject({ outcome: 'abandoned', reason: 'bookings-unverified' });
+    expect(out.rollback.cancelled).toBe(3);
+  });
+
+  it('does NOT roll back when the verification read itself fails', async () => {
+    // A failed read is not a failed write. Cancelling good bookings because a
+    // verification request timed out would destroy the thing being checked.
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': res({ status: 503 }),
+      'DELETE bookings/:id': ok({ success: true }),
+    });
+    const out = await run(client, matchedCovering);
+
+    expect(out).toMatchObject({ ok: false, outcome: 'unverified', reason: 'bookings-unread' });
+    expect(client.calls.some(c => c.method === 'DELETE')).toBe(false);
+    // The rows still travel, so the human control can act on them.
+    expect(out.bookings.map(b => b.booking_id)).toEqual(['b1', 'b2', 'b3']);
+  });
+
+  it('reports a rollback that itself failed, rather than claiming it worked', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': nth => (nth < 3 ? ok({ booking_id: `b${nth}` }) : refused(CLASS_CLOSED)),
+      'GET bookings': ok([]),
+      'DELETE bookings/:id': res({ status: 500 }),
+    });
+    const out = await run(client, matchedCovering);
+
+    expect(out.rollback.cancelled).toBe(0);
+    expect(out.rollback.failed).toHaveLength(2);
+  });
+
+  it('retries a booking that failed on a 5xx, since Clubworx refuses its own duplicate', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': nth => (nth === 1 ? res({ status: 502 }) : ok({ booking_id: `b${nth}` })),
+      'GET bookings': ok([
+        { booking_id: 'b2', event_id: 101 },
+        { booking_id: 'b3', event_id: 102 },
+      ]),
+    });
+    const out = await run(client, { contactKey: 'ck-known' });
+
+    expect(out.outcome).toBe('complete');
+    expect(client.calls.filter(c => c.method === 'POST' && c.path === 'bookings')).toHaveLength(3);
+  });
+
+  it('gives up after the second attempt rather than hammering a throttled API', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': res({ status: 429 }),
+      'GET bookings': ok([]),
+      'DELETE bookings/:id': ok({ success: true }),
+    });
+    const out = await run(client, { contactKey: 'ck-known' });
+
+    expect(out.reason).toBe('throttled');
+    expect(client.calls.filter(c => c.method === 'POST' && c.path === 'bookings')).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// What the result carries back
+// ---------------------------------------------------------------------------
+
+describe('the result', () => {
+  it('counts the requests it spent, because the allowance is gym-wide', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': nth => ok({ booking_id: `b${nth}` }),
+      'GET bookings': ok([
+        { booking_id: 'b1', event_id: 101 },
+        { booking_id: 'b2', event_id: 102 },
+      ]),
+    });
+    const out = await run(client, { contactKey: 'ck-known' });
+
+    // 1 membership read + 2 bookings + 1 verification read.
+    expect(out.requests).toBe(4);
+  });
+
+  it('carries no student name or date of birth in anything it hands back', async () => {
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2026-09-05')]),
+    });
+    const out = await run(client, { contactKey: 'ck-known' });
+
+    const text = JSON.stringify(out);
+    expect(text).not.toContain(STUDENT.first_name);
+    expect(text).not.toContain(STUDENT.dob);
+  });
+
+  it('repeats an unrecognised Clubworx message verbatim — D6', async () => {
+    const strange = 'The instructor has locked this session.';
+    const client = makeClient({
+      'GET memberships': ok([pass('2026-08-01', '2027-01-28')]),
+      'POST bookings': refused(strange),
+      'GET bookings': ok([]),
+    });
+    const out = await run(client, { contactKey: 'ck-known' });
+
+    expect(JSON.stringify(out)).toContain(strange);
+    expect(out.bookings[0].refusal).toBe('unknown');
+  });
+});

--- a/cloudflare-clubworx/test/student.test.js
+++ b/cloudflare-clubworx/test/student.test.js
@@ -186,6 +186,29 @@ describe('a new student', () => {
     expect(create.payload).toMatchObject({ ...STUDENT, membership_plan_id: PLAN });
   });
 
+  it('sends only the four fields Clubworx asked for, never the caller object', async () => {
+    // The body arrives over HTTP from a page this Worker does not control, and
+    // an extra key would be written onto a contact nobody can delete — silently,
+    // since Clubworx answers 200 either way.
+    const client = happy();
+    await run(client, {
+      student: { ...STUDENT, notes: 'allergic to peanuts', admin_flag: true, id: 'injected' },
+    });
+
+    const create = client.calls.find(c => c.method === 'POST' && c.path === 'members');
+    expect(Object.keys(create.payload).sort()).toEqual(
+      ['dob', 'email', 'first_name', 'last_name', 'membership_plan_id'].sort(),
+    );
+  });
+
+  it('takes membership_plan_id from the resolved plan, not from the student object', async () => {
+    const client = happy();
+    await run(client, { student: { ...STUDENT, membership_plan_id: 999 }, membershipPlanId: PLAN });
+
+    const create = client.calls.find(c => c.method === 'POST' && c.path === 'members');
+    expect(create.payload.membership_plan_id).toBe(PLAN);
+  });
+
   it('never reads memberships for a contact it just created — D4', async () => {
     const client = happy();
     await run(client);

--- a/cloudflare-clubworx/test/upstream.test.js
+++ b/cloudflare-clubworx/test/upstream.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { isRetryable, upstreamReason, upstreamMessage } from '../src/upstream.js';
+
+describe('isRetryable — D8', () => {
+  it('retries a throttle, a 5xx and a connection failure', () => {
+    expect(isRetryable({ status: 429 })).toBe(true);
+    expect(isRetryable({ status: 500 })).toBe(true);
+    expect(isRetryable({ status: 503 })).toBe(true);
+    expect(isRetryable({ status: 0, networkError: true })).toBe(true);
+  });
+
+  it('NEVER retries a 400 — all three known ones are permanent for that attempt', () => {
+    expect(isRetryable({ status: 400 })).toBe(false);
+  });
+
+  it('does not retry the other 4xx either, including the one that means a missing parameter', () => {
+    // 401 "Authorization failed" on a DELETE means contact_key is missing (#50).
+    // Sending it again unchanged cannot work.
+    expect(isRetryable({ status: 401 })).toBe(false);
+    expect(isRetryable({ status: 403 })).toBe(false);
+    expect(isRetryable({ status: 404 })).toBe(false);
+  });
+
+  it('does not retry a success', () => {
+    expect(isRetryable({ status: 200, ok: true })).toBe(false);
+  });
+});
+
+describe('upstreamReason', () => {
+  it('names a throttle as itself, because it pauses the whole run', () => {
+    expect(upstreamReason({ status: 429 })).toBe('throttled');
+  });
+
+  it('tells a connection failure apart from an upstream answer', () => {
+    expect(upstreamReason({ status: 0, networkError: true })).toBe('network');
+    expect(upstreamReason({ status: 500 })).toBe('upstream-error');
+  });
+
+  it('prefers the throttle even on a network-flagged 429', () => {
+    expect(upstreamReason({ status: 429, networkError: true })).toBe('throttled');
+  });
+});
+
+describe('upstreamMessage', () => {
+  it('prefers the extracted message over the raw body text', () => {
+    expect(upstreamMessage({ message: 'nope', bodyText: '<html>' })).toBe('nope');
+  });
+
+  it('falls back to the scrubbed body text when there is no JSON message', () => {
+    expect(upstreamMessage({ message: null, bodyText: '<html>too many</html>' })).toBe(
+      '<html>too many</html>',
+    );
+  });
+
+  it('answers null rather than inventing a message', () => {
+    expect(upstreamMessage({})).toBeNull();
+  });
+});

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -22,9 +22,13 @@ const accepts = email => async () => ({ ok: true, email, sub: 'sub-1' });
 const rejects = reason => async () => ({ ok: false, reason, email: null, sub: null });
 
 /** A handler with a stubbed verifier and a capturing log. */
-function handlerWith(verify, { env = ENV } = {}) {
+function handlerWith(verify, { env = ENV, ...deps } = {}) {
   const lines = [];
-  const handle = createHandler({ makeVerifier: () => verify, log: line => lines.push(line) });
+  const handle = createHandler({
+    makeVerifier: () => verify,
+    log: line => lines.push(line),
+    ...deps,
+  });
   return {
     lines,
     call: (path, init = {}) => handle(new Request(`https://ujstaff.happyk.au${path}`, init), env),
@@ -150,10 +154,10 @@ describe('GET /health', () => {
 
 describe('routes not built yet', () => {
   it('answers 404 for an authenticated call to a route this ticket does not add', async () => {
-    // #67/#68/#70 add events, contacts, student and unbook. Until then a 404 is
+    // #67 adds events, plan and schools; #70 adds unbook. Until then a 404 is
     // the honest answer — not a 500, and not a silent 200.
     const h = handlerWith(accepts('staff@urbanjungleirc.com'));
-    const res = await h.call('/api/clubworx/student', { ...withJwt, method: 'POST' });
+    const res = await h.call('/api/clubworx/unbook', { ...withJwt, method: 'POST' });
 
     expect(res.status).toBe(404);
     expect((await res.json()).error).toBe('not found');
@@ -453,5 +457,215 @@ describe('GET /contacts', () => {
 
     expect(h.lines[0]).not.toContain('Amelia');
     expect(h.lines[0]).not.toContain('ck-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /student — the only route that creates permanent records (#69)
+// ---------------------------------------------------------------------------
+
+describe('POST /student', () => {
+  const OPERATOR = 'staff@urbanjungleirc.com';
+
+  const BODY = {
+    student: {
+      first_name: 'Ada',
+      last_name: 'Wayfinder',
+      dob: '2012-03-04',
+      email: 'noreply+stbedes@urbanjungleirc.com',
+    },
+    contact_key: null,
+    membership_plan_id: 64189,
+    membership_duration: '26 weeks',
+    events: [{ event_id: 101, starts_at: '2026-09-03T02:00:00Z' }],
+  };
+
+  const post = (body = BODY) => ({
+    method: 'POST',
+    headers: { ...withJwt.headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const completes = over => async () => ({
+    ok: true,
+    outcome: 'complete',
+    written: true,
+    contact: { contact_key: 'ck-1', state: 'created' },
+    pass: { state: 'created-with-contact' },
+    bookings: [{ event_id: 101, state: 'booked', booking_id: 'b1' }],
+    rollback: null,
+    stranded: false,
+    warnings: [],
+    requests: 4,
+    reason: null,
+    message: null,
+    ...over,
+  });
+
+  it('needs POST — a GET must not be able to write anything', async () => {
+    const h = handlerWith(accepts(OPERATOR), { runStudent: completes() });
+    const res = await h.call('/api/clubworx/student', withJwt);
+    expect(res.status).toBe(405);
+  });
+
+  it('runs behind the Access gate like every other route', async () => {
+    let ran = false;
+    const h = handlerWith(rejects('expired'), {
+      runStudent: async () => {
+        ran = true;
+        return {};
+      },
+    });
+
+    const res = await h.call('/api/clubworx/student', post());
+
+    expect(res.status).toBe(401);
+    expect(ran).toBe(false);
+  });
+
+  it('refuses a body that is not JSON, without touching Clubworx', async () => {
+    let ran = false;
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: async () => {
+        ran = true;
+        return {};
+      },
+    });
+
+    const res = await h.call('/api/clubworx/student', {
+      method: 'POST',
+      headers: { ...withJwt.headers, 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+
+    expect(res.status).toBe(400);
+    expect(ran).toBe(false);
+  });
+
+  it('tells a missing secret apart from a Clubworx refusal', async () => {
+    const h = handlerWith(accepts(OPERATOR), {
+      env: { ...ENV, CLUBWORX_ACCOUNT_KEY: '' },
+      runStudent: completes(),
+    });
+
+    const res = await h.call('/api/clubworx/student', post());
+
+    expect(res.status).toBe(503);
+    expect((await res.json()).reason).toBe('not-configured');
+  });
+
+  it('hands the whole result back on a completed student', async () => {
+    const h = handlerWith(accepts(OPERATOR), { runStudent: completes() });
+    const res = await h.call('/api/clubworx/student', post());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ outcome: 'complete', requests: 4 });
+  });
+
+  it('passes the page a 400 for a refusal that happened before any write', async () => {
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: completes({ ok: false, outcome: 'refused', reason: 'lead-time', written: false }),
+    });
+
+    const res = await h.call('/api/clubworx/student', post());
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).reason).toBe('lead-time');
+  });
+
+  it('answers 429 on a throttle, so the page pauses the whole run', async () => {
+    // The allowance is gym-wide. Backing off one student while the rest continue
+    // just spends the next window failing.
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: completes({ ok: false, outcome: 'failed', reason: 'throttled', written: false }),
+    });
+
+    expect((await h.call('/api/clubworx/student', post())).status).toBe(429);
+  });
+
+  it('answers 200 for an abandoned student, because the rollback is a result', async () => {
+    // Not an error status: a row that was written and rolled back is exactly
+    // what the result table has to show, and it must survive the round trip.
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: completes({
+        ok: false,
+        outcome: 'abandoned',
+        reason: 'no-spaces',
+        written: true,
+        stranded: true,
+        rollback: { cancelled: 2, skipped: 0, failed: [] },
+      }),
+    });
+
+    const res = await h.call('/api/clubworx/student', post());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ outcome: 'abandoned', stranded: true });
+  });
+
+  it('answers 200 for needs-confirmation, which is a row and not a fault', async () => {
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: completes({
+        ok: false,
+        outcome: 'needs-confirmation',
+        reason: 'pass-not-covering',
+        written: false,
+      }),
+    });
+
+    expect((await h.call('/api/clubworx/student', post())).status).toBe(200);
+  });
+
+  it('gives the chain what the request asked for, and nothing it invented', async () => {
+    let seen = null;
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: async args => {
+        seen = args;
+        return (await completes()()) ;
+      },
+    });
+
+    await h.call('/api/clubworx/student', post());
+
+    expect(seen).toMatchObject({
+      contactKey: null,
+      membershipPlanId: 64189,
+      membershipDuration: '26 weeks',
+    });
+    expect(seen.student).toMatchObject(BODY.student);
+    expect(seen.events).toHaveLength(1);
+  });
+
+  it('names the operator on the log line of a write', async () => {
+    // #47: one key per gym, so attribution by key is impossible. The verified
+    // Access email is the only record of who ran it.
+    const h = handlerWith(accepts(OPERATOR), { runStudent: completes() });
+    await h.call('/api/clubworx/student', post());
+
+    expect(JSON.parse(h.lines.at(-1))).toMatchObject({
+      route: '/api/clubworx/student',
+      method: 'POST',
+      status: 200,
+      email: OPERATOR,
+    });
+  });
+
+  it('never logs the student, the body or anything from the response', async () => {
+    // The single rule this Worker is one console.log away from breaking.
+    const h = handlerWith(accepts(OPERATOR), { runStudent: completes() });
+    await h.call('/api/clubworx/student', post());
+
+    const logged = h.lines.join('\n');
+    expect(logged).not.toContain('Wayfinder');
+    expect(logged).not.toContain('2012-03-04');
+    expect(logged).not.toContain('noreply+stbedes');
+    expect(logged).not.toContain('ck-1');
+    expect(logged).not.toContain(ENV.CLUBWORX_ACCOUNT_KEY);
+  });
+
+  it('answers no-store, like every other route on this Worker', async () => {
+    const h = handlerWith(accepts(OPERATOR), { runStudent: completes() });
+    const res = await h.call('/api/clubworx/student', post());
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
   });
 });

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -603,6 +603,29 @@ describe('POST /student', () => {
     expect(await res.json()).toMatchObject({ outcome: 'abandoned', stranded: true });
   });
 
+  it('answers 200 on a throttle that already wrote something, so the row survives', async () => {
+    // The body is the record. D10 writes each row to localStorage as it lands,
+    // because a page reload destroying the only record of a creation that cannot
+    // be undone is the specific failure that defends against — and a non-200
+    // invites a client to throw the body away. The page still sees
+    // `reason: "throttled"` and pauses the run on that.
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: completes({
+        ok: false,
+        outcome: 'abandoned',
+        reason: 'throttled',
+        written: true,
+        stranded: true,
+        rollback: { cancelled: 1, skipped: 0, failed: [] },
+      }),
+    });
+
+    const res = await h.call('/api/clubworx/student', post());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ reason: 'throttled', stranded: true });
+  });
+
   it('answers 200 for needs-confirmation, which is a row and not a fault', async () => {
     const h = handlerWith(accepts(OPERATOR), {
       runStudent: completes({

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -137,8 +137,17 @@ which either happened or did not. §12 still handles it for found contacts.
 > `membership_plan_id` works on create, and it does. The encoding is the one
 > claim #63 could not check, because the first shape it tried succeeded.
 >
-> Note the sibling write paths differ: `/memberships` and `/bookings` **are**
-> form-encoded (#60). The encoding is per-endpoint, not per-API.
+> Note the sibling write paths differ: **`/memberships` is form-encoded** (#60).
+> The encoding is per-endpoint, not per-API.
+>
+> **Corrected 2026-08-20, while building #69.** This line previously said
+> `/bookings` was form-encoded too. It is not: `probes/lib/booking.mjs` sent a
+> **JSON** body and that is the call that produced the 200 creating booking
+> `63510241` in #60. The reversal — `DELETE /bookings/:id` — *is* form-encoded,
+> and that is almost certainly where the mistake came from. The Worker
+> implements what was run: JSON to `POST /members` and `POST /bookings`, a form
+> to `POST /memberships` and `DELETE /bookings/:id`. Anyone reconciling the two
+> should trust `probes/lib/` over this table — it is the code that was executed.
 
 **A created member holds no membership until one is granted.** #63 found D
 sitting in `GET /members` with an empty `/memberships` list. This section


### PR DESCRIPTION
Implements #69. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §10, §11, §12; [ADR 0005](docs/adr/0005-school-pass-runs-26-weeks.md).

`POST /api/clubworx/student` — **the only route in this Worker that creates permanent records.**

```
matched → re-read membership → ensure School Pass → book ×N → verify
new     → create contact WITH the pass ───────────→ book ×N → verify
```

## Why it looks the way it does

Contacts and memberships **cannot be deleted** — 42 endpoints reviewed, no delete on either. Bookings are the one reversal there is. Everything unusual in `src/student.js` follows from that asymmetry:

- **Every write is verified by re-reading the resource**, never by the status code. An accepted-but-silent failure and a success are the same `200`. The `contact_key` the chain books against comes from the re-read, not from the create response.
- **A retry re-reads first.** A connection error on `POST /members` may have landed; retrying blind is how one student becomes two permanent records.
- **Anything uncertain refuses.** A read that fails, a body that is not a list, a date that will not parse.

## D3 — all-or-nothing, with rollback

Any failure abandons the student and cancels the bookings this run made for them. The rollback runs the same code path as the human "Cancel bookings from this run" control **with no human present**, so it honours the same interlock: act on `booked`, never on `already booked`. That is enforced twice — `bookEvent` returns no booking id on an already-booked row, and `cancelRunBookings` refuses the state outright and takes the contact key off the row rather than from the caller.

It leaves a **stranded student**, which the result names. Under D3 an abandoned student is *guaranteed* to be stranded, so it is routine, not an edge case.

## D4's middle row splits (ADR 0005)

The test is **covers the last selected session**, never *active today* — the answer that hid the original bug, because every booking is written on a day the pass is active.

| Case | What happens |
|---|---|
| New contact | `POST /members` carrying `membership_plan_id` — one call |
| Returning, pass **covers** the term | skip the grant |
| Returning, pass **expired** | grant |
| Returning, pass **active but not covering** | **`needs-confirmation`** — never a silent second grant |

That last row is #90's open question: granting there puts a second School Pass on a live holder, deliberately never probed because memberships have no delete. Until it answers, the row refuses and a human decides.

**The number 26 is nowhere in the code.** `membership_duration` is read off the plan, `expiration_date` off the granted pass. An unparseable duration produces a warning naming the raw value — never a silently skipped check.

## Two corrections this turned up

1. **§2 of the design spec said `POST /bookings` is form-encoded. It is not.** `probes/lib/booking.mjs` sent JSON and that is the call that produced the 200 creating booking `63510241` in #60. The form-encoded sibling is `DELETE /bookings/:id`, almost certainly where the mistake came from. Corrected in the spec; the Worker implements what was run.
2. **`del` now sends `account_key` in the body as well as the query**, matching the measured shape. It previously sent it query-only — never exercised, since #70 has not landed — and the way that fails is the `401 "Authorization failed"` that cost #50 a week.

## Review

Both `/code-review` axes ran. **No documented standard was violated.** Four real defects were found and fixed in `3406273`:

- a throttle that had already written something was leaving as a `429`, inviting a client to discard the body that is the only record of an un-deletable creation;
- `POST /members` was spreading the caller's object, so an extra key from the page would have been written onto a permanent contact;
- the cancel path took `contact_key` from the caller rather than the booking row (#70's stated property);
- `'already booked'` and `'already-booked'` differed by one character across three files and decided whether a student was a success or was rolled back.

Plus deduplication: `isRealDay` and the ISO-day regex collapse into `duration.js`, `PAGE_SIZE` comes from `contacts.js`, and D8's retry rule moves to a new `src/upstream.js` so it has one definition instead of one per module.

## Known, and deliberate

A new student's pass expiry is **not** read back, so `pass.expiration_date` is null on that row. That is D4 refusing a membership read for a contact just created, which provably held none.

## Verification

506 tests pass (19 files). `npm run check` clean. No page changes — this is Worker and docs only; the Worker deploys separately with `npx wrangler deploy`.

Closes #69