### PR TITLE
Probe #97: GET /events/:id is not a route

### DIFF
--- a/cloudflare-clubworx/package.json
+++ b/cloudflare-clubworx/package.json
@@ -10,7 +10,8 @@
     "probe:51": "node probes/run-51.mjs",
     "probe:49": "node probes/run-49.mjs",
     "probe:60": "node probes/run-60.mjs",
-    "probe:63": "node probes/run-63.mjs"
+    "probe:63": "node probes/run-63.mjs",
+    "probe:97": "node probes/run-97.mjs"
   },
   "devDependencies": {
     "vitest": "^2.1.0",

--- a/cloudflare-clubworx/probes/97-events-by-id.md
+++ b/cloudflare-clubworx/probes/97-events-by-id.md
@@ -1,0 +1,139 @@
+# `GET /events/:id` is not a route — the answer to #97
+
+Probed against production Clubworx on **2026-08-21**, read-only, 4 GETs per run,
+three runs. Answers [#97](https://github.com/urbanjungleirc/staff-site/issues/97),
+which asked whether the paste-the-event-id fallback [#67](https://github.com/urbanjungleirc/staff-site/issues/67)
+shipped actually works against production.
+
+**It does not.** `GET /api/v2/events/<id>` answers **HTTP 404** with
+`{"status": 404, "error": "Not Found"}` — for a real event id, for an invented
+one, with the date window and without it. There is no such route.
+`resolveEvent` in `../src/events.js` cannot succeed as written, and the paste
+field on [#54](https://github.com/urbanjungleirc/staff-site/issues/54) has no
+Worker-side route behind it.
+
+| | Question | Answer |
+|---|---|---|
+| 1 | Is `GET /events/:id` a route? | **No** — 404, `"Not Found"` |
+| 2 | Bare object, or one-element array? | **Neither** — an error envelope, fields `status` and `error` |
+| 3 | What does a non-existent id answer? | **The same 404** — indistinguishable from a real one |
+| 4 | Does the date window requirement follow to the addressed form? | **Unanswerable** — nothing resolves either way |
+| 5 | Does #67's `resolveEvent` survive it? | **No** |
+
+Nothing was written. The only verb issued was GET.
+
+## What was measured
+
+Seed listing, `GET /events?event_starts_after=2026-08-20&event_ends_before=2026-08-24&page_size=50`:
+**HTTP 200**, 44 events, page not full, so the listing is complete rather than
+truncated (#51's rule). First future event id **20013052**, starting
+`2026-08-21T16:00:00.000+08:00`.
+
+Then the three addressed calls:
+
+```
+GET /events/20013052?event_starts_after=…&event_ends_before=…&page_size=50   404   1332ms
+GET /events/999999999?event_starts_after=…&event_ends_before=…&page_size=50  404    286ms
+GET /events/20013052?page_size=50                                            404    283ms
+```
+
+Body, identical in all three, `content-type: application/json; charset=UTF-8`:
+
+```json
+{"status": 404, "error": "Not Found"}
+```
+
+Reproduced on three separate runs, including one over a 60-day window whose
+listing came back full at 50. The window makes no difference; nothing about the
+window was ever the problem.
+
+### The 404 is the router's, not the database's
+
+The two calls that follow a warmed connection answer in **~285ms**, against
+**~1,950ms** for the `/events` collection read beside them. Clubworx is not
+looking anything up and failing to find it — it is declining to route the
+request at all. The identical answer for id `999999999` and for a real,
+currently-listed event id says the same thing from the other direction: nothing
+here is reading the id.
+
+That is why the write-up says *there is no route* rather than *the event could
+not be found*. The distinction is the whole finding.
+
+## Path addressing exists in this API — just not here
+
+`DELETE /bookings/:id` was measured working in [#60](60-member-school-pass-booking.md).
+So Clubworx does address individual records by path, which is exactly why
+`events/:id` was a reasonable guess, and exactly why it had to be checked rather
+than assumed. The API's shape is **inconsistent between resources**, and no part
+of the published reference says so.
+
+The general lesson for this map is the one #50 already paid for: *an endpoint
+nobody has completed is unproven*, and a plausible pattern from a neighbouring
+resource is not evidence about this one.
+
+## What a staff member sees today
+
+The route is deployed. `GET /api/clubworx/events?event_id=<anything>` currently
+returns:
+
+```json
+{"error": "Not Found", "reason": "upstream-error", "upstreamStatus": 404}
+```
+
+`errorMessageOf` reads Clubworx's `error` field, `upstreamMessage` passes it
+through verbatim per D6 — and the result is that a staff member who pastes a
+perfectly valid event id is told **"Not Found"**. That reads as *"the event
+doesn't exist"*, not *"this feature has never worked"*, which is the more
+expensive of the two misreadings: it sends someone to check the id they already
+know is right.
+
+Nothing here is a fault in the error handling. Every layer reported honestly
+what it received; the request underneath it was addressed to a route that does
+not exist.
+
+## What this leaves open
+
+#97 closes; the follow-up is a **decision on #54**, and it is not this ticket's
+to make. The issue states both options:
+
+- **Resolve the pasted id page-side**, from the window the picker already holds.
+  The listing is already on screen, and #67 rejected the Worker re-walking that
+  window — up to `MAX_PAGES` requests of a gym-wide 75/min allowance to find an
+  id the page can already see. Nothing in this measurement changes that
+  reasoning; it removes the alternative.
+- **Drop the field.**
+
+What the measurement does settle is that the third option — the one currently
+deployed — is not an option. A field wired to a 404 is worse than no field: it
+looks like a working escape hatch until somebody needs it.
+
+Note also what page-side resolution *is not*. The paste field was justified as
+insurance against the search being unhelpful — a name filtered out, a truncated
+window, a long timetable. Resolving from the window the page holds keeps exactly
+that much and no more: if the id is outside the window, the page does not have
+it either. It never survived `/events` being enforced against its own
+documentation (#51), and `resolveEvent`'s header already says so.
+
+## Reproducing
+
+```bash
+cd cloudflare-clubworx
+node probes/run-97.mjs --dry-run    # the 4 calls, no network, no key needed
+node probes/run-97.mjs              # ~4 reads
+node probes/run-97.mjs --days=30 --missing-id=123456789
+```
+
+`probes/lib/report.mjs`'s `describeEventById` is the part with the judgement in
+it, and it is unit-tested. Three of its rules were written because a draft got
+them wrong in a way that would have produced a confident, false finding:
+
+- A one-element array carrying the right id **is not proof**. If the path
+  segment were ignored and the window held exactly one event, a collection read
+  and a genuine resolution would be byte-identical. It needs corroboration — a
+  made-up id that answers differently, or a collection wider than what came
+  back.
+- A `401` leaves the verdict **null, never false**. #50 read a refusal as a
+  permissions wall and lost an architectural route for a week.
+- `resolveEvent` sends **no date window**, so the windowless call is the one that
+  answers for the shipped code. Had `events/:id` turned out to need a window, the
+  route would have been reported as working while 422-ing in production.

--- a/cloudflare-clubworx/probes/97-events-by-id.md
+++ b/cloudflare-clubworx/probes/97-events-by-id.md
@@ -5,9 +5,10 @@ three runs. Answers [#97](https://github.com/urbanjungleirc/staff-site/issues/97
 which asked whether the paste-the-event-id fallback [#67](https://github.com/urbanjungleirc/staff-site/issues/67)
 shipped actually works against production.
 
-**It does not.** `GET /api/v2/events/<id>` answers **HTTP 404** with
-`{"status": 404, "error": "Not Found"}` — for a real event id, for an invented
-one, with the date window and without it. There is no such route.
+**It does not.** `GET /api/v2/events/<id>` answers **HTTP 404**, with a JSON body
+carrying two fields — `status` and `error` — and an error message of
+`"Not Found"`. For a real event id, for an invented one, with the date window
+and without it. There is no such route.
 `resolveEvent` in `../src/events.js` cannot succeed as written, and the paste
 field on [#54](https://github.com/urbanjungleirc/staff-site/issues/54) has no
 Worker-side route behind it.
@@ -37,27 +38,53 @@ GET /events/999999999?event_starts_after=…&event_ends_before=…&page_size=50 
 GET /events/20013052?page_size=50                                            404    283ms
 ```
 
-Body, identical in all three, `content-type: application/json; charset=UTF-8`:
+Body shape, `content-type: application/json; charset=UTF-8` on all three — field
+**names** and the error message, which is all the summariser records:
 
-```json
-{"status": 404, "error": "Not Found"}
+```
+fields: ["status", "error"]     error message: "Not Found"
 ```
 
-Reproduced on three separate runs, including one over a 60-day window whose
-listing came back full at 50. The window makes no difference; nothing about the
-window was ever the problem.
+The `status` field's *value* is not recorded — the summariser reduces a body to
+field names before anything is written — so this document does not quote a
+literal body it cannot show evidence for.
 
-### The 404 is the router's, not the database's
+### What reproduced, and what did not
 
-The two calls that follow a warmed connection answer in **~285ms**, against
-**~1,950ms** for the `/events` collection read beside them. Clubworx is not
-looking anything up and failing to find it — it is declining to route the
-request at all. The identical answer for id `999999999` and for a real,
-currently-listed event id says the same thing from the other direction: nothing
-here is reading the id.
+The **network behaviour** reproduced on all three runs: 404 on every addressed
+call, every time, including one run over a 60-day window whose listing came back
+full at 50. The window makes no difference; nothing about the window was ever
+the problem.
 
-That is why the write-up says *there is no route* rather than *the event could
-not be found*. The distinction is the whole finding.
+The **derived findings did not**, and the records say so.
+`probes/lib/report.mjs` was still being fixed between runs — three of its fields
+reported confident values about an absent route before the gates went in. Run 1
+has no `refusal` key at all and `windowRequired: true`; run 2 still has
+`discriminates: true`. **Only run 3 corresponds to the shipped classifier.**
+Runs 2 and 3 used `--days=3`; the default is 14.
+
+The finding stands on the network facts, which are identical across all three.
+
+### The 404 does not look like a lookup failing
+
+Two lines of evidence, and they are not equally strong.
+
+**The strong one.** A real, currently-listed event id and `999999999` come back
+identical — same status, same body shape, same message. Whatever answers is not
+reading the id, so it cannot be looking something up and failing to find it.
+This carries the finding on its own.
+
+**The weak one, recorded for completeness.** Calls 3 and 4 answer in ~225–300ms
+against ~1,850–1,965ms for the `/events` collection read. That looks like a
+router rejection — but the *first* addressed call took **1,222 / 1,332 /
+1,311ms** across the three runs, never ~285ms, and the fast pair always follows
+it on a warmed connection. The comparison is confounded by payload size too:
+44–50 rows against a two-field error envelope. The timings are **consistent
+with** a routing refusal; they are not evidence for it, and nothing here rests
+on them.
+
+So the finding is *there is no route* rather than *the event could not be
+found* — resting on the identical answers, not on the clock.
 
 ## Path addressing exists in this API — just not here
 
@@ -74,22 +101,32 @@ resource is not evidence about this one.
 ## What a staff member sees today
 
 The route is deployed. `GET /api/clubworx/events?event_id=<anything>` currently
-returns:
+returns **HTTP 502**:
 
 ```json
-{"error": "Not Found", "reason": "upstream-error", "upstreamStatus": 404}
+{"error": "Not Found", "reason": "upstream-error", "upstreamStatus": 404, "view": null}
 ```
 
-`errorMessageOf` reads Clubworx's `error` field, `upstreamMessage` passes it
-through verbatim per D6 — and the result is that a staff member who pastes a
-perfectly valid event id is told **"Not Found"**. That reads as *"the event
-doesn't exist"*, not *"this feature has never worked"*, which is the more
-expensive of the two misreadings: it sends someone to check the id they already
-know is right.
+Traced rather than assumed: `resolveEvent` fails at `!res.ok`, so the reason is
+`upstreamReason(res)` → `'upstream-error'`, which is not in `index.js`'s
+`REFUSALS` set, so `readStatus` maps it to **502**. `readFailure` adds
+`view: null` unconditionally.
+
+Two things follow. The **502 is honest** — it says the upstream failed, which is
+true, and a page treating 5xx as "something is broken" will do the right thing.
+But the **`error` string is not**: `upstreamMessage` passes Clubworx's own
+`"Not Found"` through verbatim per D6, so any surface that shows the message
+rather than the status tells a staff member who pasted a perfectly valid id that
+it was **not found**. That is the more expensive misreading — it sends someone
+to re-check an id that was correct.
+
+Worth noting: `resolveEvent`'s own `'event-not-found'` reason — the one that
+would map to a 400 — is **unreachable in production**. It is only returned after
+a successful upstream read, and there are none.
 
 Nothing here is a fault in the error handling. Every layer reported honestly
-what it received; the request underneath it was addressed to a route that does
-not exist.
+what it received; the request underneath was addressed to a route that does not
+exist.
 
 ## What this leaves open
 
@@ -98,8 +135,8 @@ to make. The issue states both options:
 
 - **Resolve the pasted id page-side**, from the window the picker already holds.
   The listing is already on screen, and #67 rejected the Worker re-walking that
-  window — up to `MAX_PAGES` requests of a gym-wide 75/min allowance to find an
-  id the page can already see. Nothing in this measurement changes that
+  window — up to **10** requests (`MAX_PAGES`) of a gym-wide 75/min allowance to
+  find an id the page can already see. Nothing in this measurement changes that
   reasoning; it removes the alternative.
 - **Drop the field.**
 
@@ -119,7 +156,8 @@ documentation (#51), and `resolveEvent`'s header already says so.
 ```bash
 cd cloudflare-clubworx
 node probes/run-97.mjs --dry-run    # the 4 calls, no network, no key needed
-node probes/run-97.mjs              # ~4 reads
+node probes/run-97.mjs              # 4 reads, 14-day window
+node probes/run-97.mjs --days=3     # the window these runs used
 node probes/run-97.mjs --days=30 --missing-id=123456789
 ```
 

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -62,6 +62,7 @@ node probes/run-63.mjs --encoding=form       # force the body shape rather than 
 
 node probes/run-97.mjs --dry-run     # the 4 calls, zero network — and no key needed
 node probes/run-97.mjs               # read-only: is events/:id a route, and what shape
+node probes/run-97.mjs --days=3      # how far ahead to look for one real event (default 14)
 node probes/run-97.mjs --missing-id=<id>     # choose the id that should not exist
 
 npm test                             # the pure logic, no network

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -17,8 +17,7 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-60.mjs` | The probe that produced it — **writes, and deletes** |
 | `63-member-creation.md` | [#63](https://github.com/urbanjungleirc/staff-site/issues/63) — the gate on the #46 build: does `POST /api/v2/members` create a contact, is it bookable, and can the School Pass ride along on the create call |
 | `run-63.mjs` | The probe that produced it — **creates contacts, assigns passes, books and cancels** |
-| `97-events-by-id.md` | [#97](https://github.com/urbanjungleirc/staff-site/issues/97) — is `GET /events/:id` a route, and does #67's paste-the-id fallback survive whatever it is |
-| `run-97.mjs` | The probe that produced it — read-only, 4 reads |
+| `run-97.mjs` | [#97](https://github.com/urbanjungleirc/staff-site/issues/97) — is `GET /events/:id` a route, and does #67's paste-the-id fallback survive whatever it is. Read-only, 4 reads. **Not yet run** — see below |
 
 A file's number is the issue it answers, so `63-member-creation.md` belongs to
 [#63](https://github.com/urbanjungleirc/staff-site/issues/63). That ticket's own
@@ -176,6 +175,21 @@ which is the one place these runners differ. A dry run is what somebody reads
 *before* deciding to point a script at production, and that reader is the one
 least likely to have a key in place yet; the others refuse to describe
 themselves without one.
+
+### #97 has no write-up yet, and the row above says so
+
+Every other probe here is a script *and* the findings it produced. #97 is the
+script only: it was built on a machine without the key (ACCESS.md §1 — the gym
+key is not recoverable from Cloudflare, and both Workers are behind Access), so
+the four reads have never been issued.
+
+There is deliberately no `97-events-by-id.md` stub. A findings file in a
+directory where every other findings file is measured would be read as measured,
+and the one thing #97 exists to stop is an unverified answer about `events/:id`
+being treated as a verified one. Run `node probes/run-97.mjs`, then write the
+document from what came back — and `../src/events.js`'s `resolveEvent` header,
+which currently says the route is unmeasured, is the second half of that same
+edit.
 
 The two `../src/` entries are not probe files any more. staff-site#66 promoted
 them into the Worker's own module, because the Worker needs exactly the same URL

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -17,6 +17,8 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-60.mjs` | The probe that produced it — **writes, and deletes** |
 | `63-member-creation.md` | [#63](https://github.com/urbanjungleirc/staff-site/issues/63) — the gate on the #46 build: does `POST /api/v2/members` create a contact, is it bookable, and can the School Pass ride along on the create call |
 | `run-63.mjs` | The probe that produced it — **creates contacts, assigns passes, books and cancels** |
+| `97-events-by-id.md` | [#97](https://github.com/urbanjungleirc/staff-site/issues/97) — is `GET /events/:id` a route, and does #67's paste-the-id fallback survive whatever it is |
+| `run-97.mjs` | The probe that produced it — read-only, 4 reads |
 
 A file's number is the issue it answers, so `63-member-creation.md` belongs to
 [#63](https://github.com/urbanjungleirc/staff-site/issues/63). That ticket's own
@@ -57,6 +59,10 @@ node probes/run-63.mjs --dry-run     # the plan and every request, zero network
 node probes/run-63.mjs               # read-only: what exists already, and the plan lookup
 node probes/run-63.mjs --event=<id> --write  # ⚠️ creates up to 2 PERMANENT contacts + 2 passes
 node probes/run-63.mjs --encoding=form       # force the body shape rather than discovering it
+
+node probes/run-97.mjs --dry-run     # the 4 calls, zero network — and no key needed
+node probes/run-97.mjs               # read-only: is events/:id a route, and what shape
+node probes/run-97.mjs --missing-id=<id>     # choose the id that should not exist
 
 npm test                             # the pure logic, no network
 ```
@@ -162,7 +168,14 @@ run-50.mjs        the #50 probe itself — writes and deletes
 run-60.mjs        the #60 probe itself — writes and deletes
 run-63.mjs        the #63 probe itself — creates contacts,
                   assigns passes, books and deletes
+run-97.mjs        the #97 probe itself — read-only
 ```
+
+`run-97.mjs` loads the key **after** its `--dry-run` branch rather than before,
+which is the one place these runners differ. A dry run is what somebody reads
+*before* deciding to point a script at production, and that reader is the one
+least likely to have a key in place yet; the others refuse to describe
+themselves without one.
 
 The two `../src/` entries are not probe files any more. staff-site#66 promoted
 them into the Worker's own module, because the Worker needs exactly the same URL

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -17,7 +17,8 @@ only way to learn how it behaves is to ask it, carefully, in production.
 | `run-60.mjs` | The probe that produced it — **writes, and deletes** |
 | `63-member-creation.md` | [#63](https://github.com/urbanjungleirc/staff-site/issues/63) — the gate on the #46 build: does `POST /api/v2/members` create a contact, is it bookable, and can the School Pass ride along on the create call |
 | `run-63.mjs` | The probe that produced it — **creates contacts, assigns passes, books and cancels** |
-| `run-97.mjs` | [#97](https://github.com/urbanjungleirc/staff-site/issues/97) — is `GET /events/:id` a route, and does #67's paste-the-id fallback survive whatever it is. Read-only, 4 reads. **Not yet run** — see below |
+| `97-events-by-id.md` | [#97](https://github.com/urbanjungleirc/staff-site/issues/97) — **no**, `GET /events/:id` is not a route: a flat `404 "Not Found"` for a real id and an invented one alike, so #67's paste-the-id fallback cannot work |
+| `run-97.mjs` | The probe that produced it — read-only, 4 reads |
 
 A file's number is the issue it answers, so `63-member-creation.md` belongs to
 [#63](https://github.com/urbanjungleirc/staff-site/issues/63). That ticket's own
@@ -176,20 +177,13 @@ which is the one place these runners differ. A dry run is what somebody reads
 least likely to have a key in place yet; the others refuse to describe
 themselves without one.
 
-### #97 has no write-up yet, and the row above says so
+### `events/:id` does not exist, and `DELETE /bookings/:id` does
 
-Every other probe here is a script *and* the findings it produced. #97 is the
-script only: it was built on a machine without the key (ACCESS.md §1 — the gym
-key is not recoverable from Cloudflare, and both Workers are behind Access), so
-the four reads have never been issued.
-
-There is deliberately no `97-events-by-id.md` stub. A findings file in a
-directory where every other findings file is measured would be read as measured,
-and the one thing #97 exists to stop is an unverified answer about `events/:id`
-being treated as a verified one. Run `node probes/run-97.mjs`, then write the
-document from what came back — and `../src/events.js`'s `resolveEvent` header,
-which currently says the route is unmeasured, is the second half of that same
-edit.
+The two facts sit next to each other in this directory and they are the reason
+"it works for that resource" is not evidence here. Clubworx addresses bookings
+by path (#60) and does not address events by path (#97) — same API, same
+version, no note of it in the reference. Anything path-addressed that nobody has
+actually completed is unproven, whatever its neighbours do.
 
 The two `../src/` entries are not probe files any more. staff-site#66 promoted
 them into the Worker's own module, because the Worker needs exactly the same URL

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -9,6 +9,8 @@
  * gitignore rule somebody has to remember.
  */
 
+import { errorMessageOf } from '../../src/errors.js';
+
 /** Nearest-rank percentile. Null for an empty set, so it never prints as NaN. */
 export function percentile(values, p) {
   if (!values.length) return null;
@@ -902,7 +904,13 @@ export function describeEventById({
   // `wantedId` would make a *resolved* fake id look unrecognisable, and report
   // the route as discriminating on exactly the case that proves it does not.
   const missingBehaviour = shapeOf(missing, missingId);
-  const discriminates = missingBehaviour === null ? null : DISCRIMINATION[missingBehaviour] ?? null;
+  // Only askable if the real id resolved. When neither did, the two calls got
+  // the *same* answer and it was the absence of a route — which is not the
+  // route distinguishing them, however much a `404` on a fake id looks like it.
+  const discriminates =
+    missingBehaviour === null || !RESOLVING.has(verdict)
+      ? null
+      : DISCRIMINATION[missingBehaviour] ?? null;
 
   // Is the answer to a real id distinguishable from the collection, or from the
   // answer to an id that does not exist?
@@ -915,10 +923,15 @@ export function describeEventById({
   const narrowerThanCollection =
     Array.isArray(collectionIds) && collectionIds.length > 1 && returnedIds.length < collectionIds.length;
 
-  const confounded =
-    discriminates === false || echoesCollection === true ? true
-    : discriminates === true || narrowerThanCollection || verdict === 'single-object' ? false
-    : null;
+  // Gated on the direct call having resolved at all, like `discriminates` and
+  // `windowRequired` below it. Nothing came back to be told apart from the
+  // collection when nothing came back — and an empty 404 body is trivially
+  // "narrower than the collection", which would otherwise print as corroboration.
+  const confounded = !RESOLVING.has(verdict)
+    ? null
+    : discriminates === false || echoesCollection === true ? true
+      : discriminates === true || narrowerThanCollection || verdict === 'single-object' ? false
+        : null;
 
   // Three states, and the third is the point. `false` is a measured absence;
   // `null` is "this run did not find out" — a refusal, a dropped connection, a
@@ -936,7 +949,14 @@ export function describeEventById({
     : verdict === 'unrecognised' ? null
     : false;
 
-  const windowRequired = windowlessShape === null ? null : !RESOLVING.has(windowlessShape);
+  // Only meaningful if addressing works *with* a window. Against a route that
+  // does not exist both calls fail for the same reason, and reporting `true`
+  // would invent a window requirement out of a plain absence — measured
+  // 2026-08-21, when every addressed call came back 404.
+  const windowRequired =
+    windowlessShape === null || !RESOLVING.has(verdict)
+      ? null
+      : !RESOLVING.has(windowlessShape);
 
   return {
     verdict,
@@ -944,6 +964,11 @@ export function describeEventById({
     resolvesFallback,
     fallbackBasis,
     status: direct?.status ?? null,
+    // The server's complaint about *our own request*, which is the whole answer
+    // when there is no route to describe. `errorMessageOf` is the one bounded
+    // way into a body here — error-shaped fields only, never the record fields
+    // where names and dates of birth live.
+    refusal: errorMessageOf(direct?.body),
     fields: fieldNamesOf(direct?.body),
     returnedIds,
     echoesCollection,

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -848,14 +848,29 @@ export function describeEventById({
   collectionIds = null,
 } = {}) {
   const verdict = shapeOf(direct, wantedId) ?? 'error';
-  const resolvesFallback = RESOLVING.has(verdict);
+  const windowlessShape = shapeOf(windowless, wantedId);
+
+  // `resolveEvent` sends `events/<id>` and **no parameters at all** — no date
+  // window. So the call that answers for the shipped route is the windowless
+  // one, not the windowed one the issue leads with. If `events/:id` resolves
+  // only when a window rides along, the shipped route does not have it, and
+  // reporting the windowed 200 as success would green-light a production
+  // failure. `fallbackBasis` says which call the answer came from, so a
+  // findings document cannot quietly cite the wrong one.
+  const fallbackBasis = windowlessShape === null ? 'windowed' : 'windowless';
+  const resolvesFallback = RESOLVING.has(fallbackBasis === 'windowless' ? windowlessShape : verdict);
 
   // Three states, and the third is the point. `false` is a measured absence;
   // `null` is "this run did not find out", which a refusal or a dropped
   // connection is. Collapsing them would write an unmeasured "no" into the
   // findings.
+  //
+  // Read off the *addressed* call rather than the shipped route's one: "is
+  // `events/:id` a route" and "does #67's code work" are different questions,
+  // and a route that needs a window is a yes to the first and a no to the
+  // second.
   const isRoute =
-    resolvesFallback ? true
+    RESOLVING.has(verdict) ? true
     : verdict === 'refused' || verdict === 'error' || verdict === 'error-status' ? null
     : false;
 
@@ -874,13 +889,13 @@ export function describeEventById({
   const discriminates =
     missingBehaviour === null ? null : !RESOLVING.has(missingBehaviour) && missingBehaviour !== 'collection';
 
-  const windowlessShape = shapeOf(windowless, wantedId);
   const windowRequired = windowlessShape === null ? null : !RESOLVING.has(windowlessShape);
 
   return {
     verdict,
     isRoute,
     resolvesFallback,
+    fallbackBasis,
     status: direct?.status ?? null,
     fields: fieldNamesOf(direct?.body),
     returnedIds,

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -960,6 +960,10 @@ export function describeEventById({
 
   return {
     verdict,
+    // Did the addressed call come back with the event at all? Every gate below
+    // hangs off this, and it is exported so a caller does not have to restate
+    // the rule in its own terms and get it subtly different.
+    resolved: RESOLVING.has(verdict),
     isRoute,
     resolvesFallback,
     fallbackBasis,

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -741,3 +741,155 @@ export function describeCreatedPass({ states = [], on, requested = null } = {}) 
       ` · active ${Boolean(state.active)}`,
   };
 }
+
+/** A bare object and a one-element array are the same one row, read the same way. */
+const rowsOf = body => (Array.isArray(body) ? body : body && typeof body === 'object' ? [body] : []);
+
+/** Field names of whatever came back, in first-seen order. Names only, never values. */
+const fieldNamesOf = body => {
+  const names = new Set();
+  for (const row of rowsOf(body)) for (const name of Object.keys(row ?? {})) names.add(name);
+  return [...names];
+};
+
+/** A pasted id is a string and Clubworx sends a number. Compare as text or nothing matches. */
+const sameEventId = (row, wanted) => String(row?.event_id) === String(wanted);
+
+/**
+ * What a `GET /events/:id` response *is* — a resolved event, or the collection
+ * wearing its clothes.
+ *
+ * Shared by the direct call, the made-up id and the windowless call, so all
+ * three are read by one set of rules rather than three sets that drift.
+ */
+function shapeOf(res, wanted) {
+  if (!res) return null;
+  if (res.error) return 'error';
+
+  const { status, body } = res;
+
+  // #50 is the standing reminder of what reading a 401 as a wall costs: a
+  // malformed request answered "Authorization failed", it was written up as a
+  // permissions problem, and an architectural route was lost for a week.
+  if (status === 401 || status === 403) return 'refused';
+  if (status === 404) return 'not-found';
+  if (status === 422) return 'rejected';
+  if (typeof status !== 'number' || status < 200 || status >= 300) return 'error-status';
+
+  if (Array.isArray(body)) {
+    if (body.length === 0) return 'empty';
+    // One row that is not the row asked for means the path segment was ignored
+    // and the window happened to hold a single event — the collection, not a
+    // resolution.
+    if (body.length === 1 && sameEventId(body[0], wanted)) return 'one-element-array';
+    return 'collection';
+  }
+
+  if (body && typeof body === 'object') {
+    return sameEventId(body, wanted) ? 'single-object' : 'unrecognised';
+  }
+
+  return 'unrecognised';
+}
+
+/** The shapes `resolveEvent` in `../src/events.js` accepts as one confirmed event. */
+const RESOLVING = new Set(['single-object', 'one-element-array']);
+
+const SHAPE_SUMMARY = {
+  'single-object': 'a bare object carrying the id asked for — events/:id resolves',
+  'one-element-array': 'a one-element array carrying the id asked for — events/:id resolves',
+  collection: 'the /events collection — the path segment is ignored, not addressed',
+  empty: 'an empty array — read as a filter that matched nothing, not as an address',
+  'not-found': '404 — there is no events/:id route',
+  rejected: '422 — the request was refused, not the id',
+  refused:
+    'a 401/403. Nothing follows from it: read the endpoint\'s parameters before ' +
+    'concluding a route is absent (#50)',
+  error: 'the request never completed — unmeasured, not absent',
+  'error-status': 'an unexpected status',
+  unrecognised: 'a 2xx body that is neither an event nor a list of them',
+};
+
+/**
+ * staff-site#97 — is `GET /api/v2/events/:id` a route, and does the shipped
+ * paste-the-id fallback survive whatever it is?
+ *
+ * `resolveEvent` was written against both plausible shapes and shipped on #67
+ * without ever being called: every probe up to here read the `/events`
+ * collection. Path addressing does exist in this API (`DELETE /bookings/:id`,
+ * #60), which is why `events/:id` was the guess — but a guess is what #50 cost a
+ * week on, so it gets measured.
+ *
+ * `isRoute` and `resolvesFallback` are separate answers on purpose.
+ * `resolvesFallback` is the one #54 depends on: it is true only for the two
+ * shapes `resolveEvent` accepts *and* only when the row carries the id that was
+ * asked for. A route that answers with the collection is still "a 200", and
+ * reading it as success is exactly how the wrong class would reach an operator
+ * to confirm.
+ *
+ * Nothing here records a row: field **names**, ids and statuses only.
+ *
+ * @param {object} opts
+ * @param {string|number} opts.wantedId The real event id the direct call asked for.
+ * @param {{status: number|null, body: unknown, error: string|null}} opts.direct
+ *   `GET events/<real id>`, inside the date window.
+ * @param {{status: number|null, body: unknown, error: string|null}} [opts.missing]
+ *   `GET events/<an id that does not exist>`. Omitted when that call was not made.
+ * @param {{status: number|null, body: unknown, error: string|null}} [opts.windowless]
+ *   `GET events/<real id>` with no date window. Omitted when that call was not made.
+ * @param {Array<string|number>} [opts.collectionIds] Ids the listing walk held, to
+ *   tell "answered with the collection" from "answered with an event".
+ */
+export function describeEventById({
+  wantedId,
+  direct = null,
+  missing = null,
+  windowless = null,
+  collectionIds = null,
+} = {}) {
+  const verdict = shapeOf(direct, wantedId) ?? 'error';
+  const resolvesFallback = RESOLVING.has(verdict);
+
+  // Three states, and the third is the point. `false` is a measured absence;
+  // `null` is "this run did not find out", which a refusal or a dropped
+  // connection is. Collapsing them would write an unmeasured "no" into the
+  // findings.
+  const isRoute =
+    resolvesFallback ? true
+    : verdict === 'refused' || verdict === 'error' || verdict === 'error-status' ? null
+    : false;
+
+  const returnedIds = rowsOf(direct?.body)
+    .map(r => r?.event_id)
+    .filter(id => id !== null && id !== undefined);
+  const echoesCollection =
+    Array.isArray(collectionIds) && collectionIds.length > 0 && returnedIds.length > 0
+      ? sameIds(returnedIds, collectionIds)
+      : false;
+
+  const missingBehaviour = shapeOf(missing, `${wantedId}-does-not-exist`);
+  // A route that answers a made-up id the same way it answers a real one tells
+  // an operator nothing, and a paste field built on it would confirm anything
+  // typed into it.
+  const discriminates =
+    missingBehaviour === null ? null : !RESOLVING.has(missingBehaviour) && missingBehaviour !== 'collection';
+
+  const windowlessShape = shapeOf(windowless, wantedId);
+  const windowRequired = windowlessShape === null ? null : !RESOLVING.has(windowlessShape);
+
+  return {
+    verdict,
+    isRoute,
+    resolvesFallback,
+    status: direct?.status ?? null,
+    fields: fieldNamesOf(direct?.body),
+    returnedIds,
+    echoesCollection,
+    missingBehaviour,
+    missingStatus: missing?.status ?? null,
+    discriminates,
+    windowRequired,
+    windowlessStatus: windowless?.status ?? null,
+    summary: `HTTP ${direct?.status ?? 'n/a'} · ${SHAPE_SUMMARY[verdict] ?? verdict}`,
+  };
+}

--- a/cloudflare-clubworx/probes/lib/report.mjs
+++ b/cloudflare-clubworx/probes/lib/report.mjs
@@ -795,6 +795,27 @@ function shapeOf(res, wanted) {
 /** The shapes `resolveEvent` in `../src/events.js` accepts as one confirmed event. */
 const RESOLVING = new Set(['single-object', 'one-element-array']);
 
+/**
+ * What a made-up id's answer proves about the route.
+ *
+ * `true` — it told a real id from an invented one, which is what addressing
+ * means. `false` — it answered content for an id that does not exist, so it is
+ * answering *something else* and a paste field on it would confirm anything
+ * typed in. `null` — a refusal or a dropped request, which proves neither.
+ */
+const DISCRIMINATION = {
+  'not-found': true,
+  rejected: true,
+  empty: true,
+  'single-object': false,
+  'one-element-array': false,
+  collection: false,
+  unrecognised: false,
+  refused: null,
+  error: null,
+  'error-status': null,
+};
+
 const SHAPE_SUMMARY = {
   'single-object': 'a bare object carrying the id asked for — events/:id resolves',
   'one-element-array': 'a one-element array carrying the id asked for — events/:id resolves',
@@ -829,8 +850,16 @@ const SHAPE_SUMMARY = {
  *
  * Nothing here records a row: field **names**, ids and statuses only.
  *
+ * `confounded` is the one to read before quoting any of the others. A window
+ * holding exactly one event makes a path-ignoring collection read and a genuine
+ * resolution byte-identical, so "it came back with the right event" is not on
+ * its own an answer — it needs either a made-up id that answers differently, or
+ * a collection wider than what came back.
+ *
  * @param {object} opts
  * @param {string|number} opts.wantedId The real event id the direct call asked for.
+ * @param {string|number} [opts.missingId] The id the made-up call asked for. Read
+ *   `missing` against this, never against `wantedId`.
  * @param {{status: number|null, body: unknown, error: string|null}} opts.direct
  *   `GET events/<real id>`, inside the date window.
  * @param {{status: number|null, body: unknown, error: string|null}} [opts.missing]
@@ -842,6 +871,7 @@ const SHAPE_SUMMARY = {
  */
 export function describeEventById({
   wantedId,
+  missingId = null,
   direct = null,
   missing = null,
   windowless = null,
@@ -860,20 +890,6 @@ export function describeEventById({
   const fallbackBasis = windowlessShape === null ? 'windowed' : 'windowless';
   const resolvesFallback = RESOLVING.has(fallbackBasis === 'windowless' ? windowlessShape : verdict);
 
-  // Three states, and the third is the point. `false` is a measured absence;
-  // `null` is "this run did not find out", which a refusal or a dropped
-  // connection is. Collapsing them would write an unmeasured "no" into the
-  // findings.
-  //
-  // Read off the *addressed* call rather than the shipped route's one: "is
-  // `events/:id` a route" and "does #67's code work" are different questions,
-  // and a route that needs a window is a yes to the first and a no to the
-  // second.
-  const isRoute =
-    RESOLVING.has(verdict) ? true
-    : verdict === 'refused' || verdict === 'error' || verdict === 'error-status' ? null
-    : false;
-
   const returnedIds = rowsOf(direct?.body)
     .map(r => r?.event_id)
     .filter(id => id !== null && id !== undefined);
@@ -882,12 +898,43 @@ export function describeEventById({
       ? sameIds(returnedIds, collectionIds)
       : false;
 
-  const missingBehaviour = shapeOf(missing, `${wantedId}-does-not-exist`);
-  // A route that answers a made-up id the same way it answers a real one tells
-  // an operator nothing, and a paste field built on it would confirm anything
-  // typed into it.
-  const discriminates =
-    missingBehaviour === null ? null : !RESOLVING.has(missingBehaviour) && missingBehaviour !== 'collection';
+  // Read against the id the made-up call actually asked for. Scoring it against
+  // `wantedId` would make a *resolved* fake id look unrecognisable, and report
+  // the route as discriminating on exactly the case that proves it does not.
+  const missingBehaviour = shapeOf(missing, missingId);
+  const discriminates = missingBehaviour === null ? null : DISCRIMINATION[missingBehaviour] ?? null;
+
+  // Is the answer to a real id distinguishable from the collection, or from the
+  // answer to an id that does not exist?
+  //
+  // This is the trap the whole probe turns on. A window holding exactly one
+  // event makes a path-ignoring collection read and a genuine resolution
+  // *byte-identical* — both are a one-element array carrying the id asked for.
+  // A bare object is different: `/events` returns a list, so an object is
+  // evidence in itself.
+  const narrowerThanCollection =
+    Array.isArray(collectionIds) && collectionIds.length > 1 && returnedIds.length < collectionIds.length;
+
+  const confounded =
+    discriminates === false || echoesCollection === true ? true
+    : discriminates === true || narrowerThanCollection || verdict === 'single-object' ? false
+    : null;
+
+  // Three states, and the third is the point. `false` is a measured absence;
+  // `null` is "this run did not find out" — a refusal, a dropped connection, a
+  // 2xx body in a shape nobody has read, or an answer that cannot be told from
+  // the collection. Collapsing any of them into `false` would write an
+  // unmeasured "no" into the findings.
+  //
+  // Read off the *addressed* call rather than the shipped route's one: "is
+  // `events/:id` a route" and "does #67's code work" are different questions,
+  // and a route that needs a window is a yes to the first and a no to the
+  // second.
+  const isRoute =
+    RESOLVING.has(verdict) ? (confounded === null ? null : !confounded)
+    : verdict === 'refused' || verdict === 'error' || verdict === 'error-status' ? null
+    : verdict === 'unrecognised' ? null
+    : false;
 
   const windowRequired = windowlessShape === null ? null : !RESOLVING.has(windowlessShape);
 
@@ -900,6 +947,7 @@ export function describeEventById({
     fields: fieldNamesOf(direct?.body),
     returnedIds,
     echoesCollection,
+    confounded,
     missingBehaviour,
     missingStatus: missing?.status ?? null,
     discriminates,

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -878,6 +878,30 @@ describe('describeEventById', () => {
     expect(out.discriminates).toBeNull();
   });
 
+  it('answers for the shipped route from the windowless call, because that is what it sends', () => {
+    // `resolveEvent` calls `client.get('events/<id>')` with no params at all.
+    // A route that resolves only *with* a window is a route the shipped code
+    // does not have — reporting the windowed 200 as success would green-light
+    // a production failure.
+    const out = describeEventById({
+      wantedId,
+      direct: ok(row()),
+      windowless: { status: 422, body: null, error: null },
+    });
+
+    expect(out.verdict).toBe('single-object');
+    expect(out.isRoute).toBe(true);
+    expect(out.resolvesFallback).toBe(false);
+    expect(out.fallbackBasis).toBe('windowless');
+  });
+
+  it('falls back to the windowed call when the windowless one was not made, and says so', () => {
+    const out = describeEventById({ wantedId, direct: ok(row()) });
+
+    expect(out.resolvesFallback).toBe(true);
+    expect(out.fallbackBasis).toBe('windowed');
+  });
+
   it('reports the date window as not required when the windowless call resolves', () => {
     const out = describeEventById({ wantedId, direct: ok(row()), windowless: ok(row()) });
 

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -1022,4 +1022,49 @@ describe('describeEventById', () => {
 
     expect(out.windowRequired).toBeNull();
   });
+
+  it('leaves the window question open when nothing resolved at all', () => {
+    // Measured 2026-08-21: every addressed call 404s. "Is the window required?"
+    // only means something if addressing works *with* one — against a route
+    // that does not exist, both calls fail for the same reason and reporting
+    // `true` would invent a requirement out of an absence.
+    const notFound = { status: 404, body: { status: 404, error: 'Not Found' }, error: null };
+    const out = describeEventById({ wantedId, direct: notFound, windowless: notFound });
+
+    expect(out.verdict).toBe('not-found');
+    expect(out.windowRequired).toBeNull();
+  });
+
+  it('will not claim a made-up id was told apart when the real one 404d too', () => {
+    // Measured 2026-08-21: both ids answered 404. "It distinguished them" is
+    // not a thing that can be true when neither resolved — they got the same
+    // answer, and that answer was the absence of a route.
+    const notFound = { status: 404, body: { status: 404, error: 'Not Found' }, error: null };
+    const out = describeEventById({
+      wantedId,
+      missingId: 999999999,
+      direct: notFound,
+      missing: notFound,
+    });
+
+    expect(out.missingBehaviour).toBe('not-found');
+    expect(out.discriminates).toBeNull();
+  });
+
+  it('reads the refusal message, which is the answer when the route is absent', () => {
+    const out = describeEventById({
+      wantedId,
+      direct: { status: 404, body: { status: 404, error: 'Not Found' }, error: null },
+    });
+
+    expect(out.refusal).toBe('Not Found');
+  });
+
+  it('reads no message out of a body that carries an event', () => {
+    // `errorMessageOf` is bounded to error-shaped fields; a row must not leak
+    // through it.
+    const out = describeEventById({ wantedId, direct: ok(row()) });
+
+    expect(out.refusal).toBeNull();
+  });
 });

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -759,12 +759,72 @@ describe('describeEventById', () => {
     expect(out.resolvesFallback).toBe(true);
   });
 
-  it('reads a one-element array carrying the asked-for id as a resolving route', () => {
-    const out = describeEventById({ wantedId, direct: ok([row()]) });
+  it('reads a corroborated one-element array as a resolving route', () => {
+    const out = describeEventById({
+      wantedId,
+      direct: ok([row()]),
+      // The window held more than the one row that came back, so the path
+      // segment narrowed it — the collection cannot be what answered.
+      collectionIds: [wantedId, 999, 1000],
+    });
 
     expect(out.verdict).toBe('one-element-array');
     expect(out.isRoute).toBe(true);
+    expect(out.confounded).toBe(false);
     expect(out.resolvesFallback).toBe(true);
+  });
+
+  it('will not call an uncorroborated one-element array a route', () => {
+    // A window holding exactly one event answers a path-ignoring collection
+    // read and a genuine resolution identically. Nothing here can tell them
+    // apart, so nothing here may claim to.
+    const out = describeEventById({ wantedId, direct: ok([row()]) });
+
+    expect(out.verdict).toBe('one-element-array');
+    expect(out.confounded).toBeNull();
+    expect(out.isRoute).toBeNull();
+  });
+
+  it('takes a bare object as evidence in itself — the collection never sends one', () => {
+    const out = describeEventById({ wantedId, direct: ok(row()) });
+
+    expect(out.confounded).toBe(false);
+    expect(out.isRoute).toBe(true);
+  });
+
+  it('refuses to call it a route when a made-up id answers the same way', () => {
+    const out = describeEventById({
+      wantedId,
+      missingId: 999999999,
+      direct: ok([row()]),
+      collectionIds: [wantedId, 999, 1000],
+      missing: ok([row(999999999)]),
+    });
+
+    expect(out.confounded).toBe(true);
+    expect(out.isRoute).toBe(false);
+  });
+
+  it('refuses to call it a route when the rows returned are the whole collection', () => {
+    const out = describeEventById({
+      wantedId,
+      direct: ok([row()]),
+      collectionIds: [wantedId],
+    });
+
+    expect(out.echoesCollection).toBe(true);
+    expect(out.confounded).toBe(true);
+    expect(out.isRoute).toBe(false);
+  });
+
+  it('reads a 2xx body it cannot interpret as unmeasured, not as an absent route', () => {
+    // A single event naming its key `id` rather than `event_id` would land
+    // here. That is a shape nobody has read yet, not a missing route.
+    const out = describeEventById({ wantedId, direct: ok({ id: wantedId, name: 'x' }) });
+
+    expect(out.verdict).toBe('unrecognised');
+    expect(out.isRoute).toBeNull();
+    expect(out.resolvesFallback).toBe(false);
   });
 
   it('matches the id as text, because a pasted id is a string and Clubworx sends a number', () => {
@@ -869,6 +929,45 @@ describe('describeEventById', () => {
 
     expect(out.missingBehaviour).toBe('collection');
     expect(out.discriminates).toBe(false);
+  });
+
+  it('flags a made-up id that resolves as an event — read against the id actually asked for', () => {
+    // The made-up call asked for `missingId`, not `wantedId`. Reading it
+    // against the real id would score a resolved fake as "unrecognised" and
+    // report the route as discriminating on precisely the case that proves it
+    // does not.
+    const out = describeEventById({
+      wantedId,
+      missingId: 999999999,
+      direct: ok(row()),
+      missing: ok(row(999999999)),
+    });
+
+    expect(out.missingBehaviour).toBe('single-object');
+    expect(out.discriminates).toBe(false);
+  });
+
+  it('leaves the made-up id unknown when the answer was a refusal, not an absence', () => {
+    const out = describeEventById({
+      wantedId,
+      missingId: 999999999,
+      direct: ok(row()),
+      missing: { status: 401, body: null, error: null },
+    });
+
+    expect(out.missingBehaviour).toBe('refused');
+    expect(out.discriminates).toBeNull();
+  });
+
+  it('counts an empty answer to a made-up id as discriminating', () => {
+    const out = describeEventById({
+      wantedId,
+      missingId: 999999999,
+      direct: ok(row()),
+      missing: ok([]),
+    });
+
+    expect(out.discriminates).toBe(true);
   });
 
   it('leaves the made-up id unknown when that call was not made', () => {

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -17,6 +17,7 @@ import {
   describeCancellation,
   describeMemberCreation,
   describeCreatedPass,
+  describeEventById,
 } from './report.mjs';
 
 // What a probe is allowed to write down. Everything here is counts, ids, status
@@ -736,5 +737,166 @@ describe('describeCreatedPass', () => {
     expect(r.granted).toBe(true);
     expect(r.spanDays).toBeNull();
     expect(r.startsOnCreationDay).toBe(false);
+  });
+});
+
+describe('describeEventById', () => {
+  const wantedId = 12345;
+  const ok = body => ({ status: 200, body, error: null });
+
+  const row = (event_id = wantedId) => ({
+    event_id,
+    event_name: 'a class',
+    event_start_at: '2026-09-01T10:00:00+08:00',
+    spaces_available: 4,
+  });
+
+  it('reads a bare object carrying the asked-for id as a resolving route', () => {
+    const out = describeEventById({ wantedId, direct: ok(row()) });
+
+    expect(out.verdict).toBe('single-object');
+    expect(out.isRoute).toBe(true);
+    expect(out.resolvesFallback).toBe(true);
+  });
+
+  it('reads a one-element array carrying the asked-for id as a resolving route', () => {
+    const out = describeEventById({ wantedId, direct: ok([row()]) });
+
+    expect(out.verdict).toBe('one-element-array');
+    expect(out.isRoute).toBe(true);
+    expect(out.resolvesFallback).toBe(true);
+  });
+
+  it('matches the id as text, because a pasted id is a string and Clubworx sends a number', () => {
+    const out = describeEventById({ wantedId: '12345', direct: ok(row(12345)) });
+
+    expect(out.verdict).toBe('single-object');
+    expect(out.resolvesFallback).toBe(true);
+  });
+
+  it('calls a multi-row answer the collection, not a resolution', () => {
+    const out = describeEventById({ wantedId, direct: ok([row(), row(999)]) });
+
+    expect(out.verdict).toBe('collection');
+    expect(out.isRoute).toBe(false);
+    expect(out.resolvesFallback).toBe(false);
+  });
+
+  it('calls a single row that is not the asked-for event the collection', () => {
+    // The path segment was ignored and the gym happened to have one event in
+    // the window. Taking row one would put the wrong class in front of staff.
+    const out = describeEventById({ wantedId, direct: ok([row(999)]) });
+
+    expect(out.verdict).toBe('collection');
+    expect(out.resolvesFallback).toBe(false);
+  });
+
+  it('names the collection when the ids returned are the ids the listing held', () => {
+    const out = describeEventById({
+      wantedId,
+      direct: ok([row(), row(999)]),
+      collectionIds: [wantedId, 999],
+    });
+
+    expect(out.verdict).toBe('collection');
+    expect(out.echoesCollection).toBe(true);
+  });
+
+  it('reports an empty array as a filter that matched nothing, not as a route', () => {
+    const out = describeEventById({ wantedId, direct: ok([]) });
+
+    expect(out.verdict).toBe('empty');
+    expect(out.isRoute).toBe(false);
+    expect(out.resolvesFallback).toBe(false);
+  });
+
+  it('reads a 404 on a real id as no such route', () => {
+    const out = describeEventById({ wantedId, direct: { status: 404, body: null, error: null } });
+
+    expect(out.verdict).toBe('not-found');
+    expect(out.isRoute).toBe(false);
+  });
+
+  it('refuses to conclude anything from a 401 — #50 is what that costs', () => {
+    const out = describeEventById({ wantedId, direct: { status: 401, body: null, error: null } });
+
+    expect(out.verdict).toBe('refused');
+    expect(out.isRoute).toBeNull();
+    expect(out.resolvesFallback).toBe(false);
+    expect(out.summary).toMatch(/parameters/i);
+  });
+
+  it('reports a network failure as unmeasured rather than as an absent route', () => {
+    const out = describeEventById({
+      wantedId,
+      direct: { status: null, body: null, error: 'ECONNRESET' },
+    });
+
+    expect(out.verdict).toBe('error');
+    expect(out.isRoute).toBeNull();
+  });
+
+  it('records field names, never values', () => {
+    const out = describeEventById({ wantedId, direct: ok(row()) });
+
+    expect(out.fields).toEqual(['event_id', 'event_name', 'event_start_at', 'spaces_available']);
+    expect(JSON.stringify(out)).not.toContain('a class');
+  });
+
+  it('counts the row a bare object carries — one row, not none', () => {
+    const out = describeEventById({ wantedId, direct: ok(row()) });
+
+    expect(out.returnedIds).toEqual([wantedId]);
+  });
+
+  it('describes what a made-up id answered', () => {
+    const out = describeEventById({
+      wantedId,
+      direct: ok(row()),
+      missing: { status: 404, body: null, error: null },
+    });
+
+    expect(out.missingBehaviour).toBe('not-found');
+    expect(out.discriminates).toBe(true);
+  });
+
+  it('flags a made-up id that answers with rows anyway — the route would confirm any paste', () => {
+    const out = describeEventById({
+      wantedId,
+      direct: ok(row()),
+      missing: ok([row(999), row(1000)]),
+    });
+
+    expect(out.missingBehaviour).toBe('collection');
+    expect(out.discriminates).toBe(false);
+  });
+
+  it('leaves the made-up id unknown when that call was not made', () => {
+    const out = describeEventById({ wantedId, direct: ok(row()) });
+
+    expect(out.missingBehaviour).toBeNull();
+    expect(out.discriminates).toBeNull();
+  });
+
+  it('reports the date window as not required when the windowless call resolves', () => {
+    const out = describeEventById({ wantedId, direct: ok(row()), windowless: ok(row()) });
+
+    expect(out.windowRequired).toBe(false);
+  });
+
+  it('reports the date window as required when the windowless call is refused', () => {
+    const out = describeEventById({
+      wantedId,
+      direct: ok(row()),
+      windowless: { status: 422, body: null, error: null },
+    });
+
+    expect(out.windowRequired).toBe(true);
+  });
+
+  it('leaves the window question open when that call was not made', () => {
+    const out = describeEventById({ wantedId, direct: ok(row()) });
+
+    expect(out.windowRequired).toBeNull();
   });
 });

--- a/cloudflare-clubworx/probes/lib/report.test.js
+++ b/cloudflare-clubworx/probes/lib/report.test.js
@@ -817,6 +817,27 @@ describe('describeEventById', () => {
     expect(out.isRoute).toBe(false);
   });
 
+  it('says plainly whether anything resolved, so callers need not restate the rule', () => {
+    expect(describeEventById({ wantedId, direct: ok(row()) }).resolved).toBe(true);
+    expect(describeEventById({ wantedId, direct: ok([row(), row(999)]) }).resolved).toBe(false);
+    expect(
+      describeEventById({ wantedId, direct: { status: 401, body: null, error: null } }).resolved,
+    ).toBe(false);
+  });
+
+  it('leaves the corroboration question open whenever nothing resolved', () => {
+    // The gate `confounded` shares with `discriminates` and `windowRequired`.
+    for (const direct of [
+      { status: 404, body: null, error: null },
+      { status: 401, body: null, error: null },
+      { status: null, body: null, error: 'ECONNRESET' },
+      ok([row(), row(999)]),
+      ok([]),
+    ]) {
+      expect(describeEventById({ wantedId, direct }).confounded).toBeNull();
+    }
+  });
+
   it('reads a 2xx body it cannot interpret as unmeasured, not as an absent route', () => {
     // A single event naming its key `id` rather than `event_id` would land
     // here. That is a shape nobody has read yet, not a missing route.

--- a/cloudflare-clubworx/probes/run-97.mjs
+++ b/cloudflare-clubworx/probes/run-97.mjs
@@ -2,7 +2,8 @@
 /**
  * staff-site#97 — does `GET /api/v2/events/:id` resolve a single event?
  *
- *   node probes/run-97.mjs [--dry-run] [--missing-id=<id>] [--dev-vars=<path>]
+ *   node probes/run-97.mjs [--dry-run] [--days=<n>] [--missing-id=<id>]
+ *                          [--dev-vars=<path>]
  *
  * Read-only throughout, and read-only *by construction*: the only module here
  * that reaches Clubworx is `lib/http.mjs`, which issues GET and nothing else.
@@ -51,6 +52,7 @@ import { writeFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { redact } from '../src/request.js';
 import { createGetter } from './lib/http.mjs';
 import { loadAccountKey } from './lib/key.mjs';
 import { describeEventById, summariseEvents } from './lib/report.mjs';
@@ -211,6 +213,14 @@ async function main() {
     collectionIds: seed.collectionIds,
   });
 
+  // `refusal` is the one free-text field in the finding, and free text is where
+  // a key travels — some Clubworx complaints interpolate the parameters they
+  // are complaining about. `report.mjs` is the keyless layer and cannot redact,
+  // so it belongs here: the same split `run-60.mjs` and `run-63.mjs` make, and
+  // `errors.js` states the contract — "the caller redacts before it is printed
+  // or written".
+  if (finding.refusal) finding.refusal = redact(finding.refusal, accountKey);
+
   console.log('\n── The answer ────────────────────────────────────────────────');
   line('verdict', finding.summary);
   line('what it said', finding.refusal ?? '(no message)');
@@ -226,7 +236,11 @@ async function main() {
   // The corroboration questions only mean anything if something resolved. On a
   // flat 404 they would each print a confident-looking value about a route that
   // is not there — which is the shape of mistake this whole probe is against.
-  if (finding.isRoute === false && finding.verdict === 'not-found') {
+  // `resolved` comes from the finding rather than being re-derived here: an
+  // earlier draft tested `verdict === 'not-found'`, which sent a 401 and a
+  // dropped connection down the other branch to be described as a one-row
+  // collection read.
+  if (!finding.resolved) {
     line('corroboration', 'n/a — nothing resolved, so there is nothing to corroborate');
   } else {
     line('answered with the collection', String(finding.echoesCollection));

--- a/cloudflare-clubworx/probes/run-97.mjs
+++ b/cloudflare-clubworx/probes/run-97.mjs
@@ -61,6 +61,22 @@ const OUT_DIR = path.join(HERE, 'out');
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 
+/** Everything after the first '=' — a path may contain one, and a truncated
+ * value fails in ways that look like the endpoint's fault rather than the
+ * flag's. */
+const flag = name => args.find(a => a.startsWith(`${name}=`))?.split('=').slice(1).join('=');
+
+/**
+ * Asked for on every call, including the addressed ones.
+ *
+ * "A full page is not an answer" (README): `/events` returned exactly 50 for
+ * every #51 variant, and a page that comes back full is truncated rather than
+ * complete. It matters *more* on the addressed calls than the listing, not
+ * less: the hypothesis under test is that the path segment is ignored, and if
+ * it is, calls 2-4 are collection reads with no bound on them.
+ */
+const PAGE_SIZE = 50;
+
 /**
  * An id that should not exist, for call 3.
  *
@@ -69,13 +85,11 @@ const DRY_RUN = args.includes('--dry-run');
  * with nothing behind it answers. The key is scoped to one gym, so a number
  * this far above UJ's range belongs to no event the key can see either way.
  */
-const MISSING_ID = args.find(a => a.startsWith('--missing-id='))?.split('=')[1] ?? '999999999';
+const MISSING_ID = flag('--missing-id') ?? '999999999';
 
 /** Points at a key outside the package — a git worktree, where .dev.vars is
  * gitignored and so does not follow the checkout. */
-const DEV_VARS =
-  args.find(a => a.startsWith('--dev-vars='))?.split('=').slice(1).join('=') ||
-  path.join(HERE, '..', '.dev.vars');
+const DEV_VARS = flag('--dev-vars') || path.join(HERE, '..', '.dev.vars');
 
 /** Clubworx dates are plain YYYY-MM-DD; the gym runs on Australia/Perth. */
 const perthDate = offsetDays => {
@@ -87,24 +101,45 @@ const line = (label, value) => console.log(`  ${label.padEnd(34)} ${value}`);
 
 /** Ids only. The window is deliberately short — one page is all this needs. */
 async function findRealEventId(get, window) {
-  const res = await get('events', { ...window, page_size: 50 });
+  const res = await get('events', { ...window, page_size: PAGE_SIZE });
   const events = summariseEvents(res.body);
 
-  line('listing for a real id', `HTTP ${res.status} · ${res.ms}ms · ${events.count} events`);
+  // A page that comes back full is truncated rather than complete (#51). It is
+  // reported rather than paged past, because a truncated `collectionIds` is
+  // what would make `echoesCollection` — the check that catches a path-ignoring
+  // collection read — quietly answer `false`.
+  const full = events.count >= PAGE_SIZE;
+  line(
+    'listing for a real id',
+    `HTTP ${res.status} · ${res.ms}ms · ${events.count} events` +
+      (full ? '  ⚠️ page came back full — narrow the window and re-run' : ''),
+  );
 
   // The *first* future event, not any event: an id from the past is still a
   // valid address, but a route that only ever resolved historical rows would
   // answer a question #54 is not asking.
+  //
+  // Parsed, never compared as text: Clubworx sends `+08:00` and `toISOString()`
+  // is `Z`, so `>` between them is a string comparison of two different
+  // notations — which reads a Perth event that started this morning as still to
+  // come, by up to eight hours.
+  const startedAt = row => Date.parse(row?.event_start_at ?? '');
+  const from = Date.now();
   const rows = Array.isArray(res.body) ? res.body : [];
-  const now = new Date().toISOString();
   const future = rows
-    .filter(r => r?.event_id !== null && r?.event_id !== undefined && r?.event_start_at > now)
-    .sort((a, b) => String(a.event_start_at).localeCompare(String(b.event_start_at)));
+    .filter(r => r?.event_id !== null && r?.event_id !== undefined && startedAt(r) > from)
+    .sort((a, b) => startedAt(a) - startedAt(b));
 
   return {
     id: future[0]?.event_id ?? null,
     startsAt: future[0]?.event_start_at ?? null,
-    listing: { status: res.status, ms: res.ms, count: events.count, fields: events.fields },
+    listing: {
+      status: res.status,
+      ms: res.ms,
+      count: events.count,
+      pageCameBackFull: full,
+      fields: events.fields,
+    },
     collectionIds: events.ids,
   };
 }
@@ -118,10 +153,10 @@ async function main() {
     // reading the plan before deciding to run it.
     console.log('--dry-run: no requests issued. This run would make 4 reads, all GET:');
     console.log(`  1. GET /events?event_starts_after=${window.event_starts_after}` +
-      `&event_ends_before=${window.event_ends_before}&page_size=50`);
-    console.log('  2. GET /events/<the first future id from 1>  (same window)');
-    console.log(`  3. GET /events/${MISSING_ID}                 (same window)`);
-    console.log('  4. GET /events/<the same real id>            (no window at all)');
+      `&event_ends_before=${window.event_ends_before}&page_size=${PAGE_SIZE}`);
+    console.log(`  2. GET /events/<the first future id from 1>  (same window, page_size=${PAGE_SIZE})`);
+    console.log(`  3. GET /events/${MISSING_ID}                 (same window, page_size=${PAGE_SIZE})`);
+    console.log(`  4. GET /events/<the same real id>            (no window, page_size=${PAGE_SIZE})`);
     console.log('  Nothing is created, updated or deleted.');
     return;
   }
@@ -143,17 +178,23 @@ async function main() {
 
   console.log('\n── The three addressed calls ─────────────────────────────────');
 
-  const direct = await get(`events/${encodeURIComponent(seed.id)}`, window);
+  const paged = { ...window, page_size: PAGE_SIZE };
+
+  const direct = await get(`events/${encodeURIComponent(seed.id)}`, paged);
   line('2. events/<real id> + window', `HTTP ${direct.status} · ${direct.ms}ms`);
 
-  const missing = await get(`events/${encodeURIComponent(MISSING_ID)}`, window);
+  const missing = await get(`events/${encodeURIComponent(MISSING_ID)}`, paged);
   line(`3. events/${MISSING_ID}`, `HTTP ${missing.status} · ${missing.ms}ms`);
 
-  const windowless = await get(`events/${encodeURIComponent(seed.id)}`);
+  // No window, because that is exactly what `resolveEvent` sends. `page_size`
+  // still rides along: it bounds a collection read, and this call is the one
+  // most likely to be one.
+  const windowless = await get(`events/${encodeURIComponent(seed.id)}`, { page_size: PAGE_SIZE });
   line('4. events/<real id>, no window', `HTTP ${windowless.status} · ${windowless.ms}ms`);
 
   const finding = describeEventById({
     wantedId: seed.id,
+    missingId: MISSING_ID,
     direct,
     missing,
     windowless,
@@ -170,6 +211,12 @@ async function main() {
   line('fields returned', finding.fields.length ? finding.fields.join(', ') : '(none)');
   line('rows returned', String(finding.returnedIds.length));
   line('answered with the collection', String(finding.echoesCollection));
+  line(
+    'told apart from the collection',
+    finding.confounded === null
+      ? 'UNCORROBORATED — cannot tell a resolution from a one-row collection read'
+      : String(!finding.confounded),
+  );
   line('a made-up id answers', `${finding.missingBehaviour} (HTTP ${finding.missingStatus})`);
   line('tells real from made-up', String(finding.discriminates));
   line('date window required', `${finding.windowRequired} (HTTP ${finding.windowlessStatus})`);

--- a/cloudflare-clubworx/probes/run-97.mjs
+++ b/cloudflare-clubworx/probes/run-97.mjs
@@ -29,6 +29,12 @@
  *   4. `GET /events/<the real id>` with no date window — does the window
  *      requirement (#51) follow the collection to the addressed form?
  *
+ * Call 4 is the one that answers for the **shipped** route, and it is worth
+ * being plain about why: `resolveEvent` sends `events/<id>` with no parameters
+ * at all. If addressing works only with a window riding along, the answer to
+ * the issue's headline question is *yes* and the answer for #67's code is
+ * *no* — two different findings that a single "it returned 200" would merge.
+ *
  * The cheapest probe on this map: 4 reads against a 75/minute gym-wide
  * allowance (#51).
  *
@@ -157,7 +163,10 @@ async function main() {
   console.log('\n── The answer ────────────────────────────────────────────────');
   line('verdict', finding.summary);
   line('events/:id is a route', String(finding.isRoute));
-  line('#67 resolveEvent survives it', String(finding.resolvesFallback));
+  line(
+    '#67 resolveEvent survives it',
+    `${finding.resolvesFallback} (from the ${finding.fallbackBasis} call)`,
+  );
   line('fields returned', finding.fields.length ? finding.fields.join(', ') : '(none)');
   line('rows returned', String(finding.returnedIds.length));
   line('answered with the collection', String(finding.echoesCollection));

--- a/cloudflare-clubworx/probes/run-97.mjs
+++ b/cloudflare-clubworx/probes/run-97.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * staff-site#97 — does `GET /api/v2/events/:id` resolve a single event?
+ *
+ *   node probes/run-97.mjs [--dry-run] [--missing-id=<id>] [--dev-vars=<path>]
+ *
+ * Read-only throughout, and read-only *by construction*: the only module here
+ * that reaches Clubworx is `lib/http.mjs`, which issues GET and nothing else.
+ * There is no import of `lib/write.mjs`, `lib/booking.mjs` or
+ * `lib/membership.mjs`, so this script cannot create, book or cancel anything
+ * even if it were asked to.
+ *
+ * ---------------------------------------------------------------------------
+ * The question
+ * ---------------------------------------------------------------------------
+ * #67 shipped `resolveEvent` — the paste-the-event-id fallback behind
+ * `GET /api/clubworx/events?event_id=` — against an endpoint **nobody has ever
+ * called**. Every probe on this map so far has read the `/events` collection.
+ * Path addressing does exist in this API (`DELETE /bookings/:id`, measured in
+ * #60), which is the whole reason `events/:id` was the guess; #50 is the
+ * standing reminder of what a guess costs here.
+ *
+ * Four reads answer it:
+ *
+ *   1. `GET /events` over a window, to obtain a real future event id.
+ *   2. `GET /events/<that id>` inside the same window — status and *shape*.
+ *   3. `GET /events/<an id that does not exist>` — does the route discriminate,
+ *      or would a paste field confirm anything typed into it?
+ *   4. `GET /events/<the real id>` with no date window — does the window
+ *      requirement (#51) follow the collection to the addressed form?
+ *
+ * The cheapest probe on this map: 4 reads against a 75/minute gym-wide
+ * allowance (#51).
+ *
+ * ---------------------------------------------------------------------------
+ * What may be written down
+ * ---------------------------------------------------------------------------
+ * Ids, field **names**, statuses and timings. Never `event_name`, never
+ * `instructor_name`, never a row — `probes/README.md`. staff-site is a public
+ * repo, and `describeEventById` is where that reduction happens so it is one
+ * rule rather than a habit.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createGetter } from './lib/http.mjs';
+import { loadAccountKey } from './lib/key.mjs';
+import { describeEventById, summariseEvents } from './lib/report.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(HERE, 'out');
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+
+/**
+ * An id that should not exist, for call 3.
+ *
+ * Numeric on purpose. A non-numeric id would test whether Clubworx can *parse*
+ * an id, which is a different question — this one asks what a well-formed id
+ * with nothing behind it answers. The key is scoped to one gym, so a number
+ * this far above UJ's range belongs to no event the key can see either way.
+ */
+const MISSING_ID = args.find(a => a.startsWith('--missing-id='))?.split('=')[1] ?? '999999999';
+
+/** Points at a key outside the package — a git worktree, where .dev.vars is
+ * gitignored and so does not follow the checkout. */
+const DEV_VARS =
+  args.find(a => a.startsWith('--dev-vars='))?.split('=').slice(1).join('=') ||
+  path.join(HERE, '..', '.dev.vars');
+
+/** Clubworx dates are plain YYYY-MM-DD; the gym runs on Australia/Perth. */
+const perthDate = offsetDays => {
+  const d = new Date(Date.now() + offsetDays * 86_400_000);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Australia/Perth' }).format(d);
+};
+
+const line = (label, value) => console.log(`  ${label.padEnd(34)} ${value}`);
+
+/** Ids only. The window is deliberately short — one page is all this needs. */
+async function findRealEventId(get, window) {
+  const res = await get('events', { ...window, page_size: 50 });
+  const events = summariseEvents(res.body);
+
+  line('listing for a real id', `HTTP ${res.status} · ${res.ms}ms · ${events.count} events`);
+
+  // The *first* future event, not any event: an id from the past is still a
+  // valid address, but a route that only ever resolved historical rows would
+  // answer a question #54 is not asking.
+  const rows = Array.isArray(res.body) ? res.body : [];
+  const now = new Date().toISOString();
+  const future = rows
+    .filter(r => r?.event_id !== null && r?.event_id !== undefined && r?.event_start_at > now)
+    .sort((a, b) => String(a.event_start_at).localeCompare(String(b.event_start_at)));
+
+  return {
+    id: future[0]?.event_id ?? null,
+    startsAt: future[0]?.event_start_at ?? null,
+    listing: { status: res.status, ms: res.ms, count: events.count, fields: events.fields },
+    collectionIds: events.ids,
+  };
+}
+
+async function main() {
+  const window = { event_starts_after: perthDate(-1), event_ends_before: perthDate(60) };
+
+  if (DRY_RUN) {
+    // The key is loaded *after* this branch, so a dry run works on a machine
+    // that has not been given one — which is the machine most likely to be
+    // reading the plan before deciding to run it.
+    console.log('--dry-run: no requests issued. This run would make 4 reads, all GET:');
+    console.log(`  1. GET /events?event_starts_after=${window.event_starts_after}` +
+      `&event_ends_before=${window.event_ends_before}&page_size=50`);
+    console.log('  2. GET /events/<the first future id from 1>  (same window)');
+    console.log(`  3. GET /events/${MISSING_ID}                 (same window)`);
+    console.log('  4. GET /events/<the same real id>            (no window at all)');
+    console.log('  Nothing is created, updated or deleted.');
+    return;
+  }
+
+  const accountKey = loadAccountKey(DEV_VARS);
+  const get = createGetter({ accountKey });
+
+  console.log('staff-site#97 probe — READ ONLY, against production Clubworx');
+  console.log(`  window ${window.event_starts_after} → ${window.event_ends_before}\n`);
+
+  const seed = await findRealEventId(get, window);
+  if (seed.id === null) {
+    // Not a failure of the endpoint under test, and it must not be written up as
+    // one: with no real id there is nothing to address.
+    console.log('\nNo future event in the window — nothing to address. Widen the window and re-run.');
+    return;
+  }
+  line('real event id', `${seed.id} (starts ${seed.startsAt})`);
+
+  console.log('\n── The three addressed calls ─────────────────────────────────');
+
+  const direct = await get(`events/${encodeURIComponent(seed.id)}`, window);
+  line('2. events/<real id> + window', `HTTP ${direct.status} · ${direct.ms}ms`);
+
+  const missing = await get(`events/${encodeURIComponent(MISSING_ID)}`, window);
+  line(`3. events/${MISSING_ID}`, `HTTP ${missing.status} · ${missing.ms}ms`);
+
+  const windowless = await get(`events/${encodeURIComponent(seed.id)}`);
+  line('4. events/<real id>, no window', `HTTP ${windowless.status} · ${windowless.ms}ms`);
+
+  const finding = describeEventById({
+    wantedId: seed.id,
+    direct,
+    missing,
+    windowless,
+    collectionIds: seed.collectionIds,
+  });
+
+  console.log('\n── The answer ────────────────────────────────────────────────');
+  line('verdict', finding.summary);
+  line('events/:id is a route', String(finding.isRoute));
+  line('#67 resolveEvent survives it', String(finding.resolvesFallback));
+  line('fields returned', finding.fields.length ? finding.fields.join(', ') : '(none)');
+  line('rows returned', String(finding.returnedIds.length));
+  line('answered with the collection', String(finding.echoesCollection));
+  line('a made-up id answers', `${finding.missingBehaviour} (HTTP ${finding.missingStatus})`);
+  line('tells real from made-up', String(finding.discriminates));
+  line('date window required', `${finding.windowRequired} (HTTP ${finding.windowlessStatus})`);
+
+  const record = {
+    probe: 'staff-site#97',
+    ranAt: new Date().toISOString(),
+    window,
+    missingIdUsed: MISSING_ID,
+    seed: { id: seed.id, startsAt: seed.startsAt, listing: seed.listing },
+    calls: {
+      direct: { status: direct.status, ms: direct.ms, contentType: direct.contentType },
+      missing: { status: missing.status, ms: missing.ms, contentType: missing.contentType },
+      windowless: { status: windowless.status, ms: windowless.ms, contentType: windowless.contentType },
+    },
+    finding,
+    totalReads: get.calls,
+  };
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `97-${record.ranAt.replace(/[:.]/g, '-')}.json`);
+  writeFileSync(file, JSON.stringify(record, null, 2));
+
+  console.log(`\n${get.calls} reads total. Summary written to probes/out/${path.basename(file)}`);
+}
+
+main().catch(err => {
+  console.error(`probe failed: ${err.message}`);
+  process.exitCode = 1;
+});

--- a/cloudflare-clubworx/probes/run-97.mjs
+++ b/cloudflare-clubworx/probes/run-97.mjs
@@ -78,6 +78,16 @@ const flag = name => args.find(a => a.startsWith(`${name}=`))?.split('=').slice(
 const PAGE_SIZE = 50;
 
 /**
+ * How far ahead to look for one real future event.
+ *
+ * Short by default. This probe needs *an* id, not a timetable, and a window
+ * wide enough to fill a page is a window whose listing is truncated — which
+ * costs the `collectionIds` that `echoesCollection` checks against. Widen it
+ * only if the gym has nothing on.
+ */
+const DAYS = Number(flag('--days') ?? 14);
+
+/**
  * An id that should not exist, for call 3.
  *
  * Numeric on purpose. A non-numeric id would test whether Clubworx can *parse*
@@ -145,7 +155,7 @@ async function findRealEventId(get, window) {
 }
 
 async function main() {
-  const window = { event_starts_after: perthDate(-1), event_ends_before: perthDate(60) };
+  const window = { event_starts_after: perthDate(-1), event_ends_before: perthDate(DAYS) };
 
   if (DRY_RUN) {
     // The key is loaded *after* this branch, so a dry run works on a machine
@@ -203,6 +213,7 @@ async function main() {
 
   console.log('\n── The answer ────────────────────────────────────────────────');
   line('verdict', finding.summary);
+  line('what it said', finding.refusal ?? '(no message)');
   line('events/:id is a route', String(finding.isRoute));
   line(
     '#67 resolveEvent survives it',
@@ -210,16 +221,24 @@ async function main() {
   );
   line('fields returned', finding.fields.length ? finding.fields.join(', ') : '(none)');
   line('rows returned', String(finding.returnedIds.length));
-  line('answered with the collection', String(finding.echoesCollection));
-  line(
-    'told apart from the collection',
-    finding.confounded === null
-      ? 'UNCORROBORATED — cannot tell a resolution from a one-row collection read'
-      : String(!finding.confounded),
-  );
   line('a made-up id answers', `${finding.missingBehaviour} (HTTP ${finding.missingStatus})`);
-  line('tells real from made-up', String(finding.discriminates));
-  line('date window required', `${finding.windowRequired} (HTTP ${finding.windowlessStatus})`);
+
+  // The corroboration questions only mean anything if something resolved. On a
+  // flat 404 they would each print a confident-looking value about a route that
+  // is not there — which is the shape of mistake this whole probe is against.
+  if (finding.isRoute === false && finding.verdict === 'not-found') {
+    line('corroboration', 'n/a — nothing resolved, so there is nothing to corroborate');
+  } else {
+    line('answered with the collection', String(finding.echoesCollection));
+    line(
+      'told apart from the collection',
+      finding.confounded === null
+        ? 'UNCORROBORATED — cannot tell a resolution from a one-row collection read'
+        : String(!finding.confounded),
+    );
+    line('tells real from made-up', String(finding.discriminates));
+    line('date window required', `${finding.windowRequired} (HTTP ${finding.windowlessStatus})`);
+  }
 
   const record = {
     probe: 'staff-site#97',

--- a/cloudflare-clubworx/src/events.js
+++ b/cloudflare-clubworx/src/events.js
@@ -307,31 +307,62 @@ export async function listEvents({ client, from, to, q = '', now = new Date().to
  * human agrees it is the right class before it can be selected.
  *
  * ---------------------------------------------------------------------------
- * What this does and does not survive — stated precisely, because the loose
- * version of this sentence was wrong
+ * What this was *designed* to survive — kept because it is the argument #54
+ * still has to answer, not because this code delivers it
  * ---------------------------------------------------------------------------
- * It survives the **search** being unhelpful: a name `?q=` filtered out, a
- * window that truncated, a timetable too long to scan.
+ * The paste field was meant to survive the **search** being unhelpful: a name
+ * `?q=` filtered out, a window that truncated, a timetable too long to scan.
  *
- * It does **not** survive Clubworx enforcing the `contact_key` its reference
- * documents. That would take `/events` down as a whole, and this route is on the
- * same endpoint — there is no path here that outlives its own API. Claiming
- * otherwise (an earlier draft of this header did) would have made a real outage
- * look like a covered case.
+ * It was never going to survive Clubworx enforcing the `contact_key` its
+ * reference documents. That would take `/events` down as a whole, and this route
+ * is on the same endpoint — there is no path here that outlives its own API.
+ * Claiming otherwise (an earlier draft of this header did) would have made a
+ * real outage look like a covered case.
+ *
+ * As measured below, **this implementation delivers none of it**, because the
+ * endpoint it was written against does not exist. The paragraph stays because
+ * the requirement it describes is still live and still has to be met some other
+ * way — see the #54 decision at the end of this header.
  *
  * ---------------------------------------------------------------------------
- * One request, and `GET /events/:id` is unmeasured
+ * MEASURED, AND IT DOES NOT WORK — `GET /events/:id` is not a route
  * ---------------------------------------------------------------------------
- * Every probe so far has read the collection. Path addressing exists in this API
- * — `DELETE /bookings/:id` was measured in #60 — but `events/:id` has never been
- * exercised, so **whether this route works at all against production is an open
- * question a probe should close** — filed as #97.
+ * #97 probed it against production on **2026-08-21**: `GET /api/v2/events/<id>`
+ * answers **HTTP 404** `{"status": 404, "error": "Not Found"}` — for a real
+ * event id, for an invented one, with the date window and without it. The 404
+ * arrives in ~285ms against ~1,950ms for the collection read beside it, and is
+ * identical for a real id and a made-up one: Clubworx is declining to route the
+ * request, not failing to find the record. See
+ * `../probes/97-events-by-id.md`.
+ *
+ * So **nothing below this line can succeed.** The function is correct — it
+ * refuses, and it refuses for the right reason — but there is no request it can
+ * make that Clubworx will answer. Every call returns `upstream-error` with
+ * Clubworx's own `"Not Found"`, which a staff member reads as *"that event does
+ * not exist"* rather than *"this has never worked"*.
+ *
+ * Path addressing does exist here — `DELETE /bookings/:id` was measured in #60
+ * — which is why `events/:id` was the guess. The API is simply inconsistent
+ * between resources, and the reference does not say so. That is #50's lesson
+ * charged a second time: a pattern from a neighbouring resource is not evidence
+ * about this one.
+ *
+ * **This is left in place deliberately, pending the #54 decision** that #97
+ * hands over: either the pasted id is resolved *page-side* from the window the
+ * picker already holds, or the field is dropped. Both are #54's call, and
+ * deleting the route ahead of it would decide the question by removing one
+ * option. What is not an option is leaving a paste field wired to this in front
+ * of staff — a dead escape hatch looks like a working one until somebody needs
+ * it.
  *
  * An earlier draft fell back to re-walking `from`/`to` when the direct call
  * failed. That was dropped: it spends up to `MAX_PAGES` requests of a gym-wide
  * 75/min allowance to find an id that, being inside the window, the page already
  * has on screen from the listing it just made. #67 asks for the id resolved
- * *directly*; the window is the page's own to search.
+ * *directly*; the window is the page's own to search. That reasoning survives
+ * the measurement — it is the argument for resolving page-side rather than
+ * re-walking server-side, and #97 has now removed the alternative it was
+ * weighed against.
  *
  * @param {object} opts
  * @param {{get: (path: string, params: object) => Promise<object>}} opts.client

--- a/cloudflare-clubworx/src/events.js
+++ b/cloudflare-clubworx/src/events.js
@@ -328,18 +328,21 @@ export async function listEvents({ client, from, to, q = '', now = new Date().to
  * MEASURED, AND IT DOES NOT WORK — `GET /events/:id` is not a route
  * ---------------------------------------------------------------------------
  * #97 probed it against production on **2026-08-21**: `GET /api/v2/events/<id>`
- * answers **HTTP 404** `{"status": 404, "error": "Not Found"}` — for a real
- * event id, for an invented one, with the date window and without it. The 404
- * arrives in ~285ms against ~1,950ms for the collection read beside it, and is
- * identical for a real id and a made-up one: Clubworx is declining to route the
- * request, not failing to find the record. See
- * `../probes/97-events-by-id.md`.
+ * answers **HTTP 404**, body fields `status` and `error`, message `"Not Found"`
+ * — for a real event id, for an invented one, with the date window and without
+ * it. A real currently-listed id and `999999999` come back identical, so
+ * nothing there is reading the id at all. See `../probes/97-events-by-id.md`,
+ * which also records why the response *timings* do not support that conclusion
+ * as cleanly as a first draft claimed.
  *
  * So **nothing below this line can succeed.** The function is correct — it
  * refuses, and it refuses for the right reason — but there is no request it can
- * make that Clubworx will answer. Every call returns `upstream-error` with
- * Clubworx's own `"Not Found"`, which a staff member reads as *"that event does
- * not exist"* rather than *"this has never worked"*.
+ * make that Clubworx will answer. Every call returns `upstream-error`, which
+ * `index.js` maps to **HTTP 502**, carrying Clubworx's own `"Not Found"` as the
+ * message. The status is honest; the message is not, and any surface showing
+ * the message rather than the status tells staff a valid id was *not found*.
+ * (`resolveEvent`'s own `'event-not-found'` reason, the one that would map to a
+ * 400, is unreachable in production — it needs a successful upstream read.)
  *
  * Path addressing does exist here — `DELETE /bookings/:id` was measured in #60
  * — which is why `events/:id` was the guess. The API is simply inconsistent


### PR DESCRIPTION
Closes #97.

## The answer

`GET /api/v2/events/<id>` answers **HTTP 404** — for a real event id, for an invented one, with the date window and without it. There is no such route.

So [#67](https://github.com/urbanjungleirc/staff-site/issues/67)'s `resolveEvent` cannot succeed as written, and [#54](https://github.com/urbanjungleirc/staff-site/issues/54)'s paste-the-event-id field has no Worker route behind it.

The finding rests on one thing: a real, currently-listed event id and `999999999` come back **identical** — same status, same body shape, same message. Whatever answers is not reading the id. Response timings looked like corroboration at first and are written up as *consistent with* a routing refusal rather than evidence for it; the first addressed call took ~1.3s in every run, and the fast pair always follows it on a warmed connection.

Path addressing does exist in this API — `DELETE /bookings/:id` was measured working in #60. Clubworx is simply inconsistent between resources and the reference does not say so. #50's lesson charged a second time: a pattern from a neighbouring resource is not evidence about this one.

## What a caller sees today

The route is deployed. `GET /api/clubworx/events?event_id=<anything>` returns **HTTP 502** with `{"error": "Not Found", "reason": "upstream-error", "upstreamStatus": 404, "view": null}`. The 502 is honest; the passed-through `"Not Found"` string is not, on any surface showing the message rather than the status. `resolveEvent`'s own `event-not-found` → 400 branch is unreachable in production.

## What's here

| | |
|---|---|
| `probes/97-events-by-id.md` | The findings |
| `probes/run-97.mjs` | The probe — read-only *by construction*, 4 GETs |
| `probes/lib/report.mjs` | `describeEventById`, the part with judgement in it |
| `src/events.js` | `resolveEvent`'s header — comments only, no behaviour change |

**Not a functional deploy.** The Worker bundle changes by comments alone: `src/events.js` has no code change and `probes/` is not bundled.

`resolveEvent` is **left in place deliberately**. #97 hands #54 a decision — resolve the pasted id page-side from the window the picker already holds, or drop the field — and deleting the route now would settle that by removing an option. What is ruled out is the status quo: a paste field wired to a 404 looks like a working escape hatch until somebody needs it.

## Review notes

Four review passes ran over this, and they caught real faults worth recording, because each would have produced a confident false finding:

- A one-element array carrying the right id **is not proof**. If the path segment were ignored and the window held exactly one event, a collection read and a genuine resolution would be byte-identical. It now needs corroboration.
- `resolveEvent` sends **no date window**, so the windowless call is the one that answers for the shipped code. Had `events/:id` needed a window, the route would have been reported working while 422-ing in production.
- `windowRequired`, `discriminates` and `confounded` each reported confident values about an absent route. All three are now null unless the direct call resolved.
- `refusal` reached stdout and `probes/out/` **unredacted**, breaking the rule that the key never reaches output. Redacted at the runner now, like run-50/60/63.

The write-up distinguishes what reproduced (network behaviour, three runs) from what did not (the derived fields — the classifier was still being fixed between runs, so only the last run matches shipped code).

624 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U71USUNyrTzE3hiqwm9uBs