### PR TITLE
#97 was not rate limiting — path addressing is per resource

### DIFF
--- a/cloudflare-clubworx/probes/97-events-by-id.md
+++ b/cloudflare-clubworx/probes/97-events-by-id.md
@@ -86,17 +86,69 @@ on them.
 So the finding is *there is no route* rather than *the event could not be
 found* — resting on the identical answers, not on the clock.
 
-## Path addressing exists in this API — just not here
+## Path addressing exists in this API — per resource, and not for events
 
-`DELETE /bookings/:id` was measured working in [#60](60-member-school-pass-booking.md).
-So Clubworx does address individual records by path, which is exactly why
-`events/:id` was a reasonable guess, and exactly why it had to be checked rather
-than assumed. The API's shape is **inconsistent between resources**, and no part
-of the published reference says so.
+Measured 2026-08-21, same key, same session, within one minute of the events
+calls above:
 
-The general lesson for this map is the one #50 already paid for: *an endpoint
-nobody has completed is unproven*, and a plausible pattern from a neighbouring
-resource is not evidence about this one.
+| Call | Answer |
+|---|---|
+| `GET /members/<a real contact_key>` | **200**, a bare object |
+| `GET /members/<a well-formed key belonging to nobody>` | **401** |
+| `GET /events/<a real event_id>` | **404** |
+| `GET /locations/<a real location_id>` | **404** |
+| `DELETE /bookings/<id>` | **works** — measured in [#60](60-member-school-pass-booking.md) |
+
+So path addressing is **not absent from this API and not universal in it** — it
+is a property of each resource, and no part of the published reference says
+which resources have it. `members` has it for GET. `bookings` has it for DELETE.
+`events` and `locations` do not.
+
+That is what makes `events/:id` a reasonable guess and a necessary check at the
+same time. The lesson is the one #50 already paid for: *an endpoint nobody has
+completed is unproven*, and a plausible pattern from a neighbouring resource is
+not evidence about this one.
+
+### `GET /members/<unknown key>` answers 401, not 404
+
+Worth its own heading, because it is [#50](50-membership-less-booking.md)'s trap
+on a second endpoint. A well-formed `contact_key` that belongs to nobody does
+not come back "not found" — it comes back **401**, the status that reads as *you
+are not allowed*, on a request that was perfectly well authorised.
+
+`README.md`'s standing rule — *read an endpoint's parameters before concluding
+anything from a 401* — now has a second measured instance behind it, and a
+sharper form: **on this API a 401 may be about the identifier, not the
+credential.** Anything probing a Clubworx id needs a control call with a known-good
+identifier before it reads a 401 as a permissions wall.
+
+## It was not rate limiting, and that was checked
+
+The gym has one key (#47), shared by this tool, the HVT roster Worker and two
+active n8n workflows, so "we were cut off for overuse" is a fair first
+hypothesis for an unexpected refusal. It is wrong here, and the refutation is
+cheap enough to record:
+
+- **No `429` anywhere**, in roughly forty requests across four probe runs and a
+  control run. #51 measured that a throttle answers `429` for ~18 seconds and
+  often in HTML; neither appeared.
+- **Collection reads kept working, interleaved with the 404s** — `GET /events`
+  returned **200, 200, 200** in the same run as two `404`s on `events/:id`,
+  seconds apart on the same connection. A cut-off cannot be selective by path.
+- **`GET /members/<key>` returned 200 in the same minute** as `events/:id`
+  returned 404. One path-addressed GET working while another fails rules out the
+  key, the quota and the connection in a single comparison.
+- **Neither other consumer calls `events/:id` at all.** The HVT Worker reads
+  `/events` as a collection and is request-driven — no cron, no scheduled
+  handler. The n8n term-enrolment workflow is email-triggered and uses only
+  collection endpoints with query filters.
+
+Two things about those consumers are worth knowing anyway, because they *would*
+matter under load and neither is visible from here: the HVT roster fans out one
+`members/<key>` request **per contact in parallel** (up to ~300 at once, against
+a measured ~75/min ceiling), and its `/events`→`/bookings` fallback catches any
+error — including a `429` — and immediately issues up to three more requests
+rather than backing off.
 
 ## What a staff member sees today
 

--- a/cloudflare-clubworx/probes/README.md
+++ b/cloudflare-clubworx/probes/README.md
@@ -178,13 +178,19 @@ which is the one place these runners differ. A dry run is what somebody reads
 least likely to have a key in place yet; the others refuse to describe
 themselves without one.
 
-### `events/:id` does not exist, and `DELETE /bookings/:id` does
+### Path addressing is per resource, and a 401 may be about the id
 
-The two facts sit next to each other in this directory and they are the reason
-"it works for that resource" is not evidence here. Clubworx addresses bookings
-by path (#60) and does not address events by path (#97) — same API, same
-version, no note of it in the reference. Anything path-addressed that nobody has
-actually completed is unproven, whatever its neighbours do.
+Measured, all with the same key: `GET /members/<key>` **200**, `DELETE
+/bookings/:id` **works** (#60), `GET /events/:id` **404**, `GET /locations/:id`
+**404** (#97). Same API, same version, nothing in the reference distinguishing
+them. Anything path-addressed that nobody has actually completed is unproven,
+whatever its neighbours do.
+
+And the sharper form of the 401 rule above: `GET /members/<a well-formed key
+belonging to nobody>` answers **401**, not 404 (#97). On this API a 401 can be
+about the *identifier* rather than the credential — so a probe reading a 401
+needs a control call with a known-good identifier before calling it a
+permissions wall. #50 lost a week to the first instance of this.
 
 The two `../src/` entries are not probe files any more. staff-site#66 promoted
 them into the Worker's own module, because the Worker needs exactly the same URL

--- a/cloudflare-clubworx/src/events.js
+++ b/cloudflare-clubworx/src/events.js
@@ -344,11 +344,15 @@ export async function listEvents({ client, from, to, q = '', now = new Date().to
  * (`resolveEvent`'s own `'event-not-found'` reason, the one that would map to a
  * 400, is unreachable in production — it needs a successful upstream read.)
  *
- * Path addressing does exist here — `DELETE /bookings/:id` was measured in #60
- * — which is why `events/:id` was the guess. The API is simply inconsistent
- * between resources, and the reference does not say so. That is #50's lesson
- * charged a second time: a pattern from a neighbouring resource is not evidence
- * about this one.
+ * Path addressing does exist here, **per resource**: `GET /members/<key>`
+ * answers 200 and `DELETE /bookings/:id` works (#60), while `events/:id` and
+ * `locations/:id` both 404 — same key, same minute. That comparison is also
+ * what rules out the tempting systemic explanations: not a throttle (no 429 in
+ * ~40 requests), not a cut-off (collection reads returned 200 interleaved with
+ * the 404s), not a key lacking path-addressing rights. The API is simply
+ * inconsistent between resources and the reference does not say so, which is
+ * #50's lesson charged a second time: a pattern from a neighbouring resource is
+ * not evidence about this one.
  *
  * **This is left in place deliberately, pending the #54 decision** that #97
  * hands over: either the pasted id is resolved *page-side* from the window the


### PR DESCRIPTION
Follow-up to #100, prompted by a fair question: the gym has one Clubworx key (#47), shared with the HVT roster Worker and two active n8n workflows. Were the #97 404s just us being cut off for overuse?

**No — and checking sharpened the finding.**

Measured with the same key inside one minute:

| Call | Answer |
|---|---|
| `GET /members/<a real contact_key>` | **200**, a bare object |
| `GET /members/<a key belonging to nobody>` | **401** |
| `GET /events/<a real event_id>` | **404** |
| `GET /locations/<a real location_id>` | **404** |
| `DELETE /bookings/<id>` | **works** (#60) |

Path addressing is **neither absent from this API nor universal in it** — it is a property of each resource, undocumented either way. One path-addressed GET answering 200 while another answers 404, same key same minute, rules out the throttle, the quota, the connection and the key's rights in one comparison.

Supporting: no `429` in ~40 requests across four probe runs and a control run, and `GET /events` returned 200 three times interleaved with the 404s. A cut-off cannot be selective by path.

## New standing rule

**`GET /members/<unknown key>` answers 401, not 404** — #50's trap on a second endpoint. On this API a 401 may be about the *identifier* rather than the credential, so a probe reading one needs a control call with a known-good identifier before calling it a permissions wall. Added to `probes/README.md`.

## Not this PR's problem, but recorded

Neither other consumer touches `events/:id`. Two things about them would matter under load:

- The HVT roster fans out one `members/<key>` request **per contact in parallel** (`Promise.all`) — up to ~300 at once against the ~75/min ceiling #51 measured.
- Its `/events`→`/bookings` fallback catches *any* error including a `429` and immediately issues up to 3 more requests, amplifying a throttle rather than backing off.
- The n8n term-enrolment workflow reads `/events` with `page_size=200` and no pagination — the silent-truncation trap from #51.

Happy to file those separately.

Docs only — `src/events.js` changes by comments. 662 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U71USUNyrTzE3hiqwm9uBs