### PR TITLE
Clubworx Worker: the unbook route and the already-booked interlock (#70)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,14 @@ cloudflare-clubworx/    - uj-clubworx-api, the Worker for the school-group booki
                           comes from and where it lives). Verifies the Access JWT
                           rather than trusting the header, paces at 75 req/min, and
                           stores nothing — no student name or DOB in any store or
-                          log line. GET /api/clubworx/health (#66),
+                          log line. Every route the design names is built:
+                          GET /api/clubworx/health (#66),
                           GET /api/clubworx/contacts (#68),
-                          POST /api/clubworx/student (#69) and the three reads
-                          GET /api/clubworx/{events,plan,schools} (#67) so far;
-                          unbook arrives with #70.
+                          POST /api/clubworx/student (#69), the three reads
+                          GET /api/clubworx/{events,plan,schools} (#67) and
+                          POST /api/clubworx/unbook (#70), the only reversal
+                          there is — bookings can be cancelled, contacts and
+                          passes never.
                           src/student.js is the ONLY code here that creates
                           permanent records — contacts and memberships have no
                           delete, so every write is verified by re-reading it and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,15 +67,21 @@ cloudflare-clubworx/src/bookings.js - book, cancel, and the error vocabulary.
                           the only discriminator; "already booked" is a SUCCESS
                           and carries no booking id, which is what stops a
                           rollback reaching a booking this run did not create.
-cloudflare-clubworx/src/unbook.js - the cancel route. Bookings are the ONLY
-                          thing this system can take back — contacts and passes
-                          have no delete at all — so a caller gets its bookings
-                          back and nothing else. Never touches a row marked
-                          "already booked" (a re-run marks them, and cancelling
-                          one would delete a booking this run did not make). The
-                          contact_key it sends comes from the booking row, never
-                          from the caller. A 200 is not proof: every cancel is
-                          confirmed by re-reading the contact's bookings.
+                          cancelRunBookings owns ALL FOUR cancel guarantees —
+                          the interlock, contact_key-from-the-row, the halt on a
+                          throttle, and confirming by re-read — because D3's
+                          rollback needs every one of them and is not a route.
+                          The re-read matches on the EVENT as well as the id: an
+                          id-only check passes vacuously when a list row carries
+                          a shape bookingIdOf does not know.
+cloudflare-clubworx/src/unbook.js - the cancel route, and only the route's own
+                          job: validate the body, refuse a set spanning two
+                          students (one call cancels one student — a whole run
+                          in one request is minutes long and loses its log), and
+                          turn the tally into an outcome. Bookings are the ONLY
+                          thing this system can take back; contacts and passes
+                          have no delete at all, so a caller gets its bookings
+                          back and nothing else and the UI must not imply more.
 cloudflare-clubworx/src/memberships.js - is the held School Pass good enough? The
                           test is "covers the last selected session", never
                           "active today" (ADR 0005). A live-but-short pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,12 @@ cloudflare-clubworx/    - uj-clubworx-api, the Worker for the school-group booki
                           comes from and where it lives). Verifies the Access JWT
                           rather than trusting the header, paces at 75 req/min, and
                           stores nothing — no student name or DOB in any store or
-                          log line. GET /api/clubworx/health (#66),
+                          log line. Every route the design names is built:
+                          GET /api/clubworx/health (#66),
                           GET /api/clubworx/contacts (#68),
-                          POST /api/clubworx/student (#69) and the three reads
-                          GET /api/clubworx/{events,plan,schools} (#67) so far;
-                          unbook arrives with #70.
+                          POST /api/clubworx/student (#69), the three reads
+                          GET /api/clubworx/{events,plan,schools} (#67) and
+                          POST /api/clubworx/unbook (#70).
 cloudflare-clubworx/src/contacts.js - the dedup read. Searches all three disjoint
                           status views and merges, because a contact moves between
                           them (#49). Every uncertain answer is a refusal: an
@@ -66,6 +67,15 @@ cloudflare-clubworx/src/bookings.js - book, cancel, and the error vocabulary.
                           the only discriminator; "already booked" is a SUCCESS
                           and carries no booking id, which is what stops a
                           rollback reaching a booking this run did not create.
+cloudflare-clubworx/src/unbook.js - the cancel route. Bookings are the ONLY
+                          thing this system can take back — contacts and passes
+                          have no delete at all — so a caller gets its bookings
+                          back and nothing else. Never touches a row marked
+                          "already booked" (a re-run marks them, and cancelling
+                          one would delete a booking this run did not make). The
+                          contact_key it sends comes from the booking row, never
+                          from the caller. A 200 is not proof: every cancel is
+                          confirmed by re-reading the contact's bookings.
 cloudflare-clubworx/src/memberships.js - is the held School Pass good enough? The
                           test is "covers the last selected session", never
                           "active today" (ADR 0005). A live-but-short pass

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -633,6 +633,24 @@ a session a real member booked themselves.
 
 *Avoid*: styling `already booked` as a failure, and collapsing it into `booked`.
 
+### Call outcome
+
+The controlled vocabulary of whole-**call** results, distinct from the per-row
+[row outcome](#row-outcome) above. `POST /student` answers `complete`,
+`abandoned`, `unverified` or `refused`; `POST /unbook` answers `cancelled`,
+`partial`, `nothing-to-cancel`, `still-booked`, `unverified`, `failed` or
+`refused`.
+
+**`unverified` is not a synonym for `failed`.** It means the write or the cancel
+was accepted and could not be confirmed by re-reading — a throttled or truncated
+verifying read. The two send an operator to different places: `failed` means do
+it again, `unverified` means go and look in Clubworx first.
+
+*Avoid*: mapping a call outcome onto an HTTP status alone. Only a throttle that
+changed nothing and a refusal before any write leave as a non-200 — everything
+else is a `200` carrying the record, because the record is the thing that cannot
+be recreated.
+
 ### Restart-safe re-run
 
 The recovery mechanism: re-paste the same list, pick the same sessions, run

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -5,9 +5,9 @@ the school group booking map ([#46](https://github.com/urbanjungleirc/staff-site
 Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §6.
 
 #66 shipped the **skeleton**: the Worker, the Access gate, the pacer and the
-request layer. #68 added the dedup read, #69 the write chain, and #67 the three
-reads the page opens with. Only `unbook` is left; it arrives with #70 and
-answers `404` until then.
+request layer. #68 added the dedup read, #69 the write chain, #67 the three
+reads the page opens with, and #70 the cancel. **Every route §6 names is now
+here.**
 
 | Route | Ticket | Does |
 |---|---|---|
@@ -16,7 +16,8 @@ answers `404` until then.
 | `GET /api/clubworx/events?from=&to=&q=` | #67 | Lists a date window, paged to exhaustion; `?event_id=` resolves a pasted id |
 | `GET /api/clubworx/plan?name=School+Pass` | #67 | Resolves the plan name to an id **and its `membership_duration`** — see below |
 | `GET /api/clubworx/schools` | #67 | Distinct School marker tags, for the school picker |
-| `POST /api/clubworx/student` | #69 | **The only route that writes.** One student, all their sessions — see below |
+| `POST /api/clubworx/student` | #69 | **The only route that creates.** One student, all their sessions — see below |
+| `POST /api/clubworx/unbook` | #70 | **The only reversal there is.** Cancels the bookings one run made for one student — see below |
 
 `ACCESS.md` in this directory is the answer to #47: where the key comes from,
 where it lives, and what is still owed. Read it first.
@@ -33,6 +34,7 @@ src/plans.js     name -> membership_plan_id + membership_duration (#67)
 src/schools.js   the distinct School marker tags                  (#67)
 src/student.js   the per-student write chain, and D3's rollback   (#69)
 src/bookings.js  book, cancel, and the error vocabulary           (#69)
+src/unbook.js    the cancel route: the interlock, and the re-read (#70)
 src/memberships.js  summariseMemberships + D4's pass verdict (promoted, #69)
 src/duration.js  the plan's duration, and what a pass covers      (#69)
 src/upstream.js  what a Clubworx failure means: retry, report, neither (#69)
@@ -500,6 +502,93 @@ Per student: 1 membership read (matched only) + 1 write + 1 verification read
 roughly **250 requests** against a 75/min ceiling shared with the roster Worker
 and n8n — about four minutes of gym-wide slowdown. `requests` is on every
 response.
+
+
+## `POST /unbook` — the only reversal there is
+
+Body: `{"contact_key": "...", "bookings": [ ...the rows `POST /student` returned ]}`.
+`contact_key` is optional; the rows carry their own.
+
+### What it can and cannot take back
+
+| Record | Reversible? |
+|---|---|
+| **Booking** | **Yes** — `DELETE /bookings/:id`, measured in #60 |
+| **Contact** | **No.** 42 endpoints reviewed, no delete anywhere. Removable only by hand in the Clubworx UI, against a ~60,000-profile database |
+| **School Pass membership** | **No.** None appears in the reference and none was attempted. It lapses at `expiration_date` |
+
+So a caller gets its bookings back and nothing else. A student left with a
+contact and a pass and no bookings is **stranded**, and under D3's rollback that
+is a routine outcome rather than an edge case — which is why **D12: there is no
+button called "Undo"**, only *"Cancel bookings from this run"*, with the
+permanence of contacts and passes stated beside it.
+
+### The interlock
+
+**It acts on rows marked `booked` and never on rows marked `already booked`.**
+
+This is a **safety interlock, not a display distinction.** Booking is idempotent,
+so a re-run marks rows `already booked` — and a cancel scoped to the whole row
+set would delete bookings *this run did not create*, possibly a session a real
+member booked themselves. #50 identified that as the worst outcome available on
+this map.
+
+The rule lives in `cancelRunBookings`, shared with D3's automatic rollback inside
+`POST /student`. There is **no flag to relax it**: a rollback path with no human
+present is exactly the caller that would set one.
+
+### `contact_key` comes from the booking, never from the caller
+
+`DELETE /api/v2/bookings/:id` requires `contact_key` **as well as** `account_key`,
+form-encoded in the body. Without it the answer is `401 "Authorization failed"` —
+indistinguishable from a key with no delete permission, and misdiagnosed as
+exactly that for a week in #50, which reported that bookings could not be deleted
+at all. **A permissions-shaped error meant a missing parameter.**
+
+The key sent therefore comes from the booking row. A caller-supplied one can be
+forgotten (that 401) or, worse, be a different student's — which points a
+`DELETE` at somebody else's class. The body's `contact_key`, when present, is
+used only to **reject** a row that does not match it.
+
+### One contact per call
+
+A set mixing two contacts is refused before anything is sent:
+
+- **Verification is a re-read of one contact's bookings.** A mixed set could only
+  be half-verified, and a half-verified cancel reported as done is the failure
+  this route exists to prevent.
+- **D1 — the browser drives, one Worker call per student.** The human control
+  spans a run, but it loops the way the run itself does. A whole-run cancel in
+  one invocation is the multi-minute one-shot response D1 rejected, with the same
+  unrecoverable failure mode: writes landed, log lost.
+
+### A `200` proves nothing — the re-read does
+
+#60 confirmed the reversal **by re-count** — 1 booking before, 0 after —
+precisely because a status code cannot show a `DELETE` that was accepted and
+changed nothing. So every cancel is checked against
+`GET /bookings?contact_key=`, and an id still present comes back as
+`still-booked`, never as cancelled. The re-read is skipped only when nothing was
+cancelled: it costs a request against a gym-wide allowance and there is no claim
+to check.
+
+`outcome` is one of `cancelled`, `partial`, `nothing-to-cancel`, `still-booked`,
+`unverified`, `failed` or `refused`, and `verified` says whether the re-read
+actually confirmed it.
+
+### Which statuses leave
+
+The same rule `POST /student` follows. Only two things are not a `200`:
+
+- **`429`** — a throttle **that cancelled nothing**. Once a cancel has landed
+  there is a row to record, so it leaves as a `200` carrying
+  `reason: "throttled"` — the signal the page pauses the run on.
+- **`400`** — a refusal before anything was sent: no rows, or a mixed set.
+
+Everything else is a `200` carrying the full result, including a partial
+rollback. **A result is not an error**: the `failed` and `stillBooked` lists are
+the only record of which bookings a human still has to remove by hand, and a
+non-200 invites a client to throw the body away.
 
 
 ## Pacing

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -507,7 +507,10 @@ response.
 ## `POST /unbook` — the only reversal there is
 
 Body: `{"contact_key": "...", "bookings": [ ...the rows `POST /student` returned ]}`.
-`contact_key` is optional; the rows carry their own.
+
+The body's `contact_key` may be omitted — it is only ever used to **reject** a
+row belonging to somebody else. The key actually sent to Clubworx is never taken
+from the body; it comes from the booking row, and it is not optional there.
 
 ### What it can and cannot take back
 
@@ -537,7 +540,7 @@ The rule lives in `cancelRunBookings`, shared with D3's automatic rollback insid
 `POST /student`. There is **no flag to relax it**: a rollback path with no human
 present is exactly the caller that would set one.
 
-### `contact_key` comes from the booking, never from the caller
+### `contact_key` on the DELETE is not optional
 
 `DELETE /api/v2/bookings/:id` requires `contact_key` **as well as** `account_key`,
 form-encoded in the body. Without it the answer is `401 "Authorization failed"` —
@@ -566,15 +569,38 @@ A set mixing two contacts is refused before anything is sent:
 
 #60 confirmed the reversal **by re-count** — 1 booking before, 0 after —
 precisely because a status code cannot show a `DELETE` that was accepted and
-changed nothing. So every cancel is checked against
-`GET /bookings?contact_key=`, and an id still present comes back as
-`still-booked`, never as cancelled. The re-read is skipped only when nothing was
-cancelled: it costs a request against a gym-wide allowance and there is no claim
-to check.
+changed nothing. So every cancel is checked against `GET /bookings?contact_key=`,
+and an id still present comes back as `still-booked`, never as cancelled.
+
+Three things about that check:
+
+- **It lives in `cancelRunBookings`, not in this route**, because D3's automatic
+  rollback needs it too and is not a route. Putting it here would have left the
+  caller with *no human present* trusting a `200`.
+- **It matches on the event as well as the booking id**, and the event is the
+  load-bearing half. `bookingIdOf` tolerates several shapes because the create
+  response's shape was never documented; if a list row carries an id under none
+  of them, an id-only check passes having proved nothing. `student.js` verifies
+  bookings *landed* by event id for the same reason.
+- **A truncated re-read confirms nothing.** The list is walked with `paging.js`,
+  and a list that was not read to the end cannot prove a booking is absent from
+  it — that comes back `unverified`, never `cancelled`.
+
+The re-read is skipped only when nothing was cancelled: it costs a request
+against a gym-wide allowance and there is no claim to check.
 
 `outcome` is one of `cancelled`, `partial`, `nothing-to-cancel`, `still-booked`,
-`unverified`, `failed` or `refused`, and `verified` says whether the re-read
-actually confirmed it.
+`unverified`, `failed` or `refused` — on every answer, including a rejected body
+— and `verified` says whether the re-read actually confirmed it.
+
+### A throttle stops the cancel, it does not push through it
+
+§11 pauses the **whole run** on a `429`, so `cancelRunBookings` stops at the
+first one and reports the remaining rows `attempted: false`. Firing them into a
+window that is already refusing spends a gym-wide allowance to be told the same
+thing again — and comes back reporting bookings as needing a human when they are
+still perfectly cancellable. Nothing is retried inside the Worker; the page
+re-asks.
 
 ### Which statuses leave
 

--- a/cloudflare-clubworx/src/bookings.js
+++ b/cloudflare-clubworx/src/bookings.js
@@ -53,7 +53,19 @@
  */
 
 import { errorMessageOf } from './errors.js';
+import { pageThrough } from './paging.js';
 import { isRetryable, upstreamReason, upstreamMessage } from './upstream.js';
+
+/**
+ * How far a contact's own booking list is walked before it is called truncated.
+ *
+ * 5 pages of 200. A school student holds a handful, so this is never reached in
+ * the normal case — it exists because "a full page is an unfinished list, never
+ * an answer" is a rule this API has already broken twice (`paging.js`), and on
+ * THIS list an unfinished read is what makes a booking that is still there look
+ * cancelled.
+ */
+const MAX_BOOKING_PAGES = 5;
 
 /**
  * The row states, as constants rather than as literals typed twice.
@@ -297,7 +309,7 @@ export async function cancelBooking({ client, bookingId, contactKey }) {
 }
 
 /**
- * Cancel the bookings **this run** made for one student.
+ * Cancel the bookings **this run** made for one student, and confirm they went.
  *
  * The interlock: acts on `booked`, never on `already booked`. See the header.
  * There is no flag to relax it, because D3's rollback runs this with no human
@@ -305,7 +317,26 @@ export async function cancelBooking({ client, bookingId, contactKey }) {
  *
  * One failed cancel does not stop the rest. A student half-rolled-back is worse
  * than one fully rolled back, and the failures are reported so a human can
- * finish it.
+ * finish it. **A `429` is the exception** — §11 pauses the *whole run* on a
+ * throttle rather than one row, so the remaining rows are reported un-attempted
+ * instead of fired into a window that is already refusing. Spending the rest of
+ * a gym-wide allowance to be told the same thing six more times would also
+ * report six cancellable bookings as needing a human.
+ *
+ * **The verification lives here rather than in the route**, because both callers
+ * need it and only one of them is a route: the human "Cancel bookings from this
+ * run" control, and D3's automatic rollback inside `student.js` — the one with
+ * no human present to notice a cancel that did not take. #60 established the
+ * reversal **by re-count**, 1 booking before and 0 after, precisely because a
+ * `200` cannot show a `DELETE` that was accepted and changed nothing.
+ *
+ * The re-read is checked on **both** the booking id and the event id. The event
+ * is the load-bearing half: `bookingIdOf` tolerates several shapes because the
+ * create response's shape was never documented, so if a list row carries an id
+ * under none of them `bookingIds` comes back empty and an id-only check passes
+ * having proved nothing. `student.js` verifies bookings *landed* by event id
+ * (`held.eventIds`) for the same reason — that is the field measured to work on
+ * this endpoint.
  *
  * @param {object} opts
  * @param {{del: Function}} opts.client
@@ -319,11 +350,19 @@ export async function cancelRunBookings({ client, contactKey = null, rows = [] }
   const failed = [];
   // The ids, not only the count. A cancel is confirmed by re-reading the
   // contact's bookings and finding them gone (§12, #70), and a count cannot say
-  // *which* ids to look for.
+  // *which* ids to look for. The events travel alongside because the event is
+  // the half of that check known to work on this endpoint.
   const cancelledIds = [];
+  const cancelledEvents = [];
   let skipped = 0;
+  let throttled = false;
+  // The contact to re-read afterwards, taken from a row this call actually
+  // cancelled — never from the caller, for the same reason the DELETE's own key
+  // is not taken from the caller.
+  let verifyKey = null;
+  let stoppedAt = rows.length;
 
-  for (const row of rows) {
+  for (const [index, row] of rows.entries()) {
     if (row?.state !== BOOKED) {
       // Includes `already booked`, `refused` and anything else. Only a row this
       // run put there may be taken away.
@@ -376,20 +415,97 @@ export async function cancelRunBookings({ client, contactKey = null, rows = [] }
     }
 
     const res = await cancelBooking({ client, bookingId: row.booking_id, contactKey: rowKey });
-    if (res.ok) cancelledIds.push(String(row.booking_id));
-    else
-      failed.push({
-        event_id: row.event_id,
-        booking_id: row.booking_id,
-        reason: res.reason,
-        // Carried so a caller can tell a throttle from a refusal without
-        // re-parsing the sentence. §11 pauses the whole run on a 429, and a
-        // reason string is the wrong thing to switch a run on.
-        upstreamStatus: res.upstreamStatus ?? null,
-      });
+    if (res.ok) {
+      cancelledIds.push(String(row.booking_id));
+      cancelledEvents.push(String(row.event_id));
+      verifyKey = verifyKey ?? rowKey;
+      continue;
+    }
+
+    failed.push({
+      event_id: row.event_id,
+      booking_id: row.booking_id,
+      reason: res.reason,
+      // Carried so a caller can tell a throttle from a refusal without
+      // re-parsing the sentence. §11 pauses the whole run on a 429, and a
+      // reason string is the wrong thing to switch a run on.
+      upstreamStatus: res.upstreamStatus ?? null,
+      attempted: true,
+    });
+
+    if (res.upstreamStatus === 429) {
+      // §11 — stop. The allowance is gym-wide, so the rows after this one would
+      // spend the same refusing window and come back reported as needing a
+      // human, for bookings that are still perfectly cancellable.
+      throttled = true;
+      stoppedAt = index + 1;
+      break;
+    }
   }
 
-  return { cancelled: cancelledIds.length, cancelledIds, skipped, failed };
+  for (const row of rows.slice(stoppedAt)) {
+    if (row?.state !== BOOKED) {
+      skipped += 1;
+      continue;
+    }
+    failed.push({
+      event_id: row.event_id,
+      booking_id: row.booking_id ?? null,
+      reason:
+        'not attempted — Clubworx began throttling partway through, and the allowance is shared ' +
+        'with every other system on this key, so the rest of the run stopped rather than spending ' +
+        'it. These bookings are still there and can be cancelled again shortly',
+      upstreamStatus: null,
+      attempted: false,
+    });
+  }
+
+  const tally = { cancelled: cancelledIds.length, cancelledIds, skipped, failed, throttled };
+
+  // Nothing was cancelled, so there is no claim to check — and the read costs a
+  // request against the same gym-wide allowance.
+  if (cancelledIds.length === 0) {
+    return { ...tally, verified: false, verifyReason: 'nothing-cancelled', stillBooked: [] };
+  }
+
+  const held = await readBookings({ client, contactKey: verifyKey });
+
+  if (!held.ok) {
+    return {
+      ...tally,
+      verified: false,
+      verifyReason: 'bookings-unread',
+      verifyMessage: upstreamMessage(held) ?? `HTTP ${held.upstreamStatus}`,
+      stillBooked: [],
+    };
+  }
+
+  if (held.truncated) {
+    // A list that was not read to the end cannot prove anything is absent from
+    // it. Saying so is the whole point of `truncated`.
+    return {
+      ...tally,
+      verified: false,
+      verifyReason: 'bookings-truncated',
+      verifyMessage:
+        'this contact holds more bookings than the re-read walked, so their absence from it ' +
+        'proves nothing',
+      stillBooked: [],
+    };
+  }
+
+  const heldBookings = new Set(held.bookingIds.map(String));
+  const heldEvents = new Set(held.eventIds.map(String));
+  const stillBooked = cancelledIds.filter(
+    (id, i) => heldBookings.has(id) || heldEvents.has(cancelledEvents[i]),
+  );
+
+  return {
+    ...tally,
+    verified: stillBooked.length === 0,
+    verifyReason: stillBooked.length === 0 ? null : 'cancel-not-applied',
+    stillBooked,
+  };
 }
 
 /**
@@ -405,27 +521,29 @@ export async function cancelRunBookings({ client, contactKey = null, rows = [] }
  * @param {string} opts.contactKey
  */
 export async function readBookings({ client, contactKey }) {
-  const res = await client.get('bookings', { contact_key: contactKey });
+  // Walked, not fetched once. Clubworx sends no total and no next-page link, so
+  // a full default page is indistinguishable from a complete list — and on this
+  // particular list, reading an unfinished page as the whole truth reports a
+  // booking that is still there as gone. `paging.js` carries the two occasions
+  // that trap has already cost this effort real time.
+  const walk = await pageThrough({
+    client,
+    path: 'bookings',
+    params: { contact_key: contactKey },
+    maxPages: MAX_BOOKING_PAGES,
+    what: 'bookings',
+  });
 
-  if (!res.ok) {
+  if (!walk.ok) {
     return {
       ok: false,
-      reason: upstreamReason(res),
-      message: upstreamMessage(res),
-      upstreamStatus: res.status,
+      reason: walk.reason,
+      message: walk.message,
+      upstreamStatus: walk.upstreamStatus,
       eventIds: [],
       bookingIds: [],
-    };
-  }
-
-  if (!Array.isArray(res.body)) {
-    return {
-      ok: false,
-      reason: 'upstream-error',
-      message: `bookings answered ${res.status} with a body that is not a list`,
-      upstreamStatus: res.status,
-      eventIds: [],
-      bookingIds: [],
+      truncated: false,
+      requests: walk.requests,
     };
   }
 
@@ -434,8 +552,13 @@ export async function readBookings({ client, contactKey }) {
     // Strings on both sides of every later comparison — Clubworx has sent ids
     // as numbers and as strings, and `42 !== '42'` would report a booking that
     // landed as one that did not.
-    eventIds: res.body.map(r => (r?.event_id === undefined ? null : String(r.event_id))),
-    bookingIds: res.body.map(r => bookingIdOf(r)).filter(Boolean),
-    count: res.body.length,
+    eventIds: walk.rows.map(r => (r?.event_id === undefined ? null : String(r.event_id))),
+    bookingIds: walk.rows.map(r => bookingIdOf(r)).filter(Boolean),
+    count: walk.rows.length,
+    // Never interpreted here — what a ceiling MEANS is the caller's (`paging.js`).
+    // On the cancel path it is a refusal to claim anything; a list that was not
+    // read to the end cannot prove a booking is absent from it.
+    truncated: walk.truncated,
+    requests: walk.requests,
   };
 }

--- a/cloudflare-clubworx/src/bookings.js
+++ b/cloudflare-clubworx/src/bookings.js
@@ -317,7 +317,10 @@ export async function cancelBooking({ client, bookingId, contactKey }) {
  */
 export async function cancelRunBookings({ client, contactKey = null, rows = [] }) {
   const failed = [];
-  let cancelled = 0;
+  // The ids, not only the count. A cancel is confirmed by re-reading the
+  // contact's bookings and finding them gone (§12, #70), and a count cannot say
+  // *which* ids to look for.
+  const cancelledIds = [];
   let skipped = 0;
 
   for (const row of rows) {
@@ -335,6 +338,7 @@ export async function cancelRunBookings({ client, contactKey = null, rows = [] }
         reason:
           'booked, but Clubworx returned no booking id, so there is no booking id to cancel — ' +
           'this one has to be undone by hand',
+        upstreamStatus: null,
       });
       continue;
     }
@@ -352,6 +356,7 @@ export async function cancelRunBookings({ client, contactKey = null, rows = [] }
         reason:
           'this booking carries no contact_key of its own, and a cancel will not be sent on a ' +
           'contact key supplied from outside the row',
+        upstreamStatus: null,
       });
       continue;
     }
@@ -365,16 +370,26 @@ export async function cancelRunBookings({ client, contactKey = null, rows = [] }
         reason:
           'this booking belongs to a different contact than the one being rolled back, so it ' +
           'has not been cancelled',
+        upstreamStatus: null,
       });
       continue;
     }
 
     const res = await cancelBooking({ client, bookingId: row.booking_id, contactKey: rowKey });
-    if (res.ok) cancelled += 1;
-    else failed.push({ event_id: row.event_id, booking_id: row.booking_id, reason: res.reason });
+    if (res.ok) cancelledIds.push(String(row.booking_id));
+    else
+      failed.push({
+        event_id: row.event_id,
+        booking_id: row.booking_id,
+        reason: res.reason,
+        // Carried so a caller can tell a throttle from a refusal without
+        // re-parsing the sentence. §11 pauses the whole run on a 429, and a
+        // reason string is the wrong thing to switch a run on.
+        upstreamStatus: res.upstreamStatus ?? null,
+      });
   }
 
-  return { cancelled, skipped, failed };
+  return { cancelled: cancelledIds.length, cancelledIds, skipped, failed };
 }
 
 /**

--- a/cloudflare-clubworx/src/clubworx.js
+++ b/cloudflare-clubworx/src/clubworx.js
@@ -93,6 +93,36 @@ const outcome = ({
 });
 
 /**
+ * Wrap a client so every call it makes is counted.
+ *
+ * The allowance is **gym-wide** — one key per gym (#47), shared with the roster
+ * Worker and n8n — and a school import is already a four-minute slowdown for
+ * everyone else, so what a call costs is worth reporting rather than estimating.
+ * `requests` is on every response this Worker sends.
+ *
+ * Wraps whatever the client exposes rather than a fixed list, so a caller that
+ * uses `postForm` counts it without this function having to be told.
+ *
+ * @param {Record<string, Function>} client
+ * @returns {{state: {requests: number}, client: Record<string, Function>}}
+ */
+export function countedClient(client) {
+  const state = { requests: 0 };
+  const tick = fn => (...args) => {
+    state.requests += 1;
+    return fn(...args);
+  };
+  return {
+    state,
+    client: Object.fromEntries(
+      Object.entries(client)
+        .filter(([, value]) => typeof value === 'function')
+        .map(([name, fn]) => [name, tick(fn.bind(client))]),
+    ),
+  };
+}
+
+/**
  * @param {object} opts
  * @param {string} opts.accountKey
  * @param {typeof fetch} [opts.fetchImpl]

--- a/cloudflare-clubworx/src/index.js
+++ b/cloudflare-clubworx/src/index.js
@@ -22,13 +22,12 @@
  *
  * **Auth is Cloudflare Access, verified rather than assumed.** See `access.js`.
  *
- * Routes arrive a ticket at a time. #66 shipped the skeleton, the gate, the
+ * Routes arrived a ticket at a time. #66 shipped the skeleton, the gate, the
  * pacer and the request layer; #68 added `GET /contacts`; #69 added
- * `POST /student`, the only route here that writes; #67 added the three reads
- * the page opens with — `GET /events`, `GET /plan` and `GET /schools`. The
- * remaining one, `POST /unbook`, belongs to #70 and answers 404 until then,
- * deliberately: `main` is production on this repo and a page calling a route
- * that does not exist is a broken tool on the live hub (§17).
+ * `POST /student`, the route that creates the records nothing here can delete;
+ * #67 added the three reads the page opens with — `GET /events`, `GET /plan`
+ * and `GET /schools`; #70 added `POST /unbook`, the only reversal this system
+ * has. Every route §6 names is now here.
  */
 
 import { createAccessVerifier } from './access.js';
@@ -38,6 +37,7 @@ import { listEvents, resolveEvent } from './events.js';
 import { lookupPlan } from './plans.js';
 import { listSchools } from './schools.js';
 import { runStudentChain } from './student.js';
+import { unbookRun } from './unbook.js';
 import { isRealDay } from './duration.js';
 
 export const PREFIX = '/api/clubworx';
@@ -129,6 +129,13 @@ const defaultReadSchools = ({ env }) =>
   listSchools({ client: createClubworxClient({ accountKey: env.CLUBWORX_ACCOUNT_KEY }) });
 
 /**
+ * The cancel (#70). One paced client for the whole call, so the deletes and the
+ * verifying re-read queue behind each other like every other chain here.
+ */
+const defaultUnbook = ({ env, ...args }) =>
+  unbookRun({ client: createClubworxClient({ accountKey: env.CLUBWORX_ACCOUNT_KEY }), ...args });
+
+/**
  * What HTTP status a failed read leaves as.
  *
  * Three groups, and the grouping is the design rather than the convention:
@@ -206,6 +213,7 @@ const readFailure = result =>
  * @param {(args: object) => Promise<object>} [deps.readEvents]
  * @param {(args: object) => Promise<object>} [deps.readPlan]
  * @param {(args: object) => Promise<object>} [deps.readSchools]
+ * @param {(args: object) => Promise<object>} [deps.unbook]
  */
 export function createHandler({
   makeVerifier = defaultMakeVerifier,
@@ -215,6 +223,7 @@ export function createHandler({
   readEvents = defaultReadEvents,
   readPlan = defaultReadPlan,
   readSchools = defaultReadSchools,
+  unbook = defaultUnbook,
 } = {}) {
   return async function handle(request, env) {
     const url = new URL(request.url);
@@ -454,7 +463,64 @@ export function createHandler({
       return done(json(result, status), { email, outcome: result.outcome });
     }
 
-    // unbook arrives with #70.
+    if (path === '/unbook') {
+      if (method !== 'POST') return done(json({ error: 'method not allowed' }, 405), { email });
+
+      // A missing secret is a deploy that was never finished, not a Clubworx
+      // refusal — and here the caller is about to be told a rollback did not
+      // happen, which sends an operator into Clubworx by hand.
+      if (!env.CLUBWORX_ACCOUNT_KEY) return notConfigured();
+
+      let payload = null;
+      try {
+        payload = await request.json();
+      } catch {
+        payload = null;
+      }
+      if (!payload || typeof payload !== 'object' || !Array.isArray(payload.bookings)) {
+        return done(
+          json(
+            {
+              error: 'a JSON body carrying this run\u2019s booking rows is required',
+              reason: 'bad-request',
+            },
+            400,
+          ),
+          { email },
+        );
+      }
+
+      const result = await unbook({
+        env,
+        // Only ever used to REJECT a row belonging to somebody else. The key
+        // actually sent to Clubworx comes from the booking row — omitting it
+        // answers 401 "Authorization failed", and a caller-supplied one can be
+        // a different student's (§12, #50).
+        contactKey: payload.contact_key ?? null,
+        rows: payload.bookings,
+      });
+
+      // The same rule `POST /student` follows, and for the same reason: **a
+      // result is not an error.** A partial rollback's leftover list is the only
+      // record of which bookings a human still has to remove, and D10 writes it
+      // to the browser's localStorage as it lands. A 4xx or 5xx invites a client
+      // to throw the body away, and the body is the record.
+      //
+      // So only two things leave as a non-200:
+      //
+      //   - **429**, when the throttle cancelled nothing. §11 pauses the whole
+      //     run on one, because the allowance is gym-wide. Once a cancel HAS
+      //     landed there is a row to record, so it leaves as a 200 carrying
+      //     `reason: "throttled"` — the signal the page actually pauses on.
+      //   - **400** for a refusal that happened before anything was sent: no
+      //     rows, or a set mixing two contacts. Nothing was attempted, so there
+      //     is no row.
+      const throttled = result.reason === 'throttled' && result.cancelled === 0;
+      const status = throttled ? 429 : result.outcome === 'refused' ? 400 : 200;
+
+      return done(json(result, status), { email, outcome: result.outcome });
+    }
+
     return done(json({ error: 'not found' }, 404), { email });
   };
 }

--- a/cloudflare-clubworx/src/index.js
+++ b/cloudflare-clubworx/src/index.js
@@ -183,6 +183,37 @@ const readStatus = reason => (reason === 'throttled' ? 429 : REFUSALS.has(reason
  * tale: a truthful-sounding paraphrase pointed at the wrong mechanism and cost
  * an architectural route.
  */
+/**
+ * What HTTP status a **write** route leaves as — `POST /student` and
+ * `POST /unbook`, the two routes that change something.
+ *
+ * **A result is not an error.** §12's result table has to show every outcome,
+ * and D10 writes each row to the browser's `localStorage` as it lands, because a
+ * page reload destroying the only record of a creation that cannot be undone is
+ * the specific failure that design defends against. A 4xx or 5xx invites a
+ * client to throw the body away, and the body IS the record.
+ *
+ * So only two things leave as a non-200, and in both there is nothing to record:
+ *
+ *   - **429** — a throttle that changed nothing. §11 pauses the *whole run* on
+ *     one, because the allowance is gym-wide (one key per gym, #47), and the
+ *     page needs that where it cannot be missed. Once the call HAS written or
+ *     cancelled something there is a row, so it leaves as a 200 still carrying
+ *     `reason: "throttled"` — the field the page actually pauses on.
+ *   - **400** — a refusal before anything was attempted: a lead-time session, a
+ *     pass that will not cover the term, a set spanning two students, a
+ *     malformed request.
+ *
+ * `changed` is what "nothing happened yet" means on each route, and it is the
+ * only part that differs between them: on `/student` a permanent record was
+ * written, on `/unbook` a booking was cancelled.
+ *
+ * @param {{reason?: string|null, outcome?: string}} result
+ * @param {boolean} changed
+ */
+const writeStatus = (result, changed) =>
+  result.reason === 'throttled' && !changed ? 429 : result.outcome === 'refused' ? 400 : 200;
+
 const readFailure = result =>
   json(
     {
@@ -431,36 +462,14 @@ export function createHandler({
         events: payload.events,
       });
 
-      // **A result is not an error, even when the student was abandoned.**
-      //
-      // §12's result table has to show every outcome — created, already booked,
-      // refused, rolled back, stranded — and D10 writes each row to the
-      // browser's localStorage as it lands, because a page reload destroying the
-      // only record of a creation that cannot be undone is the specific failure
-      // that design defends against. A 4xx or 5xx invites a client to throw the
-      // body away, and the body is the record.
-      //
-      // So only two things leave as a non-200, and both are conditions in which
-      // there is nothing to record:
-      //
-      //   - **429**, because §11 pauses the *whole run* on a throttle. The
-      //     allowance is gym-wide, so backing off one row while the rest
-      //     continue just spends the next window failing, and the page needs
-      //     that signal where it cannot be missed.
-      //   - **400** for a refusal that happened before any write — a lead-time
-      //     session, a pass that will not cover the term, a malformed request.
-      //     Nothing was attempted, so there is no row.
-      // A throttle leaves as a 429 **only when nothing was written**. Once this
-      // call has created a contact, granted a pass or rolled bookings back,
-      // there is a row to record, and a non-200 invites a client to throw the
-      // body away — which is the body D10 writes to localStorage precisely
-      // because a lost record of an un-deletable creation is unrecoverable. The
-      // page still sees `reason: "throttled"` in the body and pauses the run on
-      // that, which is the signal §11 actually asks for.
-      const throttled = result.reason === 'throttled' && result.written !== true;
-      const status = throttled ? 429 : result.outcome === 'refused' ? 400 : 200;
-
-      return done(json(result, status), { email, outcome: result.outcome });
+      // A result is not an error, even when the student was abandoned — the
+      // whole rule is on `writeStatus`. Here, "something happened" means a
+      // permanent record was written: a contact created, a pass granted, or
+      // bookings rolled back.
+      return done(json(result, writeStatus(result, result.written === true)), {
+        email,
+        outcome: result.outcome,
+      });
     }
 
     if (path === '/unbook') {
@@ -483,10 +492,14 @@ export function createHandler({
             {
               error: 'a JSON body carrying this run\u2019s booking rows is required',
               reason: 'bad-request',
+              // Named, so the documented `outcome` vocabulary holds on every
+              // answer this route gives. A field that is absent on some replies
+              // is a field a client learns to stop checking.
+              outcome: 'refused',
             },
             400,
           ),
-          { email },
+          { email, outcome: 'refused' },
         );
       }
 
@@ -500,25 +513,14 @@ export function createHandler({
         rows: payload.bookings,
       });
 
-      // The same rule `POST /student` follows, and for the same reason: **a
-      // result is not an error.** A partial rollback's leftover list is the only
-      // record of which bookings a human still has to remove, and D10 writes it
-      // to the browser's localStorage as it lands. A 4xx or 5xx invites a client
-      // to throw the body away, and the body is the record.
-      //
-      // So only two things leave as a non-200:
-      //
-      //   - **429**, when the throttle cancelled nothing. §11 pauses the whole
-      //     run on one, because the allowance is gym-wide. Once a cancel HAS
-      //     landed there is a row to record, so it leaves as a 200 carrying
-      //     `reason: "throttled"` — the signal the page actually pauses on.
-      //   - **400** for a refusal that happened before anything was sent: no
-      //     rows, or a set mixing two contacts. Nothing was attempted, so there
-      //     is no row.
-      const throttled = result.reason === 'throttled' && result.cancelled === 0;
-      const status = throttled ? 429 : result.outcome === 'refused' ? 400 : 200;
-
-      return done(json(result, status), { email, outcome: result.outcome });
+      // The same rule `POST /student` follows, on the same helper. Here,
+      // "something happened" means a booking was actually cancelled — and the
+      // `failed` and `stillBooked` lists are then the only record of which ones
+      // a human still has to remove by hand.
+      return done(json(result, writeStatus(result, result.cancelled > 0)), {
+        email,
+        outcome: result.outcome,
+      });
     }
 
     return done(json({ error: 'not found' }, 404), { email });

--- a/cloudflare-clubworx/src/student.js
+++ b/cloudflare-clubworx/src/student.js
@@ -85,6 +85,7 @@ import {
   cancelRunBookings,
   readBookings,
 } from './bookings.js';
+import { countedClient } from './clubworx.js';
 import { PAGE_SIZE } from './contacts.js';
 import { MIN_LEAD_HOURS } from './events.js';
 import { isRetryable, upstreamMessage, upstreamReason } from './upstream.js';
@@ -125,29 +126,6 @@ const MEMBER_FIELDS = ['first_name', 'last_name', 'dob', 'email'];
 /** Case- and whitespace-insensitive, for comparing a field against what we sent. */
 const same = (a, b) => String(a ?? '').trim().toLowerCase() === String(b ?? '').trim().toLowerCase();
 
-/**
- * Wrap the client so every call it makes is counted.
- *
- * The allowance is gym-wide (one key per gym, #47) and a school import is
- * already a four-minute slowdown for everyone else, so the number a student
- * costs is worth reporting rather than estimating.
- */
-function counted(client) {
-  const state = { requests: 0 };
-  const tick = fn => (...args) => {
-    state.requests += 1;
-    return fn(...args);
-  };
-  return {
-    state,
-    client: {
-      get: tick(client.get.bind(client)),
-      post: tick(client.post.bind(client)),
-      postForm: tick(client.postForm.bind(client)),
-      del: tick(client.del.bind(client)),
-    },
-  };
-}
 
 /**
  * Find the contact this run just created, by re-reading `/members`.
@@ -404,7 +382,7 @@ export async function runStudentChain({
   now = new Date().toISOString(),
   sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
 }) {
-  const { client, state } = counted(rawClient);
+  const { client, state } = countedClient(rawClient);
   const warnings = [];
 
   const result = over => ({
@@ -634,7 +612,14 @@ export async function runStudentChain({
     // with no human present — so it honours the same interlock: act on `booked`,
     // never on `already booked`.
     const rollback = await cancelRunBookings({ client, contactKey: key, rows });
-    const leftover = rollback.failed.length;
+    // A cancel Clubworx accepted and did not apply leaves a booking behind just
+    // as surely as one it refused, so `stillBooked` counts toward the leftover
+    // rather than being reported separately. The re-read is what finds them.
+    const leftover = rollback.failed.length + rollback.stillBooked.length;
+    // Cancels were sent and nothing here knows whether they took — a throttled
+    // or truncated verifying read. Saying "no bookings from this run" on the
+    // strength of that would be the 200 being trusted all over again.
+    const unconfirmed = rollback.cancelled > 0 && !rollback.verified;
 
     return result({
       outcome: 'abandoned',
@@ -650,7 +635,10 @@ export async function runStudentChain({
         ? 'This student has a contact and a School Pass and no bookings from this run' +
           (leftover > 0
             ? `, and ${leftover} booking(s) could not be cancelled — they need removing by hand.`
-            : '. Finish them by hand, or fix the session and run the list again.')
+            : unconfirmed
+              ? ', as far as can be told — the cancellations were accepted but could not be ' +
+                'confirmed by re-reading. Check this student in Clubworx.'
+              : '. Finish them by hand, or fix the session and run the list again.')
         : null,
       requests: state.requests,
     });

--- a/cloudflare-clubworx/src/unbook.js
+++ b/cloudflare-clubworx/src/unbook.js
@@ -1,0 +1,275 @@
+/**
+ * `POST /unbook` — the only reversal this system has.
+ *
+ * staff-site#70. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §12.
+ *
+ * ---------------------------------------------------------------------------
+ * What this can and cannot take back
+ * ---------------------------------------------------------------------------
+ * | Record | Reversible? |
+ * |---|---|
+ * | **Booking** | **Yes** — `DELETE /bookings/:id`, measured in #60 |
+ * | **Contact** | **No.** 42 endpoints reviewed, no delete anywhere. Removable only by hand in the Clubworx UI, against a ~60,000-profile database |
+ * | **School Pass membership** | **No.** None appears in the reference and none was attempted. It lapses at `expiration_date` |
+ *
+ * So a caller of this route gets its bookings back and nothing else, and the
+ * page must never imply otherwise — **D12, there is no button called "Undo"**.
+ * A student left with a contact and a pass and no bookings is *stranded*, and
+ * under D3's rollback that is a routine outcome rather than an edge case.
+ *
+ * ---------------------------------------------------------------------------
+ * The interlock, which is why this is not just a loop over `DELETE`
+ * ---------------------------------------------------------------------------
+ * **Never cancel a booking marked `already booked`.** Booking is idempotent, so
+ * a re-run marks rows `already booked` — and a cancel scoped to the whole row
+ * set would delete bookings *this run did not create*, possibly a session a real
+ * member booked themselves. #50 identified that as the worst outcome available
+ * on this map.
+ *
+ * The interlock lives in `cancelRunBookings`, shared with D3's automatic
+ * rollback inside `POST /student`. It is not re-implemented here, and there is
+ * no flag to relax it: a rollback path with no human present is exactly the
+ * caller that would set one.
+ *
+ * ---------------------------------------------------------------------------
+ * `contact_key` is not optional, and it comes from the booking
+ * ---------------------------------------------------------------------------
+ * `DELETE /api/v2/bookings/:id` requires `contact_key` **as well as**
+ * `account_key`, form-encoded in the body. Without it the answer is
+ * `401 "Authorization failed"` — indistinguishable from a key with no delete
+ * permission, and misdiagnosed as exactly that for a week in #50, which reported
+ * that bookings could not be deleted at all. **A permissions-shaped error meant
+ * a missing parameter.**
+ *
+ * So the key sent is taken from the **booking row**, never from the caller. A
+ * caller-supplied key can be forgotten (that 401), or — worse — be a different
+ * student's, which points a `DELETE` at somebody else's class. The caller's
+ * `contact_key`, when it sends one, is used only to *reject* a row that does not
+ * match it.
+ *
+ * ---------------------------------------------------------------------------
+ * One contact per call
+ * ---------------------------------------------------------------------------
+ * A mixed set is refused before anything is sent. Two reasons, and the first is
+ * the load-bearing one:
+ *
+ *   - **Verification is a re-read of one contact's bookings.** A mixed set could
+ *     only be half-verified, and a half-verified cancel reported as done is the
+ *     failure this route exists to prevent.
+ *   - **D1 — the browser drives, one Worker call per student.** The human
+ *     "Cancel bookings from this run" control spans a run, but it loops the same
+ *     way the run itself does. A whole-run cancel in one invocation is the
+ *     multi-minute one-shot response D1 rejected, with the same unrecoverable
+ *     failure mode: writes landed, log lost.
+ *
+ * ---------------------------------------------------------------------------
+ * A 200 proves nothing. The re-read does
+ * ---------------------------------------------------------------------------
+ * #60 confirmed the reversal by re-count — 1 booking before, 0 after —
+ * precisely because a status code cannot show a `DELETE` that was accepted and
+ * changed nothing. So every cancel this module reports is checked against
+ * `GET /bookings?contact_key=`, and an id still present comes back as
+ * `still-booked` rather than as cancelled.
+ *
+ * The re-read is skipped only when nothing was cancelled: it costs a request
+ * against a gym-wide allowance and there is no claim to check.
+ */
+
+import { BOOKED, cancelRunBookings, readBookings } from './bookings.js';
+import { upstreamMessage } from './upstream.js';
+
+/**
+ * Wrap the client so every call it makes is counted.
+ *
+ * The same wrapper `student.js` uses, and for the same reason: the allowance is
+ * gym-wide (one key per gym, #47), so what a cancel costs is worth reporting
+ * rather than estimating.
+ */
+function counted(client) {
+  const state = { requests: 0 };
+  const tick = fn => (...args) => {
+    state.requests += 1;
+    return fn(...args);
+  };
+  return {
+    state,
+    client: {
+      get: tick(client.get.bind(client)),
+      del: tick(client.del.bind(client)),
+    },
+  };
+}
+
+/** Refused before anything was sent, so there is nothing to report but the reason. */
+const refusal = ({ reason, message }) => ({
+  ok: false,
+  outcome: 'refused',
+  reason,
+  message,
+  contact_key: null,
+  cancelled: 0,
+  cancelledIds: [],
+  skipped: 0,
+  failed: [],
+  stillBooked: [],
+  verified: false,
+  requests: 0,
+});
+
+/**
+ * Cancel the bookings one run made for one student, and confirm they are gone.
+ *
+ * @param {object} opts
+ * @param {{get: Function, del: Function}} opts.client
+ * @param {string|null} [opts.contactKey] The student being rolled back. Used
+ *   only to **reject** a row belonging to somebody else; the key actually sent
+ *   comes from the row.
+ * @param {Array<{event_id: any, state: string, booking_id: string|null,
+ *   contact_key: string|null}>|null} opts.rows The result rows from this run,
+ *   exactly as `POST /student` handed them back.
+ * @returns {Promise<{ok: boolean, outcome: 'refused'|'nothing-to-cancel'|'cancelled'|
+ *   'partial'|'failed'|'still-booked'|'unverified', reason: string|null,
+ *   message: string|null, contact_key: string|null, cancelled: number,
+ *   cancelledIds: string[], skipped: number, failed: object[],
+ *   stillBooked: string[], verified: boolean, requests: number}>}
+ */
+export async function unbookRun({ client, contactKey = null, rows = null }) {
+  if (!Array.isArray(rows)) {
+    return refusal({
+      reason: 'bad-request',
+      message: 'a list of booking rows from this run is required',
+    });
+  }
+
+  // Only rows this run put in `booked` are ever acted on. Everything else —
+  // `already booked` above all — is counted and left where it is.
+  const actionable = rows.filter(row => row?.state === BOOKED);
+
+  // The contacts this call would touch, from the rows themselves plus whatever
+  // the caller claims. More than one and nothing is sent: see the header.
+  const keys = new Set(actionable.map(row => row?.contact_key).filter(Boolean));
+  if (contactKey) keys.add(contactKey);
+
+  if (keys.size > 1) {
+    return refusal({
+      reason: 'mixed-contacts',
+      message:
+        'these booking rows belong to more than one contact. One call cancels one student, ' +
+        'because the cancellation is confirmed by re-reading that one contact’s bookings',
+    });
+  }
+
+  const key = keys.size === 1 ? [...keys][0] : null;
+  const { state, client: tracked } = counted(client);
+
+  const run = await cancelRunBookings({ client: tracked, contactKey: key, rows });
+
+  const base = {
+    contact_key: key,
+    cancelled: run.cancelled,
+    cancelledIds: run.cancelledIds,
+    skipped: run.skipped,
+    failed: run.failed,
+    stillBooked: [],
+  };
+
+  if (actionable.length === 0) {
+    // Nothing this run booked, so nothing to take away. Not an error: a re-run
+    // marks every row `already booked`, and cancelling that set is the one thing
+    // the interlock exists to stop.
+    return {
+      ...base,
+      ok: true,
+      outcome: 'nothing-to-cancel',
+      reason: null,
+      message:
+        run.skipped > 0
+          ? `${run.skipped} booking(s) were not made by this run, so none has been cancelled`
+          : 'there were no bookings from this run to cancel',
+      verified: false,
+      requests: state.requests,
+    };
+  }
+
+  // §11 — a throttle pauses the whole run, not one row, because the allowance is
+  // gym-wide. It outranks every other reason for that reason alone.
+  const throttled = run.failed.some(f => f.upstreamStatus === 429);
+
+  if (run.cancelledIds.length === 0) {
+    return {
+      ...base,
+      ok: false,
+      outcome: 'failed',
+      reason: throttled ? 'throttled' : 'cancel-failed',
+      message: throttled
+        ? 'Clubworx is busy — this can be caused by another system, not this page. Try again shortly.'
+        : `none of the ${actionable.length} booking(s) could be cancelled — they are still there`,
+      verified: false,
+      requests: state.requests,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Verify by re-reading, never by the status code (§12, #60).
+  // -------------------------------------------------------------------------
+  const held = await readBookings({ client: tracked, contactKey: key });
+
+  if (!held.ok) {
+    return {
+      ...base,
+      ok: false,
+      outcome: 'unverified',
+      reason: 'bookings-unread',
+      message:
+        `${run.cancelledIds.length} cancellation(s) were accepted but could not be confirmed by ` +
+        're-reading this contact’s bookings: ' +
+        (upstreamMessage(held) ?? `HTTP ${held.upstreamStatus}`) +
+        '. A DELETE that answers 200 and changes nothing looks identical from here, so this is ' +
+        'reported as unconfirmed rather than as done — check the student in Clubworx.',
+      verified: false,
+      requests: state.requests,
+    };
+  }
+
+  const stillHeld = new Set(held.bookingIds.map(String));
+  const stillBooked = run.cancelledIds.filter(id => stillHeld.has(String(id)));
+
+  if (stillBooked.length > 0) {
+    return {
+      ...base,
+      ok: false,
+      outcome: 'still-booked',
+      reason: 'cancel-not-applied',
+      stillBooked,
+      message:
+        `${stillBooked.length} booking(s) Clubworx accepted a cancellation for are still there on ` +
+        'a re-read. The 200 was not the truth; these have to be removed by hand.',
+      verified: false,
+      requests: state.requests,
+    };
+  }
+
+  if (run.failed.length > 0) {
+    return {
+      ...base,
+      ok: false,
+      outcome: 'partial',
+      reason: throttled ? 'throttled' : 'cancel-failed',
+      message:
+        `${run.cancelled} booking(s) cancelled and confirmed gone; ${run.failed.length} could not ` +
+        'be cancelled and need removing by hand.',
+      verified: true,
+      requests: state.requests,
+    };
+  }
+
+  return {
+    ...base,
+    ok: true,
+    outcome: 'cancelled',
+    reason: null,
+    message: `${run.cancelled} booking(s) cancelled, confirmed by re-reading this contact’s bookings.`,
+    verified: true,
+    requests: state.requests,
+  };
+}

--- a/cloudflare-clubworx/src/unbook.js
+++ b/cloudflare-clubworx/src/unbook.js
@@ -50,55 +50,39 @@
  * ---------------------------------------------------------------------------
  * One contact per call
  * ---------------------------------------------------------------------------
- * A mixed set is refused before anything is sent. Two reasons, and the first is
- * the load-bearing one:
+ * A set spanning two contacts is refused before anything is sent. The reason is
+ * the request budget of a single invocation, not tidiness.
  *
- *   - **Verification is a re-read of one contact's bookings.** A mixed set could
- *     only be half-verified, and a half-verified cancel reported as done is the
- *     failure this route exists to prevent.
- *   - **D1 — the browser drives, one Worker call per student.** The human
- *     "Cancel bookings from this run" control spans a run, but it loops the same
- *     way the run itself does. A whole-run cancel in one invocation is the
- *     multi-minute one-shot response D1 rejected, with the same unrecoverable
- *     failure mode: writes landed, log lost.
+ * §6 sizes a run at **25 students × 6 sessions**. Cancelling one is therefore up
+ * to 150 `DELETE`s plus a verifying re-read per student, and this Worker paces
+ * at ~800 ms — well over two minutes in one request, before the Workers
+ * per-invocation subrequest ceiling is even considered. That is the same shape
+ * D1 rejected for the run itself, with the same unrecoverable failure mode:
+ * **the writes land and the log is lost.** The page already loops per student to
+ * apply, holds each student's rows in `localStorage` as they land (D10), and
+ * cancels by looping the same way.
+ *
+ * This is a different check from the one `cancelRunBookings` already makes, not
+ * a second copy of it: that one rejects a **stray row** inside one student's
+ * rollback, this one rejects a **set spanning students** before any of it runs.
+ * Both refuse; neither cancels the wrong thing.
  *
  * ---------------------------------------------------------------------------
- * A 200 proves nothing. The re-read does
+ * What this module does NOT do
  * ---------------------------------------------------------------------------
- * #60 confirmed the reversal by re-count — 1 booking before, 0 after —
- * precisely because a status code cannot show a `DELETE` that was accepted and
- * changed nothing. So every cancel this module reports is checked against
- * `GET /bookings?contact_key=`, and an id still present comes back as
- * `still-booked` rather than as cancelled.
+ * The interlock, the `contact_key`-from-the-row rule, the throttle halt and the
+ * verifying re-read all live in `cancelRunBookings`, because **D3's automatic
+ * rollback needs every one of them and it is not a route.** This module is the
+ * route's own job and nothing else: validate the body, refuse a set it cannot
+ * verify, and turn the tally into an outcome and an HTTP status.
  *
- * The re-read is skipped only when nothing was cancelled: it costs a request
- * against a gym-wide allowance and there is no claim to check.
+ * Putting the verification here instead would have left the caller with no human
+ * present — the rollback — trusting a `200`, which is the exact thing #60 proved
+ * cannot be trusted.
  */
 
-import { BOOKED, cancelRunBookings, readBookings } from './bookings.js';
-import { upstreamMessage } from './upstream.js';
-
-/**
- * Wrap the client so every call it makes is counted.
- *
- * The same wrapper `student.js` uses, and for the same reason: the allowance is
- * gym-wide (one key per gym, #47), so what a cancel costs is worth reporting
- * rather than estimating.
- */
-function counted(client) {
-  const state = { requests: 0 };
-  const tick = fn => (...args) => {
-    state.requests += 1;
-    return fn(...args);
-  };
-  return {
-    state,
-    client: {
-      get: tick(client.get.bind(client)),
-      del: tick(client.del.bind(client)),
-    },
-  };
-}
+import { BOOKED, cancelRunBookings } from './bookings.js';
+import { countedClient } from './clubworx.js';
 
 /** Refused before anything was sent, so there is nothing to report but the reason. */
 const refusal = ({ reason, message }) => ({
@@ -117,7 +101,7 @@ const refusal = ({ reason, message }) => ({
 });
 
 /**
- * Cancel the bookings one run made for one student, and confirm they are gone.
+ * Cancel the bookings one run made for one student, and report what is known.
  *
  * @param {object} opts
  * @param {{get: Function, del: Function}} opts.client
@@ -141,28 +125,34 @@ export async function unbookRun({ client, contactKey = null, rows = null }) {
     });
   }
 
-  // Only rows this run put in `booked` are ever acted on. Everything else —
-  // `already booked` above all — is counted and left where it is.
-  const actionable = rows.filter(row => row?.state === BOOKED);
-
-  // The contacts this call would touch, from the rows themselves plus whatever
-  // the caller claims. More than one and nothing is sent: see the header.
-  const keys = new Set(actionable.map(row => row?.contact_key).filter(Boolean));
+  // The contacts this call would touch — from the rows this run actually booked,
+  // plus whatever the caller claims. More than one and nothing is sent; see the
+  // header for why the boundary is one student.
+  const keys = new Set(
+    rows.filter(row => row?.state === BOOKED).map(row => row?.contact_key).filter(Boolean),
+  );
   if (contactKey) keys.add(contactKey);
 
   if (keys.size > 1) {
     return refusal({
       reason: 'mixed-contacts',
       message:
-        'these booking rows belong to more than one contact. One call cancels one student, ' +
-        'because the cancellation is confirmed by re-reading that one contact’s bookings',
+        'these booking rows belong to more than one contact. One call cancels one student — ' +
+        'a whole run in one request is the multi-minute response whose failure mode is writes ' +
+        'landed and log lost',
     });
   }
 
   const key = keys.size === 1 ? [...keys][0] : null;
-  const { state, client: tracked } = counted(client);
+  const { state, client: tracked } = countedClient(client);
 
+  // The interlock, the contact-from-the-row rule, the throttle halt and the
+  // verifying re-read are all in here. This module does not repeat any of them.
   const run = await cancelRunBookings({ client: tracked, contactKey: key, rows });
+
+  // Rows this run booked, derived from the tally rather than re-filtered — the
+  // interlock's own count of what it passed over is the authority on that.
+  const actionable = rows.length - run.skipped;
 
   const base = {
     contact_key: key,
@@ -170,10 +160,12 @@ export async function unbookRun({ client, contactKey = null, rows = null }) {
     cancelledIds: run.cancelledIds,
     skipped: run.skipped,
     failed: run.failed,
-    stillBooked: [],
+    stillBooked: run.stillBooked,
+    verified: run.verified,
+    requests: state.requests,
   };
 
-  if (actionable.length === 0) {
+  if (actionable === 0) {
     // Nothing this run booked, so nothing to take away. Not an error: a re-run
     // marks every row `already booked`, and cancelling that set is the one thing
     // the interlock exists to stop.
@@ -186,66 +178,54 @@ export async function unbookRun({ client, contactKey = null, rows = null }) {
         run.skipped > 0
           ? `${run.skipped} booking(s) were not made by this run, so none has been cancelled`
           : 'there were no bookings from this run to cancel',
-      verified: false,
-      requests: state.requests,
     };
   }
 
   // §11 — a throttle pauses the whole run, not one row, because the allowance is
   // gym-wide. It outranks every other reason for that reason alone.
-  const throttled = run.failed.some(f => f.upstreamStatus === 429);
+  const reason = run.throttled ? 'throttled' : null;
+  const throttleMessage =
+    'Clubworx is busy — this can be caused by another system, not this page. Try again shortly.';
 
-  if (run.cancelledIds.length === 0) {
+  if (run.cancelled === 0) {
     return {
       ...base,
       ok: false,
       outcome: 'failed',
-      reason: throttled ? 'throttled' : 'cancel-failed',
-      message: throttled
-        ? 'Clubworx is busy — this can be caused by another system, not this page. Try again shortly.'
-        : `none of the ${actionable.length} booking(s) could be cancelled — they are still there`,
-      verified: false,
-      requests: state.requests,
+      reason: reason ?? 'cancel-failed',
+      message: run.throttled
+        ? throttleMessage
+        : `none of the ${actionable} booking(s) could be cancelled — they are still there`,
     };
   }
 
-  // -------------------------------------------------------------------------
-  // Verify by re-reading, never by the status code (§12, #60).
-  // -------------------------------------------------------------------------
-  const held = await readBookings({ client: tracked, contactKey: key });
-
-  if (!held.ok) {
-    return {
-      ...base,
-      ok: false,
-      outcome: 'unverified',
-      reason: 'bookings-unread',
-      message:
-        `${run.cancelledIds.length} cancellation(s) were accepted but could not be confirmed by ` +
-        're-reading this contact’s bookings: ' +
-        (upstreamMessage(held) ?? `HTTP ${held.upstreamStatus}`) +
-        '. A DELETE that answers 200 and changes nothing looks identical from here, so this is ' +
-        'reported as unconfirmed rather than as done — check the student in Clubworx.',
-      verified: false,
-      requests: state.requests,
-    };
-  }
-
-  const stillHeld = new Set(held.bookingIds.map(String));
-  const stillBooked = run.cancelledIds.filter(id => stillHeld.has(String(id)));
-
-  if (stillBooked.length > 0) {
+  if (run.stillBooked.length > 0) {
     return {
       ...base,
       ok: false,
       outcome: 'still-booked',
-      reason: 'cancel-not-applied',
-      stillBooked,
+      reason: reason ?? run.verifyReason,
       message:
-        `${stillBooked.length} booking(s) Clubworx accepted a cancellation for are still there on ` +
-        'a re-read. The 200 was not the truth; these have to be removed by hand.',
-      verified: false,
-      requests: state.requests,
+        `${run.stillBooked.length} booking(s) Clubworx accepted a cancellation for are still ` +
+        'there on a re-read. The 200 was not the truth; these have to be removed by hand.',
+    };
+  }
+
+  if (!run.verified) {
+    // Cancels were accepted, and nothing here knows whether they took. Reported
+    // as unconfirmed rather than as done, because the two send an operator to
+    // different places.
+    return {
+      ...base,
+      ok: false,
+      outcome: 'unverified',
+      reason: reason ?? run.verifyReason,
+      message:
+        `${run.cancelled} cancellation(s) were accepted but could not be confirmed by re-reading ` +
+        'this contact’s bookings' +
+        (run.verifyMessage ? `: ${run.verifyMessage}` : '') +
+        '. A DELETE that answers 200 and changes nothing looks identical from here, so this is ' +
+        'reported as unconfirmed rather than as done — check the student in Clubworx.',
     };
   }
 
@@ -254,12 +234,11 @@ export async function unbookRun({ client, contactKey = null, rows = null }) {
       ...base,
       ok: false,
       outcome: 'partial',
-      reason: throttled ? 'throttled' : 'cancel-failed',
+      reason: reason ?? 'cancel-failed',
       message:
         `${run.cancelled} booking(s) cancelled and confirmed gone; ${run.failed.length} could not ` +
-        'be cancelled and need removing by hand.',
-      verified: true,
-      requests: state.requests,
+        'be cancelled and need removing by hand.' +
+        (run.throttled ? ` ${throttleMessage}` : ''),
     };
   }
 
@@ -269,7 +248,5 @@ export async function unbookRun({ client, contactKey = null, rows = null }) {
     outcome: 'cancelled',
     reason: null,
     message: `${run.cancelled} booking(s) cancelled, confirmed by re-reading this contact’s bookings.`,
-    verified: true,
-    requests: state.requests,
   };
 }

--- a/cloudflare-clubworx/test/bookings.test.js
+++ b/cloudflare-clubworx/test/bookings.test.js
@@ -246,7 +246,74 @@ describe('cancelRunBookings — the safety interlock', () => {
     });
 
     expect(out.cancelled).toBe(2);
-    expect(client.calls.map(c => c.path)).toEqual(['bookings/b1', 'bookings/b2']);
+    expect(client.calls.filter(c => c.method === 'DELETE').map(c => c.path)).toEqual([
+      'bookings/b1',
+      'bookings/b2',
+    ]);
+  });
+
+  it('confirms the cancellation by re-reading, never by the DELETE 200', async () => {
+    // #60 established the reversal by re-count — 1 before, 0 after — because a
+    // status code cannot show a DELETE that was accepted and changed nothing.
+    const client = clientReturning(ok({ success: true }), ok([]));
+    const out = await cancelRunBookings({ client, contactKey: 'ck-1', rows: [bookedRow(1, 'b1')] });
+
+    const read = client.calls.find(c => c.method === 'GET');
+    expect(read.path).toBe('bookings');
+    expect(read.params).toMatchObject({ contact_key: 'ck-1' });
+    expect(out.verified).toBe(true);
+    expect(out.stillBooked).toEqual([]);
+  });
+
+  it('catches a booking still held by its EVENT, when the list carries no id it knows', async () => {
+    // The load-bearing half. `bookingIdOf` tolerates several shapes because the
+    // create response was never documented; if a list row carries none of them,
+    // an id-only check passes having proved nothing.
+    const client = clientReturning(ok({ success: true }), ok([{ some_other_id: 'x', event_id: 1 }]));
+    const out = await cancelRunBookings({ client, contactKey: 'ck-1', rows: [bookedRow(1, 'b1')] });
+
+    expect(out.verified).toBe(false);
+    expect(out.stillBooked).toEqual(['b1']);
+  });
+
+  it('will not call a cancel verified off a list it did not finish reading', async () => {
+    // A full page is an unfinished list, never an answer — and absence from an
+    // unfinished list proves nothing.
+    const full = Array.from({ length: 200 }, (_, i) => ({ booking_id: `x${i}`, event_id: i }));
+    const client = clientReturning(ok({ success: true }), ok(full));
+    const out = await cancelRunBookings({ client, contactKey: 'ck-1', rows: [bookedRow(1, 'b1')] });
+
+    expect(out.cancelled).toBe(1);
+    expect(out.verified).toBe(false);
+    expect(out.verifyReason).toBe('bookings-truncated');
+  });
+
+  it('does not spend a request verifying when nothing was cancelled', async () => {
+    const client = clientReturning(ok({ success: true }));
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [{ event_id: 1, state: 'already booked', booking_id: 'b1', contact_key: 'ck-1' }],
+    });
+
+    expect(client.calls).toHaveLength(0);
+    expect(out.verifyReason).toBe('nothing-cancelled');
+  });
+
+  it('stops on a throttle instead of spending the rest of a gym-wide allowance', async () => {
+    // §11 — a 429 pauses the whole run, not one row. The rows after it are
+    // reported un-attempted, because they are still cancellable.
+    const client = clientReturning(reply({ ok: false, status: 429 }));
+    const out = await cancelRunBookings({
+      client,
+      contactKey: 'ck-1',
+      rows: [bookedRow(1, 'b1'), bookedRow(2, 'b2'), bookedRow(3, 'b3')],
+    });
+
+    expect(client.calls.filter(c => c.method === 'DELETE')).toHaveLength(1);
+    expect(out.throttled).toBe(true);
+    expect(out.failed).toHaveLength(3);
+    expect(out.failed.filter(f => f.attempted === false)).toHaveLength(2);
   });
 
   it('NEVER cancels a row marked already booked', async () => {
@@ -262,7 +329,7 @@ describe('cancelRunBookings — the safety interlock', () => {
       ],
     });
 
-    expect(client.calls.map(c => c.path)).toEqual(['bookings/b2']);
+    expect(client.calls.filter(c => c.method === 'DELETE').map(c => c.path)).toEqual(['bookings/b2']);
     expect(out.skipped).toBe(1);
   });
 
@@ -332,6 +399,9 @@ describe('cancelRunBookings — the safety interlock', () => {
         n += 1;
         return n === 1 ? reply({ status: 500 }) : ok({ success: true });
       },
+      // The verifying re-read is part of the contract now: a cancel is confirmed
+      // by re-reading the contact's bookings, never by the DELETE's 200.
+      get: async () => ok([]),
     };
 
     const out = await cancelRunBookings({

--- a/cloudflare-clubworx/test/unbook.test.js
+++ b/cloudflare-clubworx/test/unbook.test.js
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import { unbookRun } from '../src/unbook.js';
+
+/** A stub with the shape `createClubworxClient` hands back. */
+const reply = over => ({
+  ok: false,
+  status: 400,
+  url: 'https://app.clubworx.com/api/v2/bookings',
+  ms: 1,
+  body: null,
+  nonJson: false,
+  bodyText: null,
+  message: null,
+  networkError: false,
+  ...over,
+});
+
+const ok = body => reply({ ok: true, status: 200, body });
+
+/**
+ * A client whose DELETE answers are scripted in order, and whose GET answers
+ * with the bookings the contact is left holding.
+ *
+ * The GET matters as much as the DELETEs here: #70's verification rule is that
+ * a cancellation is confirmed by re-reading the contact's bookings, never by
+ * the `200` the DELETE returned.
+ */
+const clientWith = ({ deletes = [ok({ success: true })], remaining = [] } = {}) => {
+  const calls = [];
+  return {
+    calls,
+    get: async (path, params) => {
+      calls.push({ method: 'GET', path, params });
+      return Array.isArray(remaining)
+        ? ok(remaining.map(id => ({ booking_id: id, event_id: `e-${id}` })))
+        : remaining;
+    },
+    del: async (path, form) => {
+      calls.push({ method: 'DELETE', path, form });
+      return deletes[Math.min(calls.filter(c => c.method === 'DELETE').length - 1, deletes.length - 1)];
+    },
+    post: async () => ok({}),
+    postForm: async () => ok({}),
+  };
+};
+
+const bookedRow = (eventId, bookingId, contactKey = 'ck-1') => ({
+  event_id: eventId,
+  state: 'booked',
+  booking_id: bookingId,
+  contact_key: contactKey,
+});
+
+const alreadyBookedRow = (eventId, contactKey = 'ck-1') => ({
+  event_id: eventId,
+  state: 'already booked',
+  booking_id: null,
+  contact_key: contactKey,
+});
+
+describe('unbookRun — what it refuses before touching anything', () => {
+  it('refuses when no booking rows were supplied at all', async () => {
+    const client = clientWith();
+    const out = await unbookRun({ client, rows: null });
+
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('bad-request');
+    expect(client.calls).toEqual([]);
+  });
+
+  it('treats an empty list as nothing to do rather than as an error', async () => {
+    // The page filters to its own booked rows; landing on zero is a legitimate
+    // outcome, not a malformed call. Nothing is sent either way.
+    const client = clientWith();
+    const out = await unbookRun({ client, rows: [] });
+
+    expect(out.ok).toBe(true);
+    expect(out.outcome).toBe('nothing-to-cancel');
+    expect(out.cancelled).toBe(0);
+    expect(client.calls).toEqual([]);
+  });
+
+  it('refuses a set mixing two contacts, and cancels nothing', async () => {
+    // One call, one contact. Verification is a re-read of ONE contact's
+    // bookings, so a mixed set could only be half-verified — and a half-verified
+    // cancel reported as done is the shape #70 exists to prevent.
+    const client = clientWith();
+    const out = await unbookRun({
+      client,
+      rows: [bookedRow(1, 'b1', 'ck-1'), bookedRow(2, 'b2', 'ck-2')],
+    });
+
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('mixed-contacts');
+    expect(client.calls).toEqual([]);
+  });
+
+  it('refuses a booked row carrying no contact_key of its own', async () => {
+    // The contact travels WITH the booking. A caller-supplied key can be a
+    // different student's, which would point a DELETE at somebody else's class.
+    const client = clientWith();
+    const out = await unbookRun({
+      client,
+      contactKey: 'ck-1',
+      rows: [{ event_id: 1, state: 'booked', booking_id: 'b1', contact_key: null }],
+    });
+
+    expect(out.cancelled).toBe(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0].reason).toMatch(/contact_key of its own/);
+    expect(client.calls.filter(c => c.method === 'DELETE')).toEqual([]);
+  });
+});
+
+describe('unbookRun — the interlock', () => {
+  it('never cancels a row marked already booked', async () => {
+    // The interlock, not a display distinction: a re-run marks rows `already
+    // booked`, and those bookings were not made by this run. One of them may be
+    // a session a real member booked themselves.
+    const client = clientWith({ remaining: ['b-not-ours'] });
+    const out = await unbookRun({
+      client,
+      rows: [alreadyBookedRow(1), alreadyBookedRow(2)],
+    });
+
+    expect(out.outcome).toBe('nothing-to-cancel');
+    expect(out.skipped).toBe(2);
+    expect(client.calls.filter(c => c.method === 'DELETE')).toEqual([]);
+  });
+
+  it('cancels the booked rows and leaves the already-booked ones alone', async () => {
+    const client = clientWith({ deletes: [ok({ success: true })], remaining: [] });
+    const out = await unbookRun({
+      client,
+      rows: [bookedRow(1, 'b1'), alreadyBookedRow(2), bookedRow(3, 'b3')],
+    });
+
+    expect(out.cancelled).toBe(2);
+    expect(out.skipped).toBe(1);
+    expect(client.calls.filter(c => c.method === 'DELETE').map(c => c.path)).toEqual([
+      'bookings/b1',
+      'bookings/b3',
+    ]);
+  });
+
+  it('takes the contact_key it sends from the booking row', async () => {
+    // Omitting it answers 401 "Authorization failed", which reads like a key
+    // without delete permission and was misdiagnosed as exactly that for a week
+    // in #50. Taking it from the row is what makes it impossible to forget.
+    const client = clientWith();
+    await unbookRun({ client, rows: [bookedRow(1, 'b1', 'ck-9')] });
+
+    const del = client.calls.find(c => c.method === 'DELETE');
+    expect(del.form).toEqual({ contact_key: 'ck-9' });
+  });
+
+  it('refuses a row belonging to a contact other than the one being rolled back', async () => {
+    const client = clientWith();
+    const out = await unbookRun({
+      client,
+      contactKey: 'ck-1',
+      rows: [bookedRow(1, 'b1', 'ck-2')],
+    });
+
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('mixed-contacts');
+    expect(client.calls.filter(c => c.method === 'DELETE')).toEqual([]);
+  });
+});
+
+describe('unbookRun — verification is a re-read, never the 200', () => {
+  it('re-reads the contact bookings after cancelling', async () => {
+    const client = clientWith({ remaining: [] });
+    const out = await unbookRun({ client, rows: [bookedRow(1, 'b1')] });
+
+    const read = client.calls.find(c => c.method === 'GET');
+    expect(read.path).toBe('bookings');
+    expect(read.params).toEqual({ contact_key: 'ck-1' });
+    expect(out.verified).toBe(true);
+    expect(out.outcome).toBe('cancelled');
+    expect(out.ok).toBe(true);
+  });
+
+  it('reports a booking still present on the re-read, despite the 200', async () => {
+    // A DELETE that answers 200 and changes nothing is the one failure a status
+    // code cannot show. It is reported as still booked, not as cancelled.
+    const client = clientWith({ deletes: [ok({ success: true })], remaining: ['b1'] });
+    const out = await unbookRun({ client, rows: [bookedRow(1, 'b1')] });
+
+    expect(out.ok).toBe(false);
+    expect(out.outcome).toBe('still-booked');
+    expect(out.stillBooked).toEqual(['b1']);
+    expect(out.verified).toBe(false);
+    expect(out.message).toMatch(/still/i);
+  });
+
+  it('does not claim success when the verifying read itself fails', async () => {
+    const client = clientWith({
+      remaining: reply({ ok: false, status: 500, message: 'upstream is unwell' }),
+    });
+    const out = await unbookRun({ client, rows: [bookedRow(1, 'b1')] });
+
+    expect(out.ok).toBe(false);
+    expect(out.outcome).toBe('unverified');
+    expect(out.reason).toBe('bookings-unread');
+    expect(out.cancelled).toBe(1);
+    expect(out.verified).toBe(false);
+  });
+
+  it('does not re-read when there was nothing to cancel', async () => {
+    // The read costs a request against a gym-wide allowance and can conclude
+    // nothing: no cancel was attempted, so there is no claim to verify.
+    const client = clientWith();
+    const out = await unbookRun({ client, rows: [alreadyBookedRow(1)] });
+
+    expect(client.calls).toEqual([]);
+    expect(out.verified).toBe(false);
+  });
+});
+
+describe('unbookRun — partial and failed cancels', () => {
+  it('keeps going after one cancel fails, and reports the leftover', async () => {
+    // A student half-rolled-back is worse than one fully rolled back, and the
+    // failures have to be nameable so a human can finish them.
+    const client = clientWith({
+      deletes: [reply({ ok: false, status: 500, message: 'nope' }), ok({ success: true })],
+      remaining: ['b1'],
+    });
+    const out = await unbookRun({ client, rows: [bookedRow(1, 'b1'), bookedRow(2, 'b2')] });
+
+    expect(out.cancelled).toBe(1);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0].booking_id).toBe('b1');
+    expect(out.outcome).toBe('partial');
+    expect(out.ok).toBe(false);
+  });
+
+  it('names a booked row that has no booking id as one to undo by hand', async () => {
+    const client = clientWith();
+    const out = await unbookRun({
+      client,
+      rows: [{ event_id: 7, state: 'booked', booking_id: null, contact_key: 'ck-1' }],
+    });
+
+    expect(out.cancelled).toBe(0);
+    expect(out.failed[0].reason).toMatch(/by hand/);
+    expect(out.ok).toBe(false);
+  });
+
+  it('reports a throttle as throttled, so the page pauses the whole run', async () => {
+    // §11 — the allowance is gym-wide, so a 429 pauses the run rather than one
+    // row. Backing off a single row while the others continue just spends the
+    // next window failing.
+    const client = clientWith({ deletes: [reply({ ok: false, status: 429 })] });
+    const out = await unbookRun({ client, rows: [bookedRow(1, 'b1')] });
+
+    expect(out.reason).toBe('throttled');
+    expect(out.cancelled).toBe(0);
+    expect(out.ok).toBe(false);
+  });
+
+  it('counts every request it spent', async () => {
+    const client = clientWith({ remaining: [] });
+    const out = await unbookRun({ client, rows: [bookedRow(1, 'b1'), bookedRow(2, 'b2')] });
+
+    // Two deletes and the verifying read.
+    expect(out.requests).toBe(3);
+  });
+});

--- a/cloudflare-clubworx/test/unbook.test.js
+++ b/cloudflare-clubworx/test/unbook.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { ALREADY_BOOKED_STATE, BOOKED } from '../src/bookings.js';
 import { unbookRun } from '../src/unbook.js';
 
 /** A stub with the shape `createClubworxClient` hands back. */
@@ -44,16 +45,19 @@ const clientWith = ({ deletes = [ok({ success: true })], remaining = [] } = {}) 
   };
 };
 
+// The constants, never the literals. `BOOKED` and `ALREADY_BOOKED_STATE` differ
+// by one character, and a test that types them by hand is the one place a slip
+// would assert the interlock while exercising the wrong state.
 const bookedRow = (eventId, bookingId, contactKey = 'ck-1') => ({
   event_id: eventId,
-  state: 'booked',
+  state: BOOKED,
   booking_id: bookingId,
   contact_key: contactKey,
 });
 
 const alreadyBookedRow = (eventId, contactKey = 'ck-1') => ({
   event_id: eventId,
-  state: 'already booked',
+  state: ALREADY_BOOKED_STATE,
   booking_id: null,
   contact_key: contactKey,
 });
@@ -102,7 +106,7 @@ describe('unbookRun — what it refuses before touching anything', () => {
     const out = await unbookRun({
       client,
       contactKey: 'ck-1',
-      rows: [{ event_id: 1, state: 'booked', booking_id: 'b1', contact_key: null }],
+      rows: [{ event_id: 1, state: BOOKED, booking_id: 'b1', contact_key: null }],
     });
 
     expect(out.cancelled).toBe(0);
@@ -175,7 +179,7 @@ describe('unbookRun — verification is a re-read, never the 200', () => {
 
     const read = client.calls.find(c => c.method === 'GET');
     expect(read.path).toBe('bookings');
-    expect(read.params).toEqual({ contact_key: 'ck-1' });
+    expect(read.params).toMatchObject({ contact_key: 'ck-1' });
     expect(out.verified).toBe(true);
     expect(out.outcome).toBe('cancelled');
     expect(out.ok).toBe(true);
@@ -239,12 +243,41 @@ describe('unbookRun — partial and failed cancels', () => {
     const client = clientWith();
     const out = await unbookRun({
       client,
-      rows: [{ event_id: 7, state: 'booked', booking_id: null, contact_key: 'ck-1' }],
+      rows: [{ event_id: 7, state: BOOKED, booking_id: null, contact_key: 'ck-1' }],
     });
 
     expect(out.cancelled).toBe(0);
     expect(out.failed[0].reason).toMatch(/by hand/);
     expect(out.ok).toBe(false);
+  });
+
+  it('stops on a throttle rather than spending the rest of a gym-wide allowance', async () => {
+    // §11 — the allowance is shared with the roster Worker and n8n, so firing
+    // the remaining rows into a window that is already refusing both wastes it
+    // and reports cancellable bookings as needing a human.
+    const client = clientWith({ deletes: [reply({ ok: false, status: 429 })] });
+    const out = await unbookRun({
+      client,
+      rows: [bookedRow(1, 'b1'), bookedRow(2, 'b2'), bookedRow(3, 'b3')],
+    });
+
+    expect(client.calls.filter(c => c.method === 'DELETE')).toHaveLength(1);
+    expect(out.failed.filter(f => f.attempted === false)).toHaveLength(2);
+    expect(out.reason).toBe('throttled');
+  });
+
+  it('will not report a cancel confirmed off a re-read it could not finish', async () => {
+    // A full page is an unfinished list, and absence from an unfinished list
+    // proves nothing. "Cancelled" and "probably cancelled" send an operator to
+    // different places.
+    const full = Array.from({ length: 200 }, (_, i) => ({ booking_id: `x${i}`, event_id: i }));
+    const client = clientWith({ remaining: full });
+    const out = await unbookRun({ client, rows: [bookedRow(1, 'b1')] });
+
+    expect(out.cancelled).toBe(1);
+    expect(out.verified).toBe(false);
+    expect(out.outcome).toBe('unverified');
+    expect(out.reason).toBe('bookings-truncated');
   });
 
   it('reports a throttle as throttled, so the page pauses the whole run', async () => {

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -1094,7 +1094,11 @@ describe('POST /unbook', () => {
     const res = await h.call('/api/clubworx/unbook', post({ contact_key: 'ck-1' }));
 
     expect(res.status).toBe(400);
-    expect((await res.json()).reason).toBe('bad-request');
+    const body = await res.json();
+    expect(body.reason).toBe('bad-request');
+    // The documented `outcome` vocabulary holds on every answer, including this
+    // one. A field present only sometimes is one a client stops checking.
+    expect(body.outcome).toBe('refused');
     expect(ran).toBe(false);
   });
 

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -152,12 +152,12 @@ describe('GET /health', () => {
   });
 });
 
-describe('routes not built yet', () => {
-  it('answers 404 for an authenticated call to a route this ticket does not add', async () => {
-    // #67 added events, plan and schools; #70 adds unbook. Until then a 404 is
-    // the honest answer — not a 500, and not a silent 200.
+describe('routes that do not exist', () => {
+  it('answers 404 for an authenticated call to a route this Worker does not have', async () => {
+    // Every route the design names is built. A 404 here is the honest answer
+    // for anything else — not a 500, and not a silent 200.
     const h = handlerWith(accepts('staff@urbanjungleirc.com'));
-    const res = await h.call('/api/clubworx/unbook', { ...withJwt, method: 'POST' });
+    const res = await h.call('/api/clubworx/refund', { ...withJwt, method: 'POST' });
 
     expect(res.status).toBe(404);
     expect((await res.json()).error).toBe('not found');
@@ -967,6 +967,235 @@ describe('the #67 read routes', () => {
   it('answers no-store, like every other route on this Worker', async () => {
     const h = handlerWith(accepts(OPERATOR), { readSchools: stub({ ok: true, schools: [], requests: 3 }) });
     const res = await h.call('/api/clubworx/schools', withJwt);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+});
+
+describe('POST /unbook', () => {
+  const OPERATOR = 'staff@urbanjungleirc.com';
+
+  const ROWS = [
+    { event_id: 101, state: 'booked', booking_id: 'b1', contact_key: 'ck-1' },
+    { event_id: 102, state: 'already booked', booking_id: null, contact_key: 'ck-1' },
+  ];
+
+  const post = (body = { contact_key: 'ck-1', bookings: ROWS }) => ({
+    method: 'POST',
+    headers: { ...withJwt.headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const cancels = over => async () => ({
+    ok: true,
+    outcome: 'cancelled',
+    reason: null,
+    message: '1 booking(s) cancelled, confirmed by re-reading this contact’s bookings.',
+    contact_key: 'ck-1',
+    cancelled: 1,
+    cancelledIds: ['b1'],
+    skipped: 1,
+    failed: [],
+    stillBooked: [],
+    verified: true,
+    requests: 2,
+    ...over,
+  });
+
+  it('needs POST — a GET must not be able to cancel anything', async () => {
+    const h = handlerWith(accepts(OPERATOR), { unbook: cancels() });
+    expect((await h.call('/api/clubworx/unbook', withJwt)).status).toBe(405);
+  });
+
+  it('runs behind the Access gate like every other route', async () => {
+    let ran = false;
+    const h = handlerWith(rejects('expired'), {
+      unbook: async () => {
+        ran = true;
+        return {};
+      },
+    });
+
+    const res = await h.call('/api/clubworx/unbook', post());
+
+    expect(res.status).toBe(401);
+    expect(ran).toBe(false);
+  });
+
+  it('refuses a body that is not JSON, without touching Clubworx', async () => {
+    let ran = false;
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: async () => {
+        ran = true;
+        return {};
+      },
+    });
+
+    const res = await h.call('/api/clubworx/unbook', {
+      method: 'POST',
+      headers: { ...withJwt.headers, 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+
+    expect(res.status).toBe(400);
+    expect(ran).toBe(false);
+  });
+
+  it('tells a missing secret apart from a Clubworx refusal', async () => {
+    const h = handlerWith(accepts(OPERATOR), {
+      env: { ...ENV, CLUBWORX_ACCOUNT_KEY: '' },
+      unbook: cancels(),
+    });
+
+    const res = await h.call('/api/clubworx/unbook', post());
+
+    expect(res.status).toBe(503);
+    expect((await res.json()).reason).toBe('not-configured');
+  });
+
+  it('passes the rows and the contact through as the page sent them', async () => {
+    let seen = null;
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: async args => {
+        seen = args;
+        return cancels()();
+      },
+    });
+
+    await h.call('/api/clubworx/unbook', post());
+
+    expect(seen.rows).toEqual(ROWS);
+    expect(seen.contactKey).toBe('ck-1');
+  });
+
+  it('accepts a call with no contact_key, because the rows carry their own', async () => {
+    let seen = null;
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: async args => {
+        seen = args;
+        return cancels()();
+      },
+    });
+
+    const res = await h.call('/api/clubworx/unbook', post({ bookings: ROWS }));
+
+    expect(res.status).toBe(200);
+    expect(seen.contactKey).toBe(null);
+  });
+
+  it('refuses a body with no bookings list before anything is sent', async () => {
+    let ran = false;
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: async () => {
+        ran = true;
+        return {};
+      },
+    });
+
+    const res = await h.call('/api/clubworx/unbook', post({ contact_key: 'ck-1' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).reason).toBe('bad-request');
+    expect(ran).toBe(false);
+  });
+
+  it('hands the whole result back on a clean cancel', async () => {
+    const h = handlerWith(accepts(OPERATOR), { unbook: cancels() });
+    const res = await h.call('/api/clubworx/unbook', post());
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.outcome).toBe('cancelled');
+    expect(body.cancelled).toBe(1);
+    expect(body.verified).toBe(true);
+  });
+
+  it('answers 200 for a partial cancel — the leftover list IS the record', async () => {
+    // A student half-rolled-back needs finishing by hand, and the rows naming
+    // which bookings are left are the only record of that. A 4xx invites a
+    // client to throw the body away.
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: cancels({
+        ok: false,
+        outcome: 'partial',
+        reason: 'cancel-failed',
+        cancelled: 1,
+        failed: [{ event_id: 103, booking_id: 'b3', reason: 'HTTP 500', upstreamStatus: 500 }],
+      }),
+    });
+
+    const res = await h.call('/api/clubworx/unbook', post());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).failed).toHaveLength(1);
+  });
+
+  it('answers 200 with the leftovers when a cancel was accepted but did not apply', async () => {
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: cancels({
+        ok: false,
+        outcome: 'still-booked',
+        reason: 'cancel-not-applied',
+        stillBooked: ['b1'],
+        verified: false,
+      }),
+    });
+
+    const res = await h.call('/api/clubworx/unbook', post());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).stillBooked).toEqual(['b1']);
+  });
+
+  it('answers 400 for a refusal that happened before any cancel', async () => {
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: cancels({ ok: false, outcome: 'refused', reason: 'mixed-contacts', cancelled: 0 }),
+    });
+
+    const res = await h.call('/api/clubworx/unbook', post());
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).reason).toBe('mixed-contacts');
+  });
+
+  it('answers 429 for a throttle that cancelled nothing, so the run pauses', async () => {
+    // §11 — the allowance is gym-wide, so a throttle pauses the whole run
+    // rather than one row, and the page needs it where it cannot be missed.
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: cancels({ ok: false, outcome: 'failed', reason: 'throttled', cancelled: 0, cancelledIds: [] }),
+    });
+
+    expect((await h.call('/api/clubworx/unbook', post())).status).toBe(429);
+  });
+
+  it('answers 200 for a throttle that had already cancelled something', async () => {
+    // Once a cancel has landed there is a row to record, and a non-200 invites
+    // a client to throw the body away. `reason: "throttled"` is still in it.
+    const h = handlerWith(accepts(OPERATOR), {
+      unbook: cancels({ ok: false, outcome: 'partial', reason: 'throttled', cancelled: 1, cancelledIds: ['b1'] }),
+    });
+
+    const res = await h.call('/api/clubworx/unbook', post());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).reason).toBe('throttled');
+  });
+
+  it('logs the operator and the outcome, and never a contact key or a body', async () => {
+    const h = handlerWith(accepts(OPERATOR), { unbook: cancels() });
+    await h.call('/api/clubworx/unbook', post());
+
+    const line = JSON.parse(h.lines[0]);
+    expect(line.route).toBe('/api/clubworx/unbook');
+    expect(line.method).toBe('POST');
+    expect(line.email).toBe(OPERATOR);
+    expect(line.outcome).toBe('cancelled');
+    expect(h.lines.join('\n')).not.toContain('ck-1');
+    expect(h.lines.join('\n')).not.toContain(ENV.CLUBWORX_ACCOUNT_KEY);
+  });
+
+  it('answers no-store, like every other route on this Worker', async () => {
+    const h = handlerWith(accepts(OPERATOR), { unbook: cancels() });
+    const res = await h.call('/api/clubworx/unbook', post());
     expect(res.headers.get('Cache-Control')).toBe('no-store');
   });
 });


### PR DESCRIPTION
Closes #70. Part of #46. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §11, §12.

`POST /api/clubworx/unbook` — **the only reversal this system has.** Bookings can be cancelled; contacts and School Passes have no delete at all, so a caller gets its bookings back and nothing else.

## The three properties this is actually about

**The interlock.** Acts on rows marked `booked`, never on `already booked`. Booking is idempotent, so a re-run marks rows that way — a cancel scoped to the whole row set would delete bookings *this run did not create*, possibly a session a real member booked themselves (#50's worst outcome on this map). No flag relaxes it: a rollback path with no human present is exactly the caller that would set one.

**`contact_key` comes from the booking row, never the caller.** Omitting it answers `401 "Authorization failed"`, indistinguishable from a key without delete permission and misdiagnosed as exactly that for a week in #50. A caller-supplied key can also be a *different student's*, which points a DELETE at somebody else's class.

**A 200 proves nothing.** #60 established the reversal by re-count — 1 booking before, 0 after — because a status code cannot show a DELETE that was accepted and changed nothing.

## What the two-axis review changed

The first pass shipped three real defects, all fixed in `d9ed537`:

- **Verification could pass vacuously.** It matched only on booking id via `bookingIdOf`, which tolerates several shapes because the create response was never documented. A list row carrying none of them produced an empty id list, an empty `stillBooked`, and `verified: true` — having proved nothing. It now matches on the **event** too, the field `student.js` already relies on for this endpoint.
- **A truncated re-read read as "gone".** `readBookings` fetched one unpaged page; a full page is an unfinished list and absence from one proves nothing. It now walks with `paging.js`; truncation yields `unverified`. This closes the mirror bug in #69's landed-check.
- **A 429 was labelled, not obeyed.** §11 pauses the whole run on a throttle; the loop kept firing DELETEs into a refusing window, spending a gym-wide allowance to report cancellable bookings as needing a human. It now halts and marks the rest `attempted: false`.

Verification moved from the route into `cancelRunBookings` where the interlock already lives — **D3's automatic rollback needs it and is not a route**, so the caller with no human present was the one still trusting a 200.

## Scope note

One contact per call; a set spanning two students is refused before anything is sent. §6 sizes a run at 25 × 6, so a whole-run cancel is up to 150 DELETEs plus per-student re-reads at ~800 ms pacing — minutes in one invocation, the same shape D1 rejected, with the same failure mode: writes land, log lost. #73 loops, the way it already loops to apply.

## Verification

- 628 tests passing across 24 files (621 on `main`); 16 new in `test/unbook.test.js`, 15 new route tests.
- No overlap with the in-flight #97 branch — disjoint file sets, and its only `src/` change is comment-only.

## Deploy

Pages publishes on merge as usual. **The Worker deploys separately** — `cd cloudflare-clubworx && npx wrangler deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn