### PR TITLE
School booking page: steps 1-3 — school, paste, count gate, parse result (#71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,10 +95,34 @@ cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, an
                           what they found. Start with probes/README.md — it carries
                           the rules (no production data recorded, pace under
                           75 req/min) that any new probe has to follow.
+school-booking.html     - the school booking page, steps 1-3 (#71): school,
+                          paste + declare the count, then the parse result with
+                          inline row resolution. Variant A of §9, decided on
+                          #54. NOT in tools.json and unreachable from the hub
+                          until #46's last step — §17's order, because `main`
+                          is production. Steps 4-6 are #72 and #73; nothing on
+                          this page writes anything.
 school-booking/parse.js - turns a pasted school student list into rows plus the
                           list-level inferences (layout, column mapping, date
                           orientation). Pure and unit tested; §7 of the design
-                          spec. Nothing imports it yet — see #64/#71.
+                          spec. #71 added the layout and column OVERRIDES the
+                          page's affordances need — obeyed literally, including
+                          where the inference was right, because an override
+                          the parser may discard is not an override.
+school-booking/steps.js - the gates of steps 1-3: the school tag and its
+                          permanent marker, the count declaration (P5), and one
+                          review() turning a parse plus a log of staff
+                          resolutions into rows, the P1 reconciliation and the
+                          blockers. Nothing it returns is ever a function —
+                          that is what makes §16's `x-show="b.fix"` bug
+                          unreachable, and a test asserts it. P1 is re-asserted
+                          after every dismissal, not only after a parse.
+school-booking/test/alpine-bindings.test.js - reads school-booking.html and
+                          fails on any Alpine directive naming a function
+                          without calling it (#78). A text check, because the
+                          fault is a property of the text: it is not a logic
+                          fault, so a unit test cannot see it, and it throws
+                          nothing, so runtime does not report it.
 school-booking/identity.js - the matching rule: surname + DOB narrows, first name
                           breaks ties, variance is surfaced never merged. §5 of
                           the design spec. Imports the two name forms from

--- a/school-booking.html
+++ b/school-booking.html
@@ -87,7 +87,7 @@
   .field-label {
     display: block; font-size: 0.67rem; font-weight: 600;
     text-transform: uppercase; letter-spacing: 0.05em;
-    color: #9ca3af; margin-bottom: 6px;
+    color: #6b7280; margin-bottom: 6px;
   }
 
   /* Combobox — the staff portal's dropdown, copied from vouchers/stats.html. A
@@ -156,7 +156,7 @@
     cursor: pointer;
   }
   .chip:hover { border-color: rgba(139, 28, 35, 0.45); color: var(--uj); }
-  .chip-role { font-size: 0.62rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af; }
+  .chip-role { font-size: 0.62rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280; }
 
   .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; }
   .strike { text-decoration: line-through; }
@@ -203,7 +203,7 @@
       <!-- A module that did not load is a page whose gates are decoration. Said
            out loud rather than left to fail per-expression, because every gate
            on this page fails the same way and at the same moment. -->
-      <div x-show="bootstrapError" x-cloak
+      <div x-show="bootstrapError" x-cloak role="alert"
            class="rounded-xl bg-rose-50 border border-rose-200 text-rose-800 px-4 py-3 text-sm mb-5">
         <b>This page is not safe to use.</b>
         <span x-text="bootstrapError"></span>
@@ -216,6 +216,7 @@
           <template x-for="(s, i) in STEPS" :key="s.key">
             <button type="button" :class="stepIndex === i ? 'active' : ''"
                     :disabled="i > maxStepReached || !s.built"
+                    :aria-current="stepIndex === i ? 'step' : false"
                     :title="s.built ? '' : 'Not built yet'"
                     @click="i <= maxStepReached && s.built && go(i)">
               <span class="mono text-[0.7rem] mr-1" x-text="i + 1"></span><span x-text="s.label"></span>
@@ -245,20 +246,25 @@
               <span x-text="tag || 'Choose a school, or type a new tag…'"></span>
               <svg class="combo-chevron" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"/></svg>
             </button>
-            <div x-show="schoolOpen" x-transition.origin.top x-cloak class="combo-menu" role="listbox">
+            <div x-show="schoolOpen" x-transition.origin.top x-cloak class="combo-menu">
               <div class="px-1 pb-2">
                 <input x-model="schoolQuery" type="text" placeholder="Type to filter, or type a new tag…"
+                       aria-label="Filter schools, or type a new tag"
                        class="w-full rounded-lg border border-neutral-200 px-2.5 py-1.5 text-sm focus:outline-none focus:border-uj"
                        @keydown.enter.prevent="useTypedTag()">
-                <p class="text-[0.68rem] text-neutral-400 mt-1.5 px-1" x-text="schoolsNote()"></p>
+                <p class="text-[0.68rem] text-neutral-500 mt-1.5 px-1" x-text="schoolsNote()"></p>
               </div>
 
+              <!-- The role wraps the options and nothing else: the filter box
+                   above is not an option, and a listbox containing one is
+                   invalid ARIA that a screen reader reads as a broken widget. -->
+              <div role="listbox" aria-label="Schools already in Clubworx">
               <template x-for="s in filteredSchools()" :key="s.tag">
                 <button type="button" role="option" class="combo-option"
                         :aria-selected="tag === s.tag ? 'true' : 'false'" :class="tag === s.tag ? 'active' : ''"
                         @click="tag = s.tag; schoolOpen = false">
                   <span class="mono" x-text="s.tag"></span>
-                  <span class="text-[0.68rem] text-neutral-400"
+                  <span class="text-[0.68rem] text-neutral-500"
                         x-text="s.contacts + (s.contacts === 1 ? ' contact' : ' contacts')"></span>
                 </button>
               </template>
@@ -267,11 +273,13 @@
                    gets its first one. It is offered last and shown normalised,
                    so what will be written is what is on screen before the
                    click, not after it. -->
-              <button type="button" class="combo-option" x-show="typedTag() && !knownTag(typedTag())" x-cloak
+              <button type="button" role="option" aria-selected="false"
+                      class="combo-option" x-show="typedTag() && !knownTag(typedTag())" x-cloak
                       @click="useTypedTag()">
                 <span>Use a new tag <span class="mono font-bold" x-text="typedTag()"></span></span>
-                <span class="text-[0.68rem] text-neutral-400">new school</span>
+                <span class="text-[0.68rem] text-neutral-500">new school</span>
               </button>
+              </div>
             </div>
           </div>
 
@@ -303,25 +311,39 @@
           absorbed as a student, a truncated paste and a phantom column all at once.
         </p>
 
-        <textarea x-model="rawPaste" rows="12" spellcheck="false"
+        <textarea x-model="rawPaste" rows="12" spellcheck="false" @input="pasteChanged()"
           aria-label="The pasted student list"
           class="w-full rounded-xl border border-neutral-200 p-3 text-sm mono focus:outline-none focus:border-uj focus:ring-2 focus:ring-uj/15"></textarea>
-        <p class="text-xs text-neutral-400 mt-1">
+        <p class="text-xs text-neutral-500 mt-1">
           <span class="mono" x-text="pastedLineCount()"></span> lines pasted.
         </p>
 
         <div class="flex items-end gap-4 flex-wrap mt-6">
           <div>
             <span class="field-label">Expected students</span>
-            <input x-model="countValue" type="text" inputmode="numeric" :disabled="countUnknown"
+            <input x-model="countValue" type="text" inputmode="numeric"
+                   :disabled="countUnknown || countLocked()"
                    aria-label="Expected number of students"
                    class="w-32 rounded-xl border border-neutral-200 px-3 py-2 text-lg mono font-bold focus:outline-none focus:border-uj focus:ring-2 focus:ring-uj/15 disabled:bg-neutral-50 disabled:text-neutral-300">
           </div>
           <label class="flex items-center gap-2 text-sm text-neutral-600 pb-2.5 cursor-pointer">
-            <input type="checkbox" x-model="countUnknown" class="rounded border-neutral-300 text-uj focus:ring-uj/30">
+            <input type="checkbox" x-model="countUnknown" :disabled="countLocked()"
+                   class="rounded border-neutral-300 text-uj focus:ring-uj/30 disabled:opacity-40">
             I don't know
           </label>
         </div>
+
+        <!-- Locked once the list has been read, because it has: the count is a
+             declaration about a paste, and this one has already been answered
+             about this one. Coming back here to change the number after seeing
+             what we read is the anchoring P5's ordering prevents — the same
+             move the in-place re-declare refuses, one click further away.
+             Editing the paste unlocks it, because that is a different list. -->
+        <p x-show="countLocked()" x-cloak
+           class="text-xs text-neutral-500 mt-3 bg-neutral-100 border border-neutral-200 rounded-lg px-3 py-2 inline-block">
+          You have already answered this for this list. Edit the paste to answer it again — or,
+          if fixing the rows changed the number, say so on the next screen.
+        </p>
         <p x-show="countUnknown" x-cloak
            class="text-xs text-amber-700 mt-3 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 inline-block">
           Fine — the count becomes a banner you have to read, rather than a gate that blocks.
@@ -376,7 +398,7 @@
                         <input type="text" inputmode="numeric" class="w-16 rounded-lg border border-sky-200 px-2 py-1 text-sm mono"
                                aria-label="Fields per student"
                                :value="reviewed.blockSize"
-                               @change="setBlockSize($event.target.value)">
+                               @change="setBlockSize($event.target.value, $event.target)">
                         fields per student
                       </label>
                     </template>
@@ -388,18 +410,24 @@
                   <div class="flex items-center gap-2 flex-wrap">
                     <template x-for="chip in columnChips()" :key="chip.role">
                       <div class="relative">
-                        <button type="button" class="chip" @click="chipMenu = (chipMenu === chip.role ? null : chip.role)">
+                        <button type="button" class="chip" aria-haspopup="listbox"
+                                :aria-expanded="chipMenu === chip.role ? 'true' : 'false'"
+                                :aria-label="chip.roleLabel + ' is ' + chip.label + '. Choose another column.'"
+                                @click="chipMenu = (chipMenu === chip.role ? null : chip.role)">
                           <span class="chip-role" x-text="chip.roleLabel"></span>
                           <span class="mono" x-text="chip.label"></span>
                         </button>
-                        <div x-show="chipMenu === chip.role" x-cloak class="combo-menu w-56"
-                             @click.outside="chipMenu = null">
+                        <div x-show="chipMenu === chip.role" x-cloak role="listbox"
+                             class="combo-menu w-56 max-w-[calc(100vw-3rem)]"
+                             :aria-label="'Column for ' + chip.roleLabel"
+                             @click.outside="chipMenu = null" @keydown.escape.window="chipMenu = null">
                           <template x-for="choice in columnChoices()" :key="choice.index">
-                            <button type="button" class="combo-option"
+                            <button type="button" class="combo-option" role="option"
+                                    :aria-selected="choice.index === chip.index ? 'true' : 'false'"
                                     :class="choice.index === chip.index ? 'active' : ''"
                                     @click="setColumn(chip.role, choice.index)">
                               <span class="mono" x-text="choice.label"></span>
-                              <span class="text-[0.68rem] text-neutral-400" x-text="'column ' + (choice.index + 1)"></span>
+                              <span class="text-[0.68rem] text-neutral-500" x-text="'column ' + (choice.index + 1)"></span>
                             </button>
                           </template>
                         </div>
@@ -410,7 +438,8 @@
                             @click="swapNames()">⇄ swap first and last</button>
                     <button type="button" class="chip" x-show="reviewed.columns?.combined === null" x-cloak
                             @click="setNameShape('combined')">the name is one column</button>
-                    <button type="button" class="chip" x-show="reviewed.columns?.combined !== null" x-cloak
+                    <button type="button" class="chip" x-cloak
+                            x-show="reviewed.columns?.combined !== null && nameShapedFree().length"
                             @click="setNameShape('split')">the name is two columns</button>
                   </div>
                 </div>
@@ -428,6 +457,7 @@
             <!-- Blockers. Each is data: a title, a detail and the lines it is
                  about. None of them carries a function, which is what makes
                  the #54 render-tick bug unreachable from here. -->
+            <div aria-live="polite">
             <template x-for="b in reviewed.blockers" :key="b.key">
               <div class="rounded-xl px-3.5 py-2.5 text-sm mb-2 border"
                    :class="b.severity === 'block' ? 'bg-rose-50 border-rose-200 text-rose-800' : 'bg-amber-50 border-amber-200 text-amber-800'">
@@ -436,35 +466,26 @@
                     <div class="font-semibold" x-text="b.title"></div>
                     <div class="text-xs mt-0.5 opacity-90" x-text="b.detail"></div>
                   </div>
-                  <div class="flex items-center gap-2 shrink-0">
-                    <!-- The re-declare, and the gate that survives it. Offered
-                         only once staff have moved the count themselves; see
-                         canRedeclare() in steps.js for why an ungated one is a
-                         one-click dismissal of the gate it escapes. -->
-                    <button type="button" x-show="b.kind === 'count-mismatch' && canRedeclare()" x-cloak
-                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
-                            @click="redeclare()">
-                      The count has changed — make it <span class="mono" x-text="reviewed.counts.records"></span>
-                    </button>
-                    <button type="button" x-show="acknowledgeable(b.kind)" x-cloak
-                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
-                            @click="acknowledge(b.kind)">Checked — go on</button>
-                    <button type="button" x-show="b.kind === 'name-order'" x-cloak
-                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
-                            @click="setNameOrder('first-last')">First name first</button>
-                    <button type="button" x-show="b.kind === 'name-order'" x-cloak
-                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
-                            @click="setNameOrder('last-first')">Surname first</button>
-                    <button type="button" x-show="b.kind === 'date-orientation'" x-cloak
-                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
-                            @click="setDateOrientation('dmy')">Day/month</button>
-                    <button type="button" x-show="b.kind === 'date-orientation'" x-cloak
-                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
-                            @click="setDateOrientation('mdy')">Month/day</button>
+                  <!-- One loop, because the blocker carries the controls it
+                       offers. Six `b.kind === '…'` tests here plus a matching
+                       list in the component meant a kind added in steps.js
+                       could arrive with no way out of it, and a gate nobody
+                       can clear is a stuck run. The re-declare is in this list
+                       too, and steps.js is what decides whether to include it
+                       — see canRedeclare(): ungated it is a one-click
+                       dismissal of the gate it escapes. -->
+                  <div class="flex items-center gap-2 shrink-0 flex-wrap">
+                    <template x-for="action in b.actions" :key="action.key">
+                      <button type="button"
+                              class="rounded-lg border px-3 py-1.5 text-xs font-semibold"
+                              :class="b.severity === 'block' ? 'border-rose-300 hover:bg-rose-100' : 'border-amber-300 hover:bg-amber-100'"
+                              @click="answerBlocker(action)" x-text="action.label"></button>
+                    </template>
                   </div>
                 </div>
               </div>
             </template>
+            </div>
 
             <div x-show="reviewed.ready" x-cloak
                  class="rounded-xl bg-emerald-50 border border-emerald-200 text-emerald-800 px-3.5 py-2.5 text-sm mb-2">
@@ -478,9 +499,9 @@
               <table class="w-full">
                 <thead>
                   <tr class="border-b border-neutral-100 bg-neutral-50/70">
-                    <th class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider">Student</th>
-                    <th class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider">Date of birth</th>
-                    <th class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider">Read</th>
+                    <th scope="col" class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-500 uppercase tracking-wider">Student</th>
+                    <th scope="col" class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-500 uppercase tracking-wider">Date of birth</th>
+                    <th scope="col" class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-500 uppercase tracking-wider">Read</th>
                   </tr>
                 </thead>
                 <template x-for="r in reviewed.rows" :key="r.key">
@@ -493,7 +514,7 @@
                              x-text="r.bucket === 'error' ? r.raw : nameOf(r)"></div>
                         <div x-show="r.note" class="text-xs mt-0.5"
                              :class="r.bucket === 'error' ? 'text-rose-600' : 'text-amber-700'" x-text="r.note"></div>
-                        <div class="text-[0.66rem] text-neutral-400 mono mt-0.5"
+                        <div class="text-[0.66rem] text-neutral-500 mono mt-0.5"
                              x-text="'line ' + r.lineNumbers.join(', ')"></div>
                       </td>
                       <td class="px-4 py-2.5 text-sm mono text-neutral-600" x-text="r.dob || '—'"></td>
@@ -502,10 +523,14 @@
                           <span class="pill" :class="stateTone(r)" x-text="r.state"></span>
                           <button x-show="r.needsHuman" type="button"
                                   class="text-xs font-semibold text-uj underline underline-offset-2"
+                                  :aria-expanded="expandedRow === r.key ? 'true' : 'false'"
+                                  :aria-label="(expandedRow === r.key ? 'Close ' : 'Sort out ') + nameOf(r)"
                                   @click.stop="toggleRow(r.key)"
                                   x-text="expandedRow === r.key ? 'close' : 'sort it out'"></button>
                           <button x-show="!r.needsHuman" type="button"
-                                  class="text-xs text-neutral-400 hover:text-neutral-700 underline underline-offset-2"
+                                  class="text-xs text-neutral-500 hover:text-neutral-800 underline underline-offset-2"
+                                  :aria-expanded="expandedRow === r.key ? 'true' : 'false'"
+                                  :aria-label="(expandedRow === r.key ? 'Close ' : 'Change ') + nameOf(r)"
                                   @click.stop="toggleRow(r.key)"
                                   x-text="expandedRow === r.key ? 'close' : 'change'"></button>
                         </div>
@@ -584,9 +609,9 @@
                 <div x-show="showIgnored" x-cloak class="mt-2 space-y-1">
                   <template x-for="entry in reviewed.ignored" :key="entry.lineNumbers.join('-')">
                     <div class="flex items-center gap-2">
-                      <span class="mono text-[0.66rem] text-neutral-300" x-text="entry.lineNumbers.join(', ')"></span>
-                      <span class="mono text-[0.7rem] text-neutral-400 strike" x-text="entry.text || '(blank)'"></span>
-                      <span class="text-[0.66rem] text-neutral-400" x-text="entry.reason"></span>
+                      <span class="mono text-[0.66rem] text-neutral-500" x-text="entry.lineNumbers.join(', ')"></span>
+                      <span class="mono text-[0.7rem] text-neutral-500 strike" x-text="entry.text || '(blank)'"></span>
+                      <span class="text-[0.66rem] text-neutral-500" x-text="entry.reason"></span>
                       <button type="button" x-show="entry.reason === 'dismissed'" x-cloak
                               class="text-[0.66rem] text-uj underline underline-offset-2"
                               @click="undoRow(entry.lineNumbers[0])">put it back</button>
@@ -615,9 +640,6 @@
 
   <footer class="max-w-[1100px] mx-auto w-full px-4 pb-8 text-xs text-neutral-500">
     <div class="border-t border-neutral-200 pt-4 flex flex-wrap items-center justify-between gap-x-5 gap-y-1">
-      <span x-show="accessEmail" x-cloak>
-        Signed in as <span class="font-medium text-neutral-600" x-text="accessEmail"></span>
-      </span>
       <span>Nothing on this page writes anything. Steps 4–6 are staff-site#72 and #73.</span>
     </div>
   </footer>
@@ -655,6 +677,15 @@ function schoolBooking() {
     rawPaste: '',
     countValue: '',
     countUnknown: false,
+    // The paste the current declaration was made about. P5's ordering is what
+    // the gate is made of, and a Back button reopens it: staff who cannot make
+    // the numbers agree return to a freely editable count box with the read
+    // count already on screen, which is the anchoring the ordering exists to
+    // prevent — two clicks instead of the one canRedeclare() refuses.
+    //
+    // So the declaration is locked to its paste. Change the paste and it is a
+    // declaration about a different list, and has to be made again.
+    declaredFor: null,
 
     // Step 3
     parsed: null,
@@ -666,8 +697,6 @@ function schoolBooking() {
     showIgnored: false,
     showOverrides: false,
     chipMenu: null,
-
-    accessEmail: '',
 
     init() {
       // Both modules or neither. Every gate on this page is one of their
@@ -681,7 +710,6 @@ function schoolBooking() {
         return;
       }
       this.loadSchools();
-      this.loadIdentity();
     },
 
     // --- step 1 ----------------------------------------------------------
@@ -699,17 +727,6 @@ function schoolBooking() {
         // aid to reusing an existing tag, not a permission to proceed.
         this.schools = [];
         this.schoolsState = 'error';
-      }
-    },
-
-    async loadIdentity() {
-      try {
-        const res = await fetch('/cdn-cgi/access/get-identity');
-        if (!res.ok) return;
-        const body = await res.json();
-        this.accessEmail = body.email ?? '';
-      } catch {
-        this.accessEmail = '';
       }
     },
 
@@ -748,9 +765,23 @@ function schoolBooking() {
     },
 
     // --- step 2 ----------------------------------------------------------
+    // The parser's own line count, not a second implementation of it. A
+    // trailing newline is a terminator there and would be a line here, so two
+    // implementations put two different totals on the two screens whose whole
+    // job is agreeing about a number.
     pastedLineCount() {
-      if (!this.rawPaste) return 0;
-      return this.rawPaste.replace(/\r\n|\r/g, '\n').replace(/\n$/, '').split('\n').length;
+      return this.rawPaste ? window.schoolListParser.countLines(this.rawPaste) : 0;
+    },
+
+    countLocked() {
+      return this.declaredFor !== null && this.rawPaste === this.declaredFor;
+    },
+
+    pasteChanged() {
+      if (this.declaredFor === null || this.rawPaste === this.declaredFor) return;
+      this.declaredFor = null;
+      this.countValue = '';
+      this.countUnknown = false;
     },
 
     declaration() {
@@ -765,10 +796,18 @@ function schoolBooking() {
     },
 
     readList() {
+      // Nothing changed since the last read, so this is a Back-then-forward and
+      // not a new one. Re-reading would silently throw away every row staff had
+      // already sorted out.
+      if (this.countLocked() && this.parsed) {
+        this.go(2);
+        return;
+      }
       this.resolutions = {};
       this.parseOptions = {};
       this.drafts = {};
       this.expandedRow = null;
+      this.declaredFor = this.rawPaste;
       this.reparse();
       this.go(2);
     },
@@ -843,9 +882,16 @@ function schoolBooking() {
       }
     },
 
-    setBlockSize(value) {
+    // A refused value is put back, not just ignored. Leaving it in the box
+    // while the parse keeps the old block size is two plausible states
+    // contradicting each other with nothing thrown — the fault shape §16
+    // records, and the one this page exists to be careful about.
+    setBlockSize(value, input) {
       const n = Number(String(value).trim());
-      if (!Number.isInteger(n) || n < 2) return;
+      if (!Number.isInteger(n) || n < 2) {
+        if (input) input.value = this.reviewed?.blockSize ?? '';
+        return;
+      }
       this.override({ layout: 'vertical', blockSize: n });
     },
 
@@ -887,6 +933,16 @@ function schoolBooking() {
       return (named && String(named).trim()) || `Column ${index + 1}`;
     },
 
+    // Columns holding a name in every record row, minus the ones already
+    // spoken for. Empty means the split control has no honest answer to give,
+    // and it is hidden rather than guessing one.
+    nameShapedFree() {
+      const c = this.currentColumns();
+      if (!c) return [];
+      return (this.reviewed?.nameShapedColumns ?? [])
+        .filter((index) => index !== c.combined && index !== c.dob);
+    },
+
     columnChoices() {
       const width = this.reviewed?.fieldCount ?? 0;
       return Array.from({ length: width }, (_, index) => ({ index, label: this.columnLabel(index) }));
@@ -923,9 +979,11 @@ function schoolBooking() {
         this.applyColumns({ dob: c.dob, firstName: null, lastName: null, combined: c.firstName });
         return;
       }
-      // Back to two columns: the second is whichever column is not already
-      // spoken for, which is the only unambiguous answer available here.
-      const free = this.columnChoices().map((x) => x.index).filter((i) => i !== c.combined && i !== c.dob);
+      // Back to two columns. The second one is picked from the columns the
+      // parser found to hold a name in *every* row — never the next free
+      // index, which is how `Email` or `YearLevel` becomes somebody's
+      // permanent surname, obeyed literally with nothing to disagree with it.
+      const free = this.nameShapedFree();
       if (free.length === 0) return;
       this.applyColumns({ dob: c.dob, firstName: c.combined, lastName: free[0], combined: null });
     },
@@ -940,16 +998,11 @@ function schoolBooking() {
       this.override({ columns });
     },
 
-    usableColumns(c) {
-      const named = COLUMN_ROLES.map((role) => c[role]).filter((v) => v !== null && v !== undefined);
-      if (new Set(named).size !== named.length) return false;
-      if (c.dob === null || c.dob === undefined) return false;
-      const combined = c.combined !== null && c.combined !== undefined;
-      const pair = c.firstName !== null && c.firstName !== undefined
-        && c.lastName !== null && c.lastName !== undefined;
-      // Exactly one name shape: one column holding the whole name, or two
-      // holding its halves. Neither, or both, names no columns at all.
-      return combined !== pair;
+    // The parser's rule, asked rather than restated. Two copies of "what is a
+    // usable mapping" drift, and the drift is silent: the page keeps offering
+    // a chip the parser has started refusing.
+    usableColumns(columns) {
+      return window.schoolListParser.usableColumns(columns, this.reviewed?.fieldCount ?? 0);
     },
 
     // --- rows ------------------------------------------------------------
@@ -985,8 +1038,15 @@ function schoolBooking() {
       this.resolveRow(key, null);
     },
 
-    acknowledgeable(kind) {
-      return kind === 'combined-name-comma' || kind === 'excel-serial-dates';
+    // A blocker says what answering it means; this dispatches on that and
+    // knows no blocker kinds. Adding one in steps.js therefore cannot arrive
+    // without its control — which is what a blocker with no way out of it
+    // would be: a gate staff are simply stuck behind.
+    answerBlocker(action) {
+      if (action.answers === 'nameOrder') this.override({ nameOrder: action.value });
+      else if (action.answers === 'dateOrientation') this.override({ dateOrientation: action.value });
+      else if (action.answers === 'acknowledge') this.acknowledge(action.value);
+      else if (action.answers === 'redeclare') this.redeclare(action.value);
     },
 
     acknowledge(kind) {
@@ -994,13 +1054,10 @@ function schoolBooking() {
       this.refresh();
     },
 
-    canRedeclare() {
-      return window.schoolBookingSteps.canRedeclare(this.reviewed);
-    },
-
-    redeclare() {
-      this.countValue = String(this.reviewed.counts.records);
+    redeclare(count) {
+      this.countValue = String(count);
       this.countUnknown = false;
+      this.declaredFor = this.rawPaste;
       this.refresh();
     },
 

--- a/school-booking.html
+++ b/school-booking.html
@@ -1,0 +1,1044 @@
+<!--
+  School group booking — steps 1 to 3.
+
+  staff-site#71, map #46. Design:
+  docs/superpowers/specs/2026-08-19-school-group-booking-design.md §7 and §9.
+  Variant A, the gated stepper, decided on #54 against three built prototypes.
+
+  NOT LINKED FROM tools.json. That is deliberate and is the last step of #46
+  (§17): `main` is production here, so every step before the hub entry lands is
+  deployed but invisible to staff. Steps 4–6 — the session picker, the preview
+  and Apply — are #72 and #73, and nothing on this page can write anything.
+
+  Two house rules this page is built around (§16):
+
+    1. Never bind an Alpine directive to a function-valued property. Alpine
+       INVOKES a function returned by an expression, so `x-show="b.fix"` runs
+       the fix on every render tick. It defeated this exact confirmation gate
+       during #54 — silently, with no user action and no error. Bind to a
+       string or a boolean; call the function only from `@click`.
+       school-booking/test/alpine-bindings.test.js reads this file and fails on
+       any instance of it.
+
+    2. Bump the `?v=` below whenever either module gains or renames an export.
+       There is no build step — a browser holding an earlier copy of a module
+       serves it against newer HTML, and a stale copy of a *gate* module breaks
+       every check at once and in silence.
+-->
+<!doctype html>
+<html lang="en-AU">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>School booking - staff portal</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Crect%20width='24'%20height='24'%20rx='6'%20fill='%238b1c23'/%3E%3Cg%20transform='translate(4.5%204.5)%20scale(0.625)'%20fill='none'%20stroke='%23fff'%20stroke-width='2.4'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M3%207.5%2012%203l9%204.5-9%204.5z'/%3E%3Cpath%20d='M7%2010v5c0%201.7%202.2%203%205%203s5-1.3%205-3v-5'/%3E%3C/g%3E%3C/svg%3E">
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+  tailwind.config = {
+    theme: {
+      extend: {
+        colors: { uj: { DEFAULT: '#8b1c23', dark: '#6b181e', light: '#ab2930' } },
+        fontFamily: { sans: ['"Inter"', '"Segoe UI"', 'system-ui', '-apple-system', 'sans-serif'] },
+        borderRadius: { card: '18px' }
+      }
+    }
+  }
+</script>
+
+<!-- Module scripts are deferred and deferred scripts run in document order, so
+     this sits ABOVE the Alpine tag deliberately: it guarantees both globals
+     exist before any Alpine expression is evaluated. Same arrangement as
+     vouchers/index.html, for the same reason.
+
+     ?v= on BOTH: see the header comment. `bootstrapError` below turns a stale
+     or missing module into a visible refusal rather than a page whose gates
+     quietly do nothing. -->
+<script type="module">
+  import * as parser from './school-booking/parse.js?v=1';
+  import * as steps from './school-booking/steps.js?v=1';
+  window.schoolListParser = parser;
+  window.schoolBookingSteps = steps;
+</script>
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+
+<style>
+  [x-cloak] { display: none !important; }
+  :root { --uj: #8b1c23; --border-soft: rgba(31, 41, 55, 0.08); }
+
+  .hub-header {
+    background:
+      radial-gradient(circle at 20% -20%, rgba(171, 49, 57, 0.32), transparent 55%),
+      linear-gradient(145deg, rgba(107, 24, 30, 0.95), rgba(139, 28, 35, 0.92));
+  }
+  .header-icon {
+    width: 58px; height: 58px; border-radius: 18px; color: var(--uj);
+    background: linear-gradient(135deg, #f4d4d8, #e0a9b0);
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    box-shadow: 0 12px 24px -10px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  }
+  .header-icon svg { width: 28px; height: 28px; }
+
+  .panel {
+    background: #fff; border: 1px solid var(--border-soft); border-radius: 18px;
+    box-shadow: 0 12px 30px -24px rgba(15, 23, 42, 1); padding: 24px 26px;
+  }
+
+  .field-label {
+    display: block; font-size: 0.67rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    color: #9ca3af; margin-bottom: 6px;
+  }
+
+  /* Combobox — the staff portal's dropdown, copied from vouchers/stats.html. A
+     native <select> renders with the OS chevron and OS menu, which is exactly
+     what the voucher pages threw out; this page must not reintroduce it. */
+  .combo { position: relative; }
+  .combo-trigger {
+    width: 100%; min-height: 40px;
+    display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    padding: 0.5rem 0.75rem; border-radius: 12px;
+    border: 1px solid rgba(31, 41, 55, 0.12);
+    background: #fff; color: #1f2937;
+    font-size: 0.875rem; line-height: 1.35; text-align: left;
+    transition: border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+  }
+  .combo-trigger:hover { border-color: rgba(139, 28, 35, 0.32); }
+  .combo-trigger:focus { outline: none; border-color: var(--uj); box-shadow: 0 0 0 3px rgba(139, 28, 35, 0.14); }
+  .combo-trigger > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .combo-chevron {
+    width: 16px; height: 16px; flex-shrink: 0; color: #6b7280;
+    fill: none; stroke: currentColor; stroke-width: 2;
+    stroke-linecap: round; stroke-linejoin: round;
+    transition: transform 150ms ease;
+  }
+  .combo-trigger[aria-expanded="true"] .combo-chevron { transform: rotate(180deg); }
+  .combo-menu {
+    position: absolute; z-index: 40; left: 0; right: 0; top: calc(100% + 6px);
+    max-height: min(60vh, 560px); overflow: auto;
+    padding: 6px; border-radius: 14px;
+    border: 1px solid rgba(139, 28, 35, 0.14);
+    background: #fff; box-shadow: 0 18px 36px -26px rgba(15, 23, 42, 0.75);
+  }
+  .combo-option {
+    width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 10px;
+    border: 0; border-radius: 10px; padding: 8px 10px;
+    background: transparent; color: #1f2937; font-size: 0.875rem;
+    text-align: left; cursor: pointer;
+  }
+  .combo-option:hover, .combo-option.active { background: rgba(139, 28, 35, 0.08); color: var(--uj); }
+  .combo-option.active { font-weight: 700; }
+
+  /* Segmented control — the step strip. */
+  .seg { display: inline-flex; background: rgba(31,41,55,0.05); border-radius: 12px; padding: 3px; gap: 2px; flex-wrap: wrap; }
+  .seg button {
+    border: 0; border-radius: 9px; padding: 6px 12px; background: transparent;
+    color: #6b7280; font-size: 0.8rem; font-weight: 600; cursor: pointer; white-space: nowrap;
+  }
+  .seg button.active { background: #fff; color: var(--uj); box-shadow: 0 1px 3px rgba(15,23,42,0.12); }
+  .seg button:disabled { color: #d1d5db; cursor: not-allowed; }
+
+  .pill {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 2px 8px; border-radius: 9999px;
+    font-size: 0.67rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.03em; white-space: nowrap;
+    box-shadow: inset 0 0 0 1px currentColor;
+  }
+
+  /* A column chip. Deliberately looks like something you can press: P6's
+     mapping is the decision that silently produces wrong permanent contacts,
+     so the affordance to correct it has to be visible without being hunted. */
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    border: 1px dashed rgba(31, 41, 55, 0.22); border-radius: 10px;
+    padding: 4px 9px; background: #fff; font-size: 0.78rem; color: #1f2937;
+    cursor: pointer;
+  }
+  .chip:hover { border-color: rgba(139, 28, 35, 0.45); color: var(--uj); }
+  .chip-role { font-size: 0.62rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af; }
+
+  .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; }
+  .strike { text-decoration: line-through; }
+
+  .row-hit { cursor: pointer; }
+  .row-hit:hover { background: rgba(139, 28, 35, 0.025); }
+  .lane { border-left: 3px solid transparent; }
+  .lane-need { border-left-color: #f59e0b; }
+  .lane-bad  { border-left-color: #e11d48; }
+  .lane-ok   { border-left-color: #10b981; }
+</style>
+</head>
+
+<!-- No x-init calling init(). Alpine calls a component's own init() for us, and
+     naming it here as well ran the whole bootstrap twice. See vouchers#69. -->
+<body class="bg-neutral-50 text-neutral-800 font-sans min-h-screen flex flex-col"
+      x-data="schoolBooking()" x-cloak>
+
+  <header class="hub-header text-white">
+    <div class="max-w-[1100px] mx-auto px-6 pt-10 pb-16 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
+      <div class="flex items-center gap-4 shrink-0">
+        <div class="header-icon flex items-center justify-center shrink-0">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7.5 12 3l9 4.5-9 4.5z"/><path d="M7 10v5c0 1.7 2.2 3 5 3s5-1.3 5-3v-5"/>
+          </svg>
+        </div>
+        <div>
+          <div class="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-white/65 leading-none mb-2">Staff Portal</div>
+          <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-white leading-none">School booking</h1>
+          <p class="text-sm text-white/75 mt-2">Paste a school's student list, check what we read, then book them in.</p>
+        </div>
+      </div>
+      <nav class="flex items-center gap-1.5 sm:justify-end">
+        <a href="/" class="px-4 py-2 rounded-xl border border-white/30 bg-white/[0.12] hover:bg-white/[0.22] text-[0.9rem] font-semibold transition-all">
+          Back to the hub
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-[1100px] mx-auto w-full px-4 pb-8 -mt-10 flex-1">
+    <div class="panel">
+
+      <!-- A module that did not load is a page whose gates are decoration. Said
+           out loud rather than left to fail per-expression, because every gate
+           on this page fails the same way and at the same moment. -->
+      <div x-show="bootstrapError" x-cloak
+           class="rounded-xl bg-rose-50 border border-rose-200 text-rose-800 px-4 py-3 text-sm mb-5">
+        <b>This page is not safe to use.</b>
+        <span x-text="bootstrapError"></span>
+        Reload with a hard refresh; if that does not fix it, the page has shipped against a stale module.
+      </div>
+
+      <!-- ── Step strip ──────────────────────────────────────────────────── -->
+      <div class="flex items-center justify-between gap-4 flex-wrap mb-6">
+        <div class="seg">
+          <template x-for="(s, i) in STEPS" :key="s.key">
+            <button type="button" :class="stepIndex === i ? 'active' : ''"
+                    :disabled="i > maxStepReached || !s.built"
+                    :title="s.built ? '' : 'Not built yet'"
+                    @click="i <= maxStepReached && s.built && go(i)">
+              <span class="mono text-[0.7rem] mr-1" x-text="i + 1"></span><span x-text="s.label"></span>
+            </button>
+          </template>
+        </div>
+        <div class="text-xs text-neutral-400">
+          Step <span class="mono" x-text="stepIndex + 1"></span> of <span class="mono" x-text="STEPS.length"></span>
+        </div>
+      </div>
+
+      <!-- ── 1 · School ──────────────────────────────────────────────────── -->
+      <section x-show="stepIndex === 0">
+        <h2 class="text-lg font-bold mb-1">Which school is this?</h2>
+        <p class="text-sm text-neutral-500 mb-5 max-w-2xl">
+          Reuse the school's existing tag wherever there is one. It becomes the permanent
+          marker on every contact this run creates, and it is the only record of which
+          school a contact belongs to that this system will ever have — so a second
+          spelling of one school splits its history in two, permanently.
+        </p>
+
+        <div class="max-w-lg">
+          <span class="field-label">School</span>
+          <div class="combo" @click.outside="schoolOpen = false" @keydown.escape.window="schoolOpen = false">
+            <button type="button" class="combo-trigger" @click="schoolOpen = !schoolOpen"
+                    :aria-expanded="schoolOpen ? 'true' : 'false'" aria-haspopup="listbox" aria-label="School">
+              <span x-text="tag || 'Choose a school, or type a new tag…'"></span>
+              <svg class="combo-chevron" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"/></svg>
+            </button>
+            <div x-show="schoolOpen" x-transition.origin.top x-cloak class="combo-menu" role="listbox">
+              <div class="px-1 pb-2">
+                <input x-model="schoolQuery" type="text" placeholder="Type to filter, or type a new tag…"
+                       class="w-full rounded-lg border border-neutral-200 px-2.5 py-1.5 text-sm focus:outline-none focus:border-uj"
+                       @keydown.enter.prevent="useTypedTag()">
+                <p class="text-[0.68rem] text-neutral-400 mt-1.5 px-1" x-text="schoolsNote()"></p>
+              </div>
+
+              <template x-for="s in filteredSchools()" :key="s.tag">
+                <button type="button" role="option" class="combo-option"
+                        :aria-selected="tag === s.tag ? 'true' : 'false'" :class="tag === s.tag ? 'active' : ''"
+                        @click="tag = s.tag; schoolOpen = false">
+                  <span class="mono" x-text="s.tag"></span>
+                  <span class="text-[0.68rem] text-neutral-400"
+                        x-text="s.contacts + (s.contacts === 1 ? ' contact' : ' contacts')"></span>
+                </button>
+              </template>
+
+              <!-- A new tag is a real and expected outcome — it is how a school
+                   gets its first one. It is offered last and shown normalised,
+                   so what will be written is what is on screen before the
+                   click, not after it. -->
+              <button type="button" class="combo-option" x-show="typedTag() && !knownTag(typedTag())" x-cloak
+                      @click="useTypedTag()">
+                <span>Use a new tag <span class="mono font-bold" x-text="typedTag()"></span></span>
+                <span class="text-[0.68rem] text-neutral-400">new school</span>
+              </button>
+            </div>
+          </div>
+
+          <p class="text-xs mt-3" :class="marker() ? 'text-neutral-500' : 'text-neutral-400'">
+            <template x-if="marker()">
+              <span>Every contact this run creates is written with <span class="mono text-neutral-700" x-text="marker()"></span>.</span>
+            </template>
+            <template x-if="!marker()">
+              <span>Pick or type a school to see the marker that will be written.</span>
+            </template>
+          </p>
+        </div>
+
+        <div class="flex justify-end mt-8">
+          <button type="button" :disabled="!tag"
+                  class="bg-uj hover:bg-uj-dark text-white rounded-xl px-5 py-2.5 text-sm font-semibold disabled:opacity-40"
+                  @click="go(1)">Paste the list →</button>
+        </div>
+      </section>
+
+      <!-- ── 2 · Paste, and declare the count ────────────────────────────── -->
+      <section x-show="stepIndex === 1">
+        <h2 class="text-lg font-bold mb-1">Paste the list, then say how many students there should be</h2>
+        <p class="text-sm text-neutral-500 mb-5 max-w-2xl">
+          Copy the students straight out of the email, spreadsheet or PDF — tabs, aligned
+          columns and one-field-per-line all work. Then answer the count
+          <b>before</b> we show you what we read: a number already on screen is one
+          nobody argues with, and this single check catches a misread layout, a header
+          absorbed as a student, a truncated paste and a phantom column all at once.
+        </p>
+
+        <textarea x-model="rawPaste" rows="12" spellcheck="false"
+          aria-label="The pasted student list"
+          class="w-full rounded-xl border border-neutral-200 p-3 text-sm mono focus:outline-none focus:border-uj focus:ring-2 focus:ring-uj/15"></textarea>
+        <p class="text-xs text-neutral-400 mt-1">
+          <span class="mono" x-text="pastedLineCount()"></span> lines pasted.
+        </p>
+
+        <div class="flex items-end gap-4 flex-wrap mt-6">
+          <div>
+            <span class="field-label">Expected students</span>
+            <input x-model="countValue" type="text" inputmode="numeric" :disabled="countUnknown"
+                   aria-label="Expected number of students"
+                   class="w-32 rounded-xl border border-neutral-200 px-3 py-2 text-lg mono font-bold focus:outline-none focus:border-uj focus:ring-2 focus:ring-uj/15 disabled:bg-neutral-50 disabled:text-neutral-300">
+          </div>
+          <label class="flex items-center gap-2 text-sm text-neutral-600 pb-2.5 cursor-pointer">
+            <input type="checkbox" x-model="countUnknown" class="rounded border-neutral-300 text-uj focus:ring-uj/30">
+            I don't know
+          </label>
+        </div>
+        <p x-show="countUnknown" x-cloak
+           class="text-xs text-amber-700 mt-3 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 inline-block">
+          Fine — the count becomes a banner you have to read, rather than a gate that blocks.
+        </p>
+
+        <div class="flex justify-between mt-8">
+          <button type="button" class="text-sm text-neutral-500 hover:text-neutral-800" @click="go(0)">← Back</button>
+          <button type="button" :disabled="!canRead()"
+                  class="bg-uj hover:bg-uj-dark text-white rounded-xl px-5 py-2.5 text-sm font-semibold disabled:opacity-40"
+                  @click="readList()">Show me what you read →</button>
+        </div>
+      </section>
+
+      <!-- ── 3 · Rows ────────────────────────────────────────────────────── -->
+      <section x-show="stepIndex === 2">
+        <h2 class="text-lg font-bold mb-3">What we read</h2>
+
+        <template x-if="reviewed">
+          <div>
+            <!-- The count gate, and the reconciliation under it. P1 is a sum,
+                 so it is shown as one — a sum that stops adding up is the only
+                 thing that catches a row quietly disappearing. -->
+            <div class="rounded-xl px-3.5 py-2.5 text-sm mb-2"
+                 :class="countTone()">
+              <div class="font-semibold" x-text="countLine()"></div>
+              <div class="text-xs mt-1 opacity-90" x-text="reconciliationLine()"></div>
+            </div>
+
+            <!-- The verdict, in plain English, with the override behind it. -->
+            <div class="rounded-xl bg-sky-50 border border-sky-200 text-sky-900 px-3.5 py-2.5 text-sm mb-2"
+                 x-show="!reviewed.blockers.some(b => b.kind === 'refusal')" x-cloak>
+              <div class="flex items-start justify-between gap-3 flex-wrap">
+                <div>
+                  <div x-text="reviewed.verdict"></div>
+                  <div class="text-xs text-sky-800/80 mt-1" x-text="ignoredColumnsLine()"></div>
+                </div>
+                <button type="button" class="underline underline-offset-2 font-semibold shrink-0"
+                        @click="showOverrides = !showOverrides"
+                        x-text="showOverrides ? 'done' : 'change'"></button>
+              </div>
+
+              <div x-show="showOverrides" x-cloak class="mt-3 pt-3 border-t border-sky-200 space-y-3">
+                <div>
+                  <span class="field-label text-sky-700">Layout</span>
+                  <div class="flex items-center gap-2 flex-wrap text-sm">
+                    <button type="button" class="chip" :class="reviewed.layout === 'horizontal' ? 'border-solid border-uj text-uj' : ''"
+                            @click="setLayout('horizontal')">One student per line</button>
+                    <button type="button" class="chip" :class="reviewed.layout === 'vertical' ? 'border-solid border-uj text-uj' : ''"
+                            @click="setLayout('vertical')">Fields down the page</button>
+                    <template x-if="reviewed.layout === 'vertical'">
+                      <label class="flex items-center gap-1.5 text-sm text-sky-900">
+                        <input type="text" inputmode="numeric" class="w-16 rounded-lg border border-sky-200 px-2 py-1 text-sm mono"
+                               aria-label="Fields per student"
+                               :value="reviewed.blockSize"
+                               @change="setBlockSize($event.target.value)">
+                        fields per student
+                      </label>
+                    </template>
+                  </div>
+                </div>
+
+                <div x-show="reviewed.columns" x-cloak>
+                  <span class="field-label text-sky-700">Columns</span>
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <template x-for="chip in columnChips()" :key="chip.role">
+                      <div class="relative">
+                        <button type="button" class="chip" @click="chipMenu = (chipMenu === chip.role ? null : chip.role)">
+                          <span class="chip-role" x-text="chip.roleLabel"></span>
+                          <span class="mono" x-text="chip.label"></span>
+                        </button>
+                        <div x-show="chipMenu === chip.role" x-cloak class="combo-menu w-56"
+                             @click.outside="chipMenu = null">
+                          <template x-for="choice in columnChoices()" :key="choice.index">
+                            <button type="button" class="combo-option"
+                                    :class="choice.index === chip.index ? 'active' : ''"
+                                    @click="setColumn(chip.role, choice.index)">
+                              <span class="mono" x-text="choice.label"></span>
+                              <span class="text-[0.68rem] text-neutral-400" x-text="'column ' + (choice.index + 1)"></span>
+                            </button>
+                          </template>
+                        </div>
+                      </div>
+                    </template>
+
+                    <button type="button" class="chip" x-show="reviewed.columns?.combined === null" x-cloak
+                            @click="swapNames()">⇄ swap first and last</button>
+                    <button type="button" class="chip" x-show="reviewed.columns?.combined === null" x-cloak
+                            @click="setNameShape('combined')">the name is one column</button>
+                    <button type="button" class="chip" x-show="reviewed.columns?.combined !== null" x-cloak
+                            @click="setNameShape('split')">the name is two columns</button>
+                  </div>
+                </div>
+
+                <p class="text-xs text-sky-800/80">
+                  An override is obeyed exactly as given, right or wrong — if the verdict
+                  above stops describing the list, change it back.
+                  <button type="button" class="underline underline-offset-2 font-semibold" @click="clearOverrides()">
+                    Read it again from scratch
+                  </button>
+                </p>
+              </div>
+            </div>
+
+            <!-- Blockers. Each is data: a title, a detail and the lines it is
+                 about. None of them carries a function, which is what makes
+                 the #54 render-tick bug unreachable from here. -->
+            <template x-for="b in reviewed.blockers" :key="b.key">
+              <div class="rounded-xl px-3.5 py-2.5 text-sm mb-2 border"
+                   :class="b.severity === 'block' ? 'bg-rose-50 border-rose-200 text-rose-800' : 'bg-amber-50 border-amber-200 text-amber-800'">
+                <div class="flex items-start justify-between gap-3 flex-wrap">
+                  <div>
+                    <div class="font-semibold" x-text="b.title"></div>
+                    <div class="text-xs mt-0.5 opacity-90" x-text="b.detail"></div>
+                  </div>
+                  <div class="flex items-center gap-2 shrink-0">
+                    <!-- The re-declare, and the gate that survives it. Offered
+                         only once staff have moved the count themselves; see
+                         canRedeclare() in steps.js for why an ungated one is a
+                         one-click dismissal of the gate it escapes. -->
+                    <button type="button" x-show="b.kind === 'count-mismatch' && canRedeclare()" x-cloak
+                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
+                            @click="redeclare()">
+                      The count has changed — make it <span class="mono" x-text="reviewed.counts.records"></span>
+                    </button>
+                    <button type="button" x-show="acknowledgeable(b.kind)" x-cloak
+                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
+                            @click="acknowledge(b.kind)">Checked — go on</button>
+                    <button type="button" x-show="b.kind === 'name-order'" x-cloak
+                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
+                            @click="setNameOrder('first-last')">First name first</button>
+                    <button type="button" x-show="b.kind === 'name-order'" x-cloak
+                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
+                            @click="setNameOrder('last-first')">Surname first</button>
+                    <button type="button" x-show="b.kind === 'date-orientation'" x-cloak
+                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
+                            @click="setDateOrientation('dmy')">Day/month</button>
+                    <button type="button" x-show="b.kind === 'date-orientation'" x-cloak
+                            class="rounded-lg border border-rose-300 px-3 py-1.5 text-xs font-semibold hover:bg-rose-100"
+                            @click="setDateOrientation('mdy')">Month/day</button>
+                  </div>
+                </div>
+              </div>
+            </template>
+
+            <div x-show="reviewed.ready" x-cloak
+                 class="rounded-xl bg-emerald-50 border border-emerald-200 text-emerald-800 px-3.5 py-2.5 text-sm mb-2">
+              Every line is accounted for.
+            </div>
+
+            <!-- ── The rows ─────────────────────────────────────────────── -->
+            <div class="rounded-card border border-neutral-200 overflow-hidden bg-white mt-4"
+                 x-show="reviewed.rows.length" x-cloak>
+              <div class="overflow-x-auto">
+              <table class="w-full">
+                <thead>
+                  <tr class="border-b border-neutral-100 bg-neutral-50/70">
+                    <th class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider">Student</th>
+                    <th class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider">Date of birth</th>
+                    <th class="text-left px-4 py-2.5 text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider">Read</th>
+                  </tr>
+                </thead>
+                <template x-for="r in reviewed.rows" :key="r.key">
+                  <tbody class="divide-y divide-neutral-50">
+                    <tr class="lane" :class="[laneFor(r), r.needsHuman ? 'row-hit' : '']"
+                        @click="r.needsHuman && toggleRow(r.key)">
+                      <td class="px-4 py-2.5">
+                        <div class="text-sm font-medium"
+                             :class="r.bucket === 'error' ? 'text-rose-700 mono' : 'text-neutral-800'"
+                             x-text="r.bucket === 'error' ? r.raw : nameOf(r)"></div>
+                        <div x-show="r.note" class="text-xs mt-0.5"
+                             :class="r.bucket === 'error' ? 'text-rose-600' : 'text-amber-700'" x-text="r.note"></div>
+                        <div class="text-[0.66rem] text-neutral-400 mono mt-0.5"
+                             x-text="'line ' + r.lineNumbers.join(', ')"></div>
+                      </td>
+                      <td class="px-4 py-2.5 text-sm mono text-neutral-600" x-text="r.dob || '—'"></td>
+                      <td class="px-4 py-2.5">
+                        <div class="flex items-center gap-2">
+                          <span class="pill" :class="stateTone(r)" x-text="r.state"></span>
+                          <button x-show="r.needsHuman" type="button"
+                                  class="text-xs font-semibold text-uj underline underline-offset-2"
+                                  @click.stop="toggleRow(r.key)"
+                                  x-text="expandedRow === r.key ? 'close' : 'sort it out'"></button>
+                          <button x-show="!r.needsHuman" type="button"
+                                  class="text-xs text-neutral-400 hover:text-neutral-700 underline underline-offset-2"
+                                  @click.stop="toggleRow(r.key)"
+                                  x-text="expandedRow === r.key ? 'close' : 'change'"></button>
+                        </div>
+                      </td>
+                    </tr>
+
+                    <!-- The row expands in place. A single-column stepper has
+                         nowhere to put a detail panel, and a modal would be a
+                         gate inside a gate (§9). -->
+                    <tr x-show="expandedRow === r.key" x-cloak>
+                      <td colspan="3" class="bg-neutral-50/70 border-t border-neutral-100 px-4 py-4">
+                        <div class="max-w-2xl">
+                          <div class="text-[0.67rem] font-semibold uppercase tracking-[0.05em] text-neutral-400 mb-2">Sort it out</div>
+
+                          <template x-if="r.bucket === 'error'">
+                            <div class="space-y-2">
+                              <p class="text-xs text-rose-700" x-text="r.note"></p>
+                              <div class="flex gap-2 flex-wrap">
+                                <input x-model="draftFor(r.key).firstName" placeholder="First name" aria-label="First name"
+                                       class="flex-1 min-w-[120px] rounded-xl border border-neutral-200 px-3 py-2 text-sm">
+                                <input x-model="draftFor(r.key).lastName" placeholder="Surname" aria-label="Surname"
+                                       class="flex-1 min-w-[120px] rounded-xl border border-neutral-200 px-3 py-2 text-sm">
+                                <input x-model="draftFor(r.key).dob" placeholder="dd/mm/yyyy" aria-label="Date of birth"
+                                       class="w-32 rounded-xl border border-neutral-200 px-3 py-2 text-sm mono">
+                              </div>
+                              <div class="flex gap-2 flex-wrap">
+                                <button type="button" class="rounded-xl bg-uj text-white px-3.5 py-2 text-sm font-semibold"
+                                        @click="acceptRow(r.key)">This is a student</button>
+                                <button type="button" class="rounded-xl border border-neutral-300 px-3.5 py-2 text-sm font-semibold"
+                                        @click="dismissRow(r.key)">Not a student</button>
+                              </div>
+                              <p class="text-xs text-neutral-400">
+                                Dismissing does not delete the line — it moves to the ignored list, where
+                                the counts can still see it.
+                              </p>
+                            </div>
+                          </template>
+
+                          <template x-if="r.bucket === 'record'">
+                            <div class="space-y-2">
+                              <p class="text-xs text-amber-700" x-show="r.note" x-text="r.note"></p>
+                              <div class="flex gap-2 flex-wrap">
+                                <input x-model="draftFor(r.key).firstName" aria-label="First name"
+                                       class="flex-1 min-w-[120px] rounded-xl border border-neutral-200 px-3 py-2 text-sm">
+                                <input x-model="draftFor(r.key).lastName" aria-label="Surname"
+                                       class="flex-1 min-w-[120px] rounded-xl border border-neutral-200 px-3 py-2 text-sm">
+                              </div>
+                              <div class="flex gap-2 flex-wrap">
+                                <button type="button" class="rounded-xl bg-amber-50 border border-amber-200 text-amber-800 px-3.5 py-2 text-sm font-semibold hover:bg-amber-100"
+                                        @click="confirmRow(r.key)">Confirm and include</button>
+                                <button type="button" class="rounded-xl border border-neutral-300 px-3.5 py-2 text-sm font-semibold"
+                                        @click="dismissRow(r.key)">Not a student</button>
+                                <button type="button" x-show="r.resolution" x-cloak
+                                        class="rounded-xl border border-neutral-300 px-3.5 py-2 text-sm font-semibold"
+                                        @click="undoRow(r.key)">Undo</button>
+                              </div>
+                            </div>
+                          </template>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </template>
+              </table>
+              </div>
+
+              <!-- The ignored count is always on screen; the lines themselves
+                   stay in a drawer. Six struck-through header lines above the
+                   data on every paste trains staff to stop reading that
+                   region, which is the region a real student can hide in. -->
+              <div class="px-4 py-2.5 border-t border-neutral-100 bg-neutral-50/50 text-xs text-neutral-500">
+                <button type="button" class="hover:text-neutral-800" @click="showIgnored = !showIgnored">
+                  <span x-text="showIgnored ? '▾' : '▸'"></span>
+                  <span x-text="ignoredSummary()"></span>
+                </button>
+                <div x-show="showIgnored" x-cloak class="mt-2 space-y-1">
+                  <template x-for="entry in reviewed.ignored" :key="entry.lineNumbers.join('-')">
+                    <div class="flex items-center gap-2">
+                      <span class="mono text-[0.66rem] text-neutral-300" x-text="entry.lineNumbers.join(', ')"></span>
+                      <span class="mono text-[0.7rem] text-neutral-400 strike" x-text="entry.text || '(blank)'"></span>
+                      <span class="text-[0.66rem] text-neutral-400" x-text="entry.reason"></span>
+                      <button type="button" x-show="entry.reason === 'dismissed'" x-cloak
+                              class="text-[0.66rem] text-uj underline underline-offset-2"
+                              @click="undoRow(entry.lineNumbers[0])">put it back</button>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </div>
+
+            <div class="flex justify-between mt-6">
+              <button type="button" class="text-sm text-neutral-500 hover:text-neutral-800" @click="go(1)">← Back</button>
+              <!-- Step 4 is #72. Disabled rather than absent: the strip above
+                   shows six steps because six is the shape of the run, and a
+                   button that vanishes reads as "you are finished". -->
+              <button type="button" disabled title="The session picker is staff-site#72"
+                      class="rounded-xl px-5 py-2.5 text-sm font-semibold bg-neutral-100 text-neutral-400 cursor-not-allowed">
+                Choose sessions → (not built yet)
+              </button>
+            </div>
+          </div>
+        </template>
+      </section>
+
+    </div>
+  </main>
+
+  <footer class="max-w-[1100px] mx-auto w-full px-4 pb-8 text-xs text-neutral-500">
+    <div class="border-t border-neutral-200 pt-4 flex flex-wrap items-center justify-between gap-x-5 gap-y-1">
+      <span x-show="accessEmail" x-cloak>
+        Signed in as <span class="font-medium text-neutral-600" x-text="accessEmail"></span>
+      </span>
+      <span>Nothing on this page writes anything. Steps 4–6 are staff-site#72 and #73.</span>
+    </div>
+  </footer>
+
+<script>
+// The four roles a column can hold. Named once: the swap, the validity check
+// and the chips all have to agree about the list, and three copies would not.
+const COLUMN_ROLES = ['dob', 'firstName', 'lastName', 'combined'];
+
+function schoolBooking() {
+  return {
+    // Six steps, because six is the shape of the run (§9). The last three are
+    // not built; `built` is what the strip and the forward button read, so
+    // there is one place to change when #72 and #73 land.
+    STEPS: [
+      { key: 'school',   label: 'School',   built: true },
+      { key: 'paste',    label: 'Paste',    built: true },
+      { key: 'rows',     label: 'Rows',     built: true },
+      { key: 'sessions', label: 'Sessions', built: false },
+      { key: 'preview',  label: 'Preview',  built: false },
+      { key: 'result',   label: 'Result',   built: false },
+    ],
+    stepIndex: 0,
+    maxStepReached: 0,
+    bootstrapError: '',
+
+    // Step 1
+    schools: [],
+    schoolsState: 'idle',
+    schoolOpen: false,
+    schoolQuery: '',
+    tag: '',
+
+    // Step 2
+    rawPaste: '',
+    countValue: '',
+    countUnknown: false,
+
+    // Step 3
+    parsed: null,
+    reviewed: null,
+    resolutions: {},
+    parseOptions: {},
+    drafts: {},
+    expandedRow: null,
+    showIgnored: false,
+    showOverrides: false,
+    chipMenu: null,
+
+    accessEmail: '',
+
+    init() {
+      // Both modules or neither. Every gate on this page is one of their
+      // exports, so a partial load is a page that looks like it is checking
+      // and is not — the single failure mode §16 says to make loud.
+      const missing = [];
+      if (!window.schoolListParser?.parseStudentList) missing.push('the list parser');
+      if (!window.schoolBookingSteps?.review) missing.push('the step rules');
+      if (missing.length) {
+        this.bootstrapError = `Could not load ${missing.join(' and ')}.`;
+        return;
+      }
+      this.loadSchools();
+      this.loadIdentity();
+    },
+
+    // --- step 1 ----------------------------------------------------------
+    async loadSchools() {
+      this.schoolsState = 'loading';
+      try {
+        const res = await fetch('/api/clubworx/schools', { headers: { accept: 'application/json' } });
+        const body = await res.json();
+        if (!res.ok || !body.ok) throw new Error(body.error || `HTTP ${res.status}`);
+        this.schools = body.schools ?? [];
+        this.schoolsState = 'ready';
+      } catch {
+        // A failed read must not block step 1. Typing a tag is a first-class
+        // route — it is how a school gets its first one — and the list is an
+        // aid to reusing an existing tag, not a permission to proceed.
+        this.schools = [];
+        this.schoolsState = 'error';
+      }
+    },
+
+    async loadIdentity() {
+      try {
+        const res = await fetch('/cdn-cgi/access/get-identity');
+        if (!res.ok) return;
+        const body = await res.json();
+        this.accessEmail = body.email ?? '';
+      } catch {
+        this.accessEmail = '';
+      }
+    },
+
+    schoolsNote() {
+      if (this.schoolsState === 'loading') return 'Reading the schools Clubworx already knows about…';
+      if (this.schoolsState === 'error') {
+        return 'Could not read the existing schools. You can still type a tag — check the spelling twice.';
+      }
+      if (this.schools.length === 0) return 'No school-tagged contacts yet. Typing a tag creates the first.';
+      return `${this.schools.length} schools already tagged in Clubworx.`;
+    },
+
+    typedTag() {
+      return window.schoolBookingSteps.schoolTag(this.schoolQuery);
+    },
+
+    knownTag(tag) {
+      return this.schools.some((s) => s.tag === tag);
+    },
+
+    filteredSchools() {
+      const q = this.typedTag();
+      const list = q ? this.schools.filter((s) => s.tag.includes(q)) : this.schools;
+      return [...list].sort((a, b) => b.contacts - a.contacts);
+    },
+
+    useTypedTag() {
+      const tag = this.typedTag();
+      if (!tag) return;
+      this.tag = tag;
+      this.schoolOpen = false;
+    },
+
+    marker() {
+      return window.schoolBookingSteps.schoolMarker(this.tag) ?? '';
+    },
+
+    // --- step 2 ----------------------------------------------------------
+    pastedLineCount() {
+      if (!this.rawPaste) return 0;
+      return this.rawPaste.replace(/\r\n|\r/g, '\n').replace(/\n$/, '').split('\n').length;
+    },
+
+    declaration() {
+      return window.schoolBookingSteps.countDeclaration({
+        value: this.countValue,
+        unknown: this.countUnknown,
+      });
+    },
+
+    canRead() {
+      return Boolean(this.rawPaste.trim()) && this.declaration().ready;
+    },
+
+    readList() {
+      this.resolutions = {};
+      this.parseOptions = {};
+      this.drafts = {};
+      this.expandedRow = null;
+      this.reparse();
+      this.go(2);
+    },
+
+    // --- step 3 ----------------------------------------------------------
+    reparse() {
+      this.parsed = window.schoolListParser.parseStudentList(this.rawPaste, this.parseOptions);
+      this.refresh();
+    },
+
+    refresh() {
+      this.reviewed = window.schoolBookingSteps.review(this.parsed, {
+        declaration: this.declaration(),
+        resolutions: this.resolutions,
+      });
+      this.syncDrafts();
+    },
+
+    // Edit buffers are seeded here, once per review, rather than lazily from
+    // `draftFor()`. The expanded row is rendered hidden rather than absent, so
+    // a lazy seed would run inside a render for every row on the page — a
+    // write during a render tick, which is the same family of fault as the
+    // `x-show="b.fix"` bug this page is built to avoid.
+    syncDrafts() {
+      const next = { ...this.drafts };
+      let added = false;
+      for (const row of this.reviewed?.rows ?? []) {
+        if (next[row.key]) continue;
+        next[row.key] = { firstName: row.firstName ?? '', lastName: row.lastName ?? '', dob: '' };
+        added = true;
+      }
+      if (added) this.drafts = next;
+    },
+
+    // Every override re-parses from the original paste rather than patching
+    // the last result. A parse is the only thing that knows what a different
+    // layout or column means for every downstream inference, and half a
+    // re-read is a list nobody chose.
+    override(patch) {
+      this.parseOptions = { ...this.parseOptions, ...patch };
+      // Resolutions are keyed by source line, which survives a re-parse of the
+      // same paste — so they are deliberately kept. A staff member who fixes
+      // the column mapping has not un-dismissed the teacher they dismissed.
+      this.expandedRow = null;
+      this.chipMenu = null;
+      this.reparse();
+    },
+
+    clearOverrides() {
+      this.parseOptions = {};
+      this.expandedRow = null;
+      this.chipMenu = null;
+      this.reparse();
+    },
+
+    setLayout(layout) {
+      if (layout === 'vertical') {
+        this.override({ layout, blockSize: this.parseOptions.blockSize ?? this.reviewed?.blockSize ?? null });
+      } else {
+        this.override({ layout, blockSize: null });
+      }
+    },
+
+    setBlockSize(value) {
+      const n = Number(String(value).trim());
+      if (!Number.isInteger(n) || n < 2) return;
+      this.override({ layout: 'vertical', blockSize: n });
+    },
+
+    setNameOrder(nameOrder) {
+      this.override({ nameOrder });
+    },
+
+    setDateOrientation(dateOrientation) {
+      this.override({ dateOrientation });
+    },
+
+    // The current mapping, whatever its source — an override once one is set,
+    // the parser's inference until then. Reading it back off `reviewed` rather
+    // than off `parseOptions` is what keeps a half-set override from writing
+    // `undefined` into the two columns nobody touched.
+    currentColumns() {
+      return this.reviewed?.columns ?? null;
+    },
+
+    columnChips() {
+      const c = this.currentColumns();
+      if (!c) return [];
+      const label = (i) => (i === null || i === undefined ? '—' : this.columnLabel(i));
+      if (c.combined !== null && c.combined !== undefined) {
+        return [
+          { role: 'combined', roleLabel: 'Name', index: c.combined, label: label(c.combined) },
+          { role: 'dob', roleLabel: 'Birthday', index: c.dob, label: label(c.dob) },
+        ];
+      }
+      return [
+        { role: 'firstName', roleLabel: 'First name', index: c.firstName, label: label(c.firstName) },
+        { role: 'lastName', roleLabel: 'Surname', index: c.lastName, label: label(c.lastName) },
+        { role: 'dob', roleLabel: 'Birthday', index: c.dob, label: label(c.dob) },
+      ];
+    },
+
+    columnLabel(index) {
+      const named = this.reviewed?.header?.[index];
+      return (named && String(named).trim()) || `Column ${index + 1}`;
+    },
+
+    columnChoices() {
+      const width = this.reviewed?.fieldCount ?? 0;
+      return Array.from({ length: width }, (_, index) => ({ index, label: this.columnLabel(index) }));
+    },
+
+    // A chip is set by naming the whole mapping, not by patching one role: the
+    // parser takes the override as a replacement (see readColumnOverride), and
+    // half an inferred mapping beside half a named one is a state nobody chose.
+    //
+    // Claiming a column another role holds **swaps** the two. Clearing the
+    // other role instead leaves a named pair with one half missing, which the
+    // parser refuses outright — and a refusal on the whole list is what a
+    // broken chip looks like from the front desk.
+    setColumn(role, index) {
+      const current = this.currentColumns();
+      if (!current) return;
+      const next = { ...current };
+      const displaced = next[role] ?? null;
+      for (const key of COLUMN_ROLES) if (key !== role && next[key] === index) next[key] = displaced;
+      next[role] = index;
+      this.applyColumns(next);
+    },
+
+    swapNames() {
+      const c = this.currentColumns();
+      if (!c || c.combined !== null) return;
+      this.applyColumns({ ...c, firstName: c.lastName, lastName: c.firstName });
+    },
+
+    setNameShape(shape) {
+      const c = this.currentColumns();
+      if (!c) return;
+      if (shape === 'combined') {
+        this.applyColumns({ dob: c.dob, firstName: null, lastName: null, combined: c.firstName });
+        return;
+      }
+      // Back to two columns: the second is whichever column is not already
+      // spoken for, which is the only unambiguous answer available here.
+      const free = this.columnChoices().map((x) => x.index).filter((i) => i !== c.combined && i !== c.dob);
+      if (free.length === 0) return;
+      this.applyColumns({ dob: c.dob, firstName: c.combined, lastName: free[0], combined: null });
+    },
+
+    // Nothing the chips can produce is allowed to reach the parser as a
+    // refusal. The parser refusing an override is correct — it is a caller bug
+    // and reading a different column than the chip names would write a
+    // permanent wrong contact — but the caller is this file, so the check
+    // belongs here, before the click does anything visible.
+    applyColumns(columns) {
+      if (!this.usableColumns(columns)) return;
+      this.override({ columns });
+    },
+
+    usableColumns(c) {
+      const named = COLUMN_ROLES.map((role) => c[role]).filter((v) => v !== null && v !== undefined);
+      if (new Set(named).size !== named.length) return false;
+      if (c.dob === null || c.dob === undefined) return false;
+      const combined = c.combined !== null && c.combined !== undefined;
+      const pair = c.firstName !== null && c.firstName !== undefined
+        && c.lastName !== null && c.lastName !== undefined;
+      // Exactly one name shape: one column holding the whole name, or two
+      // holding its halves. Neither, or both, names no columns at all.
+      return combined !== pair;
+    },
+
+    // --- rows ------------------------------------------------------------
+    toggleRow(key) {
+      this.expandedRow = this.expandedRow === key ? null : key;
+    },
+
+    draftFor(key) {
+      return this.drafts[key] ?? { firstName: '', lastName: '', dob: '' };
+    },
+
+    resolveRow(key, action) {
+      this.resolutions = window.schoolBookingSteps.resolve(this.resolutions, key, action);
+      this.expandedRow = null;
+      this.refresh();
+    },
+
+    acceptRow(key) {
+      const draft = this.draftFor(key);
+      this.resolveRow(key, { kind: 'accept', ...draft });
+    },
+
+    confirmRow(key) {
+      const draft = this.draftFor(key);
+      this.resolveRow(key, { kind: 'confirm', firstName: draft.firstName, lastName: draft.lastName });
+    },
+
+    dismissRow(key) {
+      this.resolveRow(key, { kind: 'dismiss' });
+    },
+
+    undoRow(key) {
+      this.resolveRow(key, null);
+    },
+
+    acknowledgeable(kind) {
+      return kind === 'combined-name-comma' || kind === 'excel-serial-dates';
+    },
+
+    acknowledge(kind) {
+      this.resolutions = window.schoolBookingSteps.resolve(this.resolutions, `list:${kind}`, { kind: 'acknowledge' });
+      this.refresh();
+    },
+
+    canRedeclare() {
+      return window.schoolBookingSteps.canRedeclare(this.reviewed);
+    },
+
+    redeclare() {
+      this.countValue = String(this.reviewed.counts.records);
+      this.countUnknown = false;
+      this.refresh();
+    },
+
+    // --- rendering helpers, all of them returning strings ----------------
+    nameOf(row) {
+      return [row.firstName, row.lastName].filter(Boolean).join(' ') || '(no name)';
+    },
+
+    countLine() {
+      return window.schoolBookingSteps.countLine(this.reviewed);
+    },
+
+    reconciliationLine() {
+      return window.schoolBookingSteps.reconciliationLine(this.reviewed);
+    },
+
+    ignoredColumnsLine() {
+      return window.schoolBookingSteps.ignoredColumnsLine(this.reviewed);
+    },
+
+    ignoredSummary() {
+      return window.schoolBookingSteps.ignoredSummary(this.reviewed);
+    },
+
+    countTone() {
+      const mismatched = this.reviewed?.blockers.some((b) => b.kind === 'count-mismatch');
+      return mismatched
+        ? 'bg-rose-50 border border-rose-200 text-rose-800'
+        : 'bg-emerald-50 border border-emerald-200 text-emerald-800';
+    },
+
+    laneFor(row) {
+      if (row.bucket === 'error') return 'lane-bad';
+      if (row.needsHuman) return 'lane-need';
+      return 'lane-ok';
+    },
+
+    stateTone(row) {
+      if (row.bucket === 'error') return 'text-rose-700 bg-rose-50';
+      if (row.needsHuman) return 'text-amber-700 bg-amber-50';
+      return 'text-emerald-700 bg-emerald-50';
+    },
+
+    go(index) {
+      this.stepIndex = index;
+      this.maxStepReached = Math.max(this.maxStepReached, index);
+    },
+  };
+}
+</script>
+</body>
+</html>

--- a/school-booking.html
+++ b/school-booking.html
@@ -809,18 +809,29 @@ function schoolBooking() {
     // re-read is a list nobody chose.
     override(patch) {
       this.parseOptions = { ...this.parseOptions, ...patch };
-      // Resolutions are keyed by source line, which survives a re-parse of the
-      // same paste — so they are deliberately kept. A staff member who fixes
-      // the column mapping has not un-dismissed the teacher they dismissed.
-      this.expandedRow = null;
-      this.chipMenu = null;
-      this.reparse();
+      this.reread();
     },
 
     clearOverrides() {
       this.parseOptions = {};
+      this.reread();
+    },
+
+    reread() {
       this.expandedRow = null;
       this.chipMenu = null;
+      // Resolutions are keyed by source line, which survives a re-parse of the
+      // same paste — so they are deliberately kept. A staff member who fixed
+      // the column mapping has not un-dismissed the teacher they dismissed.
+      //
+      // Edit buffers are NOT. They were seeded from the rows the *previous*
+      // read produced, and `syncDrafts` only fills the gaps — so a buffer that
+      // outlived its parse would hand the confirm button the pre-override
+      // names and quietly undo the override for that one row. Nothing would
+      // error and the row would look confirmed. Cleared here so they re-seed
+      // from what is actually on screen; an acceptance already made keeps its
+      // values, because those live in the resolution rather than the buffer.
+      this.drafts = {};
       this.reparse();
     },
 

--- a/school-booking/parse.js
+++ b/school-booking/parse.js
@@ -295,6 +295,19 @@ function splitFields(raw, delimiter) {
   return fields;
 }
 
+/**
+ * How many lines a paste holds, by the same rule `counts.lines` uses.
+ *
+ * Exported because the page needs it *before* a parse — the count gate is
+ * answered first (P5) — and a second implementation of this would put a line
+ * count on step 2 that disagrees with the one on step 3. Two numbers for one
+ * thing, differing in the trailing-newline case, on the screen whose whole job
+ * is making counts agree.
+ */
+export function countLines(text) {
+  return splitLines(text).length;
+}
+
 function modalCount(counts) {
   let best = 0;
   let bestN = 0;
@@ -452,6 +465,29 @@ function mapColumns(dataRows, width, dobCol, header) {
     };
   }
   return null;
+}
+
+/**
+ * Is this a complete, usable column mapping? The rule the parser enforces and
+ * the page's chips have to obey, in one place — the page validates before it
+ * sends, because the parser refusing an override is correct but reads to staff
+ * as a broken chip, and two copies of this rule would drift apart silently.
+ *
+ * @param {{dob, firstName, lastName, combined}} columns  column indices
+ * @param {number} width  how many columns the list has
+ */
+export function usableColumns(columns, width) {
+  if (!columns) return false;
+  const named = [columns.dob, columns.firstName, columns.lastName, columns.combined]
+    .filter((c) => c !== null && c !== undefined);
+  if (named.some((c) => !Number.isInteger(c) || c < 0 || c >= width)) return false;
+  if (new Set(named).size !== named.length) return false;
+  if (!Number.isInteger(columns.dob)) return false;
+  const combined = Number.isInteger(columns.combined);
+  const pair = Number.isInteger(columns.firstName) && Number.isInteger(columns.lastName);
+  // Exactly one name shape: one column holding the whole name, or two holding
+  // its halves. Neither names no columns at all; both is a contradiction.
+  return combined !== pair;
 }
 
 // P6's chips, read back. A chip labelled "First name" is also the answer to
@@ -728,9 +764,12 @@ export function parseStudentList(text, options = {}) {
   // A named DOB column narrows what counts as a data row to that one column.
   // It has to: naming it is how staff resolve `dob-column-ambiguous`, and
   // "any field is date-shaped" would still see both columns and still refuse.
+  // `at()` in readColumnOverride already normalised an omitted role to null, so
+  // null is the only "not named" this has to test for.
+  const overriddenDob = override?.dob ?? null;
   const dateBearing = (strict) =>
-    override?.dob !== null && override?.dob !== undefined
-      ? rows.filter((row) => isDateShaped(row.fields[override.dob], { strict }))
+    overriddenDob !== null
+      ? rows.filter((row) => isDateShaped(row.fields[overriddenDob], { strict }))
       : rows.filter((row) => row.fields.some((f) => isDateShaped(f, { strict })));
 
   let strict = true;
@@ -742,8 +781,8 @@ export function parseStudentList(text, options = {}) {
   if (dataRows.length === 0) return bail('no-dob-column');
 
   let dobCol;
-  if (override?.dob !== null && override?.dob !== undefined) {
-    dobCol = override.dob;
+  if (overriddenDob !== null) {
+    dobCol = overriddenDob;
   } else {
     const dateCols = [];
     for (let c = 0; c < width; c++) {
@@ -798,8 +837,9 @@ export function parseStudentList(text, options = {}) {
     rows.forEach((row, i) => {
       if (dataBlocks.has(row)) return;
       const before = i < firstDataAt;
-      if (before && header === null) header = row.fields;
-      const reason = before ? (header === row.fields ? 'header' : 'junk') : 'unparseable';
+      const isHeader = before && header === null;
+      if (isHeader) header = row.fields;
+      const reason = before ? (isHeader ? 'header' : 'junk') : 'unparseable';
       row.fields.forEach((value, k) => {
         (before ? ignored : errors).push({
           lineNumbers: [row.lineNumbers[k]],
@@ -831,11 +871,11 @@ export function parseStudentList(text, options = {}) {
     }
     : mapColumns(dataRows, width, dobCol, header);
   if (!mapping) return bail('no-name-columns');
-  // A named pair with one half missing names no columns at all: the row loop
-  // would read `undefined` as a name and write a student with a blank surname.
-  if (namesOverridden && mapping.combined === null && (mapping.firstName === null || mapping.lastName === null)) {
-    return bail('override-out-of-range');
-  }
+  // An inferred mapping is usable by construction, so this only ever fires on
+  // an override — a named pair with one half missing names no columns at all,
+  // and the row loop would read `undefined` as a name and write a student with
+  // a blank surname.
+  if (!usableColumns({ ...mapping, dob: dobCol }, width)) return bail('override-out-of-range');
 
   const usedCols = new Set(
     [dobCol, mapping.firstName, mapping.lastName, mapping.combined].filter(
@@ -845,6 +885,17 @@ export function parseStudentList(text, options = {}) {
   const ignoredColumns = [];
   for (let c = 0; c < width; c++) {
     if (!usedCols.has(c)) ignoredColumns.push({ index: c, label: columnLabel(header, c) });
+  }
+
+  // Which columns hold a name in *every* record row. Emitted because P6's chips
+  // otherwise have to guess: a page moving a combined name back to two columns
+  // has to name a second column, and the only alternative to this list is
+  // picking the next free index — which is how `Email` or `YearLevel` becomes
+  // somebody's permanent surname, obeyed literally and with nothing to
+  // disagree with it.
+  const nameShapedColumns = [];
+  for (let c = 0; c < width; c++) {
+    if (dataRows.every((row) => isNameShaped(row.fields[c]))) nameShapedColumns.push(c);
   }
 
   // --- date orientation, once for the whole list (P11) --------------------
@@ -1030,6 +1081,7 @@ export function parseStudentList(text, options = {}) {
         firstNameIsPreferred: mapping.firstNameIsPreferred,
       },
       ignoredColumns,
+      nameShapedColumns,
       dateOrientation: {
         value: orientation,
         basis: orientationBasis,
@@ -1110,6 +1162,7 @@ function finish({ lines, layout, records, ignored, errors, refusalValue, extras 
     verdict: '',
     columns: null,
     ignoredColumns: [],
+    nameShapedColumns: [],
     dateOrientation: null,
     nameOrder: 'first-last',
     needs: [],

--- a/school-booking/parse.js
+++ b/school-booking/parse.js
@@ -354,6 +354,17 @@ function detectVertical(seq, strict) {
   return { blockSize: gap, start, blocks, dobPos: firstHit - start };
 }
 
+// A forced block size is taken from the first non-blank line. Finding an offset
+// is the anchor's job, and a staff member reaching for this override is saying
+// the anchor was wrong — so it does not get a second vote on where the list
+// starts. Whole blocks only; the remainder is a truncated paste, which is the
+// count gate's business (P5) rather than this function's.
+function forcedVertical(seq, blockSize) {
+  const blocks = Math.floor(seq.length / blockSize);
+  if (blocks < 1) return null;
+  return { blockSize, start: 0, blocks, dobPos: null };
+}
+
 // ---------------------------------------------------------------------------
 // P6 — columns mapped content-first
 // ---------------------------------------------------------------------------
@@ -443,6 +454,33 @@ function mapColumns(dataRows, width, dobCol, header) {
   return null;
 }
 
+// P6's chips, read back. A chip labelled "First name" is also the answer to
+// P7's order question — naming the columns and then asking which order they are
+// in would ask staff the same thing twice and let the two answers disagree.
+function readColumnOverride(columns, width) {
+  if (!columns || typeof columns !== 'object') return { ok: true, override: null };
+
+  const at = (value) => (value === null || value === undefined ? null : value);
+  const picked = {
+    dob: at(columns.dob),
+    firstName: at(columns.firstName),
+    lastName: at(columns.lastName),
+    combined: at(columns.combined),
+  };
+
+  const named = Object.values(picked).filter((c) => c !== null);
+  if (named.length === 0) return { ok: true, override: null };
+  if (named.some((c) => !Number.isInteger(c) || c < 0 || c >= width)) return { ok: false };
+  // One column cannot be two fields, and a combined name column is the whole
+  // name — naming it alongside a first or last is a contradiction, not a
+  // preference this could resolve either way.
+  if (new Set(named).size !== named.length) return { ok: false };
+  if (picked.combined !== null && (picked.firstName !== null || picked.lastName !== null)) {
+    return { ok: false };
+  }
+  return { ok: true, override: picked };
+}
+
 function columnLabel(header, index) {
   const named = header && String(header[index] ?? '').trim();
   return named || `Column ${index + 1}`;
@@ -530,6 +568,11 @@ const REFUSALS = {
   'date-orientation-contradiction':
     'This list contains dates that prove both day/month and month/day, so it cannot be read '
     + 'safely.',
+  // An override out of range is a bug in the caller, not a property of the
+  // paste — the values come from the page's own chips. It refuses rather than
+  // falling back, because reading a different column than the chip names would
+  // write a permanent wrong contact with nothing on screen disagreeing.
+  'override-out-of-range': 'The layout or column override does not describe this list.',
 };
 
 const refusal = (code, extra = {}) => ({ code, message: REFUSALS[code], ...extra });
@@ -542,14 +585,29 @@ const refusal = (code, extra = {}) => ({ code, message: REFUSALS[code], ...extra
  * @param {Object<number, number>} [options.nameSplits]  answers to the P8
  *        per-row question: first source line number → chosen split point
  * @param {string} [options.eventDate]  ISO date, enables the P13 age band
+ * @param {'horizontal'|'vertical'} [options.layout]  overrides the detected
+ *        layout — P4's one-click verdict override (#71)
+ * @param {number} [options.blockSize]  fields per student, when the layout is
+ *        forced vertical. Omitted, the DOB anchor still finds it.
+ * @param {object} [options.columns]  overrides the content-first mapping —
+ *        P6's three swappable chips (#71). `{dob, firstName, lastName,
+ *        combined}`, each a column index; omit one to keep what was inferred.
  *
  * Every question this module raises in `needs` has an option above that answers
- * it. Layout and column overrides deliberately do not: those are inferences
- * with a UI affordance rather than questions, and their shape belongs to #71.
+ * it. The layout and column overrides are the other kind — inferences this
+ * module has already answered, which the page's affordances (#71) exist to
+ * contradict. They are obeyed literally, including where the inference was
+ * right: an override the parser may discard when it disagrees is not an
+ * override, and a staff member watching the verdict stay the same after
+ * clicking cannot tell a rejected override from a broken button.
  */
 export function parseStudentList(text, options = {}) {
   const nameOrder = options.nameOrder === 'last-first' ? 'last-first' : 'first-last';
   const nameSplits = options.nameSplits ?? {};
+  const layoutOverride =
+    options.layout === 'vertical' || options.layout === 'horizontal' ? options.layout : null;
+  const blockSizeOverride =
+    options.blockSize === null || options.blockSize === undefined ? null : options.blockSize;
   const lines = splitLines(text);
   const delimiter = detectDelimiter(lines);
 
@@ -586,6 +644,13 @@ export function parseStudentList(text, options = {}) {
       extras: {},
     });
 
+  // A block size below two cannot hold a name and a date, so it describes no
+  // list at all. Checked here rather than clamped: a clamp would read the list
+  // some other way and call it the caller's choice.
+  if (blockSizeOverride !== null && (!Number.isInteger(blockSizeOverride) || blockSizeOverride < 2)) {
+    return bail('override-out-of-range');
+  }
+
   if (filled.length === 0) {
     return finish({
       lines,
@@ -606,7 +671,7 @@ export function parseStudentList(text, options = {}) {
   const counts = new Map();
   for (const c of filled) counts.set(c.fields.length, (counts.get(c.fields.length) ?? 0) + 1);
   const modalWidth = modalCount([...counts.entries()]);
-  const vertical = modalWidth === 1;
+  const vertical = layoutOverride ? layoutOverride === 'vertical' : modalWidth === 1;
 
   let rows; // { fields, lineNumbers }
   let header = null;
@@ -618,8 +683,10 @@ export function parseStudentList(text, options = {}) {
     // whole line, and where a stray delimiter split one, the remainder is not
     // part of the repeating block.
     const seq = filled.map((c) => ({ value: c.fields[0], n: c.n }));
-    const shape = detectVertical(seq, true) || detectVertical(seq, false);
-    if (!shape) return bail('layout-not-held');
+    const shape = blockSizeOverride
+      ? forcedVertical(seq, blockSizeOverride)
+      : detectVertical(seq, true) || detectVertical(seq, false);
+    if (!shape) return bail(blockSizeOverride ? 'override-out-of-range' : 'layout-not-held');
 
     blockSize = shape.blockSize;
     width = blockSize;
@@ -655,8 +722,16 @@ export function parseStudentList(text, options = {}) {
   // --- the DOB anchor ----------------------------------------------------
   // Strict first, so a list that has a real date column is never anchored on a
   // five-digit integer column that happens to look like Excel serials.
+  const { ok: overrideOk, override } = readColumnOverride(options.columns, width);
+  if (!overrideOk) return bail('override-out-of-range');
+
+  // A named DOB column narrows what counts as a data row to that one column.
+  // It has to: naming it is how staff resolve `dob-column-ambiguous`, and
+  // "any field is date-shaped" would still see both columns and still refuse.
   const dateBearing = (strict) =>
-    rows.filter((row) => row.fields.some((f) => isDateShaped(f, { strict })));
+    override?.dob !== null && override?.dob !== undefined
+      ? rows.filter((row) => isDateShaped(row.fields[override.dob], { strict }))
+      : rows.filter((row) => row.fields.some((f) => isDateShaped(f, { strict })));
 
   let strict = true;
   let dataRows = dateBearing(true);
@@ -666,13 +741,18 @@ export function parseStudentList(text, options = {}) {
   }
   if (dataRows.length === 0) return bail('no-dob-column');
 
-  const dateCols = [];
-  for (let c = 0; c < width; c++) {
-    if (dataRows.every((row) => isDateShaped(row.fields[c], { strict }))) dateCols.push(c);
+  let dobCol;
+  if (override?.dob !== null && override?.dob !== undefined) {
+    dobCol = override.dob;
+  } else {
+    const dateCols = [];
+    for (let c = 0; c < width; c++) {
+      if (dataRows.every((row) => isDateShaped(row.fields[c], { strict }))) dateCols.push(c);
+    }
+    if (dateCols.length === 0) return bail('no-dob-column');
+    if (dateCols.length > 1) return bail('dob-column-ambiguous', { columns: dateCols });
+    dobCol = dateCols[0];
   }
-  if (dateCols.length === 0) return bail('no-dob-column');
-  if (dateCols.length > 1) return bail('dob-column-ambiguous', { columns: dateCols });
-  const dobCol = dateCols[0];
 
   // --- non-data lines, classified by position (P9) ------------------------
   if (!vertical) {
@@ -707,11 +787,55 @@ export function parseStudentList(text, options = {}) {
         errors.push({ lineNumbers: [cell.n], text: cell.raw, reason: 'unparseable' });
       }
     }
+  } else {
+    // The same positional rule, for whole blocks. The anchor cannot produce a
+    // dateless block — a constant stride of date-shaped lines is what it
+    // measures — but a forced block size (#71) can put the header or a
+    // trailing note inside one, and a block that is neither a record nor a
+    // bucket is a line dropped, which is the one thing P1 forbids.
+    const dataBlocks = new Set(dataRows);
+    const firstDataAt = rows.indexOf(dataRows[0]);
+    rows.forEach((row, i) => {
+      if (dataBlocks.has(row)) return;
+      const before = i < firstDataAt;
+      if (before && header === null) header = row.fields;
+      const reason = before ? (header === row.fields ? 'header' : 'junk') : 'unparseable';
+      row.fields.forEach((value, k) => {
+        (before ? ignored : errors).push({
+          lineNumbers: [row.lineNumbers[k]],
+          text: value,
+          reason,
+        });
+      });
+    });
   }
 
   // --- column mapping (P6) ------------------------------------------------
-  const mapping = mapColumns(dataRows, width, dobCol, header);
+  const namesOverridden =
+    override !== null
+    && (override.firstName !== null || override.lastName !== null || override.combined !== null);
+
+  // The override replaces the mapping rather than patching it. Half an inferred
+  // mapping beside half a named one is a state nobody chose: swapping the two
+  // name chips would leave the inferred `lastName` sitting under the column the
+  // caller just named `firstName`, and both would be written.
+  const mapping = namesOverridden
+    ? {
+      firstName: override.firstName,
+      lastName: override.lastName,
+      combined: override.combined,
+      // Naming the columns answers P7 as well; see readColumnOverride.
+      nameOrderKnown: override.combined === null,
+      firstNameIsPreferred:
+        override.firstName !== null && header ? isPreferredLabel(header[override.firstName]) : false,
+    }
+    : mapColumns(dataRows, width, dobCol, header);
   if (!mapping) return bail('no-name-columns');
+  // A named pair with one half missing names no columns at all: the row loop
+  // would read `undefined` as a name and write a student with a blank surname.
+  if (namesOverridden && mapping.combined === null && (mapping.firstName === null || mapping.lastName === null)) {
+    return bail('override-out-of-range');
+  }
 
   const usedCols = new Set(
     [dobCol, mapping.firstName, mapping.lastName, mapping.combined].filter(

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -33,7 +33,17 @@
 // re-parse of the same paste (parse.js keys its own `nameSplits` answers the
 // same way), or by `list:<kind>` for a question about the whole list.
 
-import { compareForm, readDate, writeForm } from './parse.js';
+// The `?v=` is not decoration here and is not optional. A module specifier is
+// a URL: `parse.js` and `parse.js?v=1` are two different modules to a browser,
+// so an unversioned import here would (a) instantiate a second copy of the
+// parser beside the page's, and (b) never be invalidated by bumping the page's
+// `?v=` — leaving this module, which holds every gate, running against a
+// cached parser the page has already moved on from. That is exactly the
+// "breaks every check simultaneously and silently" failure §16 names.
+//
+// Bump this in lockstep with school-booking.html. alpine-bindings.test.js
+// fails if the two ever disagree.
+import { compareForm, readDate, writeForm } from './parse.js?v=1';
 
 const DOMAIN = 'urbanjungleirc.com';
 
@@ -206,6 +216,7 @@ export function review(parsed, { declaration, resolutions } = {}) {
         title: 'This list cannot be read safely',
         detail: parsed.refusal.message,
         lineNumbers: [],
+        actions: [],
       }],
       ready: false,
       reconciled: parsed.counts.reconciled,
@@ -335,6 +346,7 @@ export function review(parsed, { declaration, resolutions } = {}) {
       title: 'The line counts do not add up',
       detail: `${counts.accounted} of ${counts.lines} pasted lines are accounted for.`,
       lineNumbers: [],
+      actions: [],
     });
   }
 
@@ -346,6 +358,7 @@ export function review(parsed, { declaration, resolutions } = {}) {
       title: `We read ${plural(counts.records, 'student')}`,
       detail: 'Nobody has said how many there should be, so nothing is checking this number.',
       lineNumbers: [],
+      actions: [],
     });
   } else if (gate.ready && gate.count !== counts.records) {
     blockers.push({
@@ -356,6 +369,17 @@ export function review(parsed, { declaration, resolutions } = {}) {
       detail: 'A layout read wrong, a header absorbed as a student or a truncated paste all '
         + 'look like this. Fix the rows, or say the count has changed.',
       lineNumbers: [],
+      // The escape hatch, offered only when the gate survives it — see
+      // countMoved() below. Carried as data so the markup cannot offer it
+      // ungated by forgetting a condition.
+      actions: countMoved(counts.records, parsed.counts.records)
+        ? [{
+          key: 'redeclare',
+          label: `The count has changed \u2014 make it ${counts.records}`,
+          answers: 'redeclare',
+          value: counts.records,
+        }]
+        : [],
     });
   }
 
@@ -369,6 +393,7 @@ export function review(parsed, { declaration, resolutions } = {}) {
       detail: 'Each sits after a real student, so each may be one. Give it a name and a '
         + 'birthday, or say it is not a student.',
       lineNumbers: unreadable.flatMap((row) => row.lineNumbers),
+      actions: [],
     });
   }
 
@@ -381,6 +406,7 @@ export function review(parsed, { declaration, resolutions } = {}) {
       title: `${plural(wanting.length, 'row')} needs you`,
       detail: wanting.map((row) => nameOf(row) || `line ${row.key}`).join(', '),
       lineNumbers: wanting.flatMap((row) => row.lineNumbers),
+      actions: [],
     });
   }
 
@@ -408,6 +434,9 @@ export function review(parsed, { declaration, resolutions } = {}) {
     verdict: parsed.verdict,
     columns: parsed.columns,
     ignoredColumns: parsed.ignoredColumns,
+    // Which columns hold a name in every row. The chips need it to move a
+    // combined name back onto two columns without guessing which one.
+    nameShapedColumns: parsed.nameShapedColumns,
     dateOrientation: parsed.dateOrientation,
     nameOrder: parsed.nameOrder,
     reconciled: counts.reconciled,
@@ -421,16 +450,32 @@ export function review(parsed, { declaration, resolutions } = {}) {
 }
 
 function listBlocker(need, parsed) {
-  const base = { key: `list:${need.kind}`, kind: need.kind, severity: 'block', lineNumbers: [] };
+  const base = {
+    key: `list:${need.kind}`, kind: need.kind, severity: 'block', lineNumbers: [], actions: [],
+  };
   if (need.kind === 'name-order') {
+    // Both readings, side by side. P7 asks for the samples "read both ways" and
+    // the reason is the whole rule: shown in list order alone, staff reverse it
+    // in their heads, which is the guess this exists to remove. A reversed
+    // contact is permanent and nothing downstream would notice.
     const shown = (need.samples ?? [])
-      .map((sample) => sample.values.join(' '))
+      .map((sample) => {
+        const values = sample.values ?? [];
+        const forward = values.join(' ');
+        const reversed = [...values].reverse().join(' ');
+        return forward === reversed ? forward : `${forward} / ${reversed}`;
+      })
       .join(' · ');
     return {
       ...base,
       title: 'Which way round are the names?',
-      detail: `No header names the columns, so this is a guess: ${shown}. Getting it wrong `
-        + 'creates a permanently reversed contact and nothing downstream would notice.',
+      detail: 'No header names the columns, so this is a guess. First-name-first, then '
+        + `surname-first: ${shown}. Getting it wrong creates a permanently reversed contact `
+        + 'and nothing downstream would notice.',
+      actions: [
+        { key: 'first-last', label: 'First name first', answers: 'nameOrder', value: 'first-last' },
+        { key: 'last-first', label: 'Surname first', answers: 'nameOrder', value: 'last-first' },
+      ],
     };
   }
   if (need.kind === 'date-orientation') {
@@ -440,13 +485,18 @@ function listBlocker(need, parsed) {
       title: 'Day/month, or month/day?',
       detail: `${sample.value} reads as ${sample.dmy} one way and ${sample.mdy} the other. `
         + 'A wrong reading does not error — it turns March into May.',
+      actions: [
+        { key: 'dmy', label: 'Day/month', answers: 'dateOrientation', value: 'dmy' },
+        { key: 'mdy', label: 'Month/day', answers: 'dateOrientation', value: 'mdy' },
+      ],
     };
   }
   if (need.kind === 'combined-name-comma') {
     return {
       ...base,
       title: 'A name was split on a comma',
-      detail: 'Read as “Surname, Given”. Check the students below read the right way round.',
+      detail: 'Read as \u201CSurname, Given\u201D. Check the students below read the right way round.',
+      actions: [acknowledgement(need.kind)],
     };
   }
   if (need.kind === 'excel-serial-dates') {
@@ -454,10 +504,22 @@ function listBlocker(need, parsed) {
       ...base,
       title: 'Some dates arrived as spreadsheet serial numbers',
       detail: 'They have been converted. Check the birthdays below before going on.',
+      actions: [acknowledgement(need.kind)],
     };
   }
   return { ...base, title: 'This list needs a decision', detail: need.kind };
 }
+
+// An action is data, like everything else a blocker carries: what to call it,
+// and what answering it means. The page reads `answers` and dispatches; it does
+// not know the blocker kinds, so a kind added here cannot arrive without the
+// control that clears it. Nothing here is ever a function — see the header.
+const acknowledgement = (kind) => ({
+  key: `acknowledge:${kind}`,
+  label: 'Checked \u2014 go on',
+  answers: 'acknowledge',
+  value: kind,
+});
 
 /**
  * Whether the count mismatch may offer a re-declare.
@@ -476,8 +538,10 @@ function listBlocker(need, parsed) {
  * was ever asked to count.
  */
 export function canRedeclare(reviewed) {
-  return Boolean(reviewed) && reviewed.counts.records !== reviewed.recordsParsed;
+  return Boolean(reviewed) && countMoved(reviewed.counts.records, reviewed.recordsParsed);
 }
+
+const countMoved = (records, recordsParsed) => records !== recordsParsed;
 
 // ---------------------------------------------------------------------------
 // The lines step 3 puts on screen
@@ -514,11 +578,23 @@ export function ignoredSummary(reviewed) {
     + `${dismissed} you dismissed`;
 }
 
-/** P1, as a sentence. It is a sum, so it is shown as one. */
+/**
+ * P1, as a sentence. It is a sum, so it has to add up on screen — which means
+ * counting the students' **lines**, not the students. A vertical list puts one
+ * student on six lines and a collapsed duplicate (P14) puts one on two, so
+ * `5 + 7 + 0 = 37` is not arithmetic anybody can check; it is the reconciliation
+ * failing quietly on the one screen whose job is making counts agree.
+ *
+ * The student count still leads, because that is the number staff came for. The
+ * line count joins it only where the two differ.
+ */
 export function reconciliationLine(reviewed) {
   const c = reviewed?.counts;
   if (!c) return '';
-  return `${plural(c.records, 'student')} + ${c.ignoredLines} ignored + ${c.errorLines} unreadable `
+  const students = c.recordLines === c.records
+    ? plural(c.records, 'student')
+    : `${plural(c.records, 'student')} on ${plural(c.recordLines, 'line')}`;
+  return `${students} + ${c.ignoredLines} ignored + ${c.errorLines} unreadable `
     + `= ${plural(c.lines, 'line')} pasted.`;
 }
 

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -1,0 +1,535 @@
+// school-booking/steps.js
+//
+// The gates of steps 1–3 of the school booking page, as a pure module: the
+// school tag, the count declaration (P5), and the review that decides whether
+// step 3 may be left. No DOM, no network, no clock — the page imports this and
+// publishes it as `window.schoolBookingSteps`, the seam delete-logic.js,
+// unsubscribes-logic.js and nav-menu.js already use.
+//
+// §9 of docs/superpowers/specs/2026-08-19-school-group-booking-design.md, and
+// #71. Parsing rules are parse.js (#64) and are not restated here; this module
+// decides what the parse *means* for the run, which is a different question and
+// the one the page's gates are made of.
+//
+// ---------------------------------------------------------------------------
+// Why the gates live here and not in the markup
+// ---------------------------------------------------------------------------
+// The gate this page exists to enforce was defeated once already, by its own
+// affordance: `x-show="b.fix"` in the #54 prototype ran the blocker's "confirm
+// all" on every render tick, silently confirming rows nobody had confirmed,
+// with no user action and no error (§16). A rendering fault, not a logic fault
+// — which is exactly why the logic has to be somewhere a test can reach it, and
+// why nothing this module returns is ever a function. There is no `fix` on a
+// blocker here to be invoked by accident.
+//
+// ---------------------------------------------------------------------------
+// The resolution log
+// ---------------------------------------------------------------------------
+// Staff edits are held as a separate layer rather than written back over the
+// parse. Re-parsing is how the layout override, the column chips and the two
+// list-level questions are answered, and each re-parse throws the previous
+// result away — an edit stored inside it would go with it. The log is keyed by
+// the row's **first source line number**, the one identifier that survives a
+// re-parse of the same paste (parse.js keys its own `nameSplits` answers the
+// same way), or by `list:<kind>` for a question about the whole list.
+
+import { compareForm, readDate, writeForm } from './parse.js';
+
+const DOMAIN = 'urbanjungleirc.com';
+
+// ---------------------------------------------------------------------------
+// Step 1 — the school tag
+// ---------------------------------------------------------------------------
+// The tag is the local part of `noreply+<tag>@urbanjungleirc.com`, the only
+// provenance this system will ever have (§4, and schools.js). Months later it
+// is the entire reason an operator resolving a duplicate can tell which school
+// the other record belongs to, so it has to survive being typed, stored and
+// searched for without changing shape.
+
+/**
+ * Normalise typed input to a tag. Lowercase letters and digits only: a tag with
+ * a space or an apostrophe in it is a tag that will not partial-match itself
+ * back out of Clubworx's email filter, which is how the picker finds the school
+ * again next term.
+ *
+ * A tag that is already a tag comes back unchanged — the picker hands back tags
+ * Clubworx already holds, and normalising one into a *different* tag would
+ * write a second spelling of a school that already has one, permanently, on
+ * contacts Clubworx cannot delete.
+ */
+export function schoolTag(value) {
+  return String(value ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/** The permanent school marker, or null when there is no tag to make one from. */
+export function schoolMarker(tag) {
+  const clean = schoolTag(tag);
+  return clean ? `noreply+${clean}@${DOMAIN}` : null;
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — P5, the count declaration
+// ---------------------------------------------------------------------------
+// Staff declare the expected count *before* the parse result is shown. The
+// order is the whole point: a count displayed first is anchoring theatre,
+// because nobody disagrees with a number already on screen.
+
+/**
+ * Read what staff typed into a declaration. "I don't know" is a declaration
+ * too, and it deliberately forgets any number typed before the box was ticked
+ * — the banner and the gate are different outcomes, and carrying a stale number
+ * into the banner would let it block something it was never asked about.
+ *
+ * @returns {{ready: boolean, unknown: boolean, count: number|null}}
+ */
+export function countDeclaration({ value, unknown } = {}) {
+  if (unknown) return { ready: true, unknown: true, count: null };
+  const text = String(value ?? '').trim();
+  const count = /^\d+$/.test(text) ? Number(text) : NaN;
+  if (!Number.isInteger(count) || count < 1) return { ready: false, unknown: false, count: null };
+  return { ready: true, unknown: false, count };
+}
+
+// ---------------------------------------------------------------------------
+// The resolution log
+// ---------------------------------------------------------------------------
+
+/**
+ * Record — or clear — one resolution. Returns a new log; the original is left
+ * alone, because Alpine re-renders from the returned value and a mutated
+ * original would make an undo unobservable.
+ *
+ * @param {object} resolutions  the current log
+ * @param {number|string} key   a row's first source line, or `list:<kind>`
+ * @param {object|null} action  `{kind: 'dismiss'|'accept'|'confirm'|'acknowledge', ...}`
+ *                              or null to take the resolution back
+ */
+export function resolve(resolutions, key, action) {
+  const next = { ...(resolutions ?? {}) };
+  if (action === null || action === undefined) delete next[key];
+  else next[key] = action;
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — the review
+// ---------------------------------------------------------------------------
+
+// Why a row wants a human, in the words staff would use. Every flag and need
+// parse.js can raise has a line here: a row that blocks the run without saying
+// why is a row that gets dismissed to make the blocker go away.
+const NOTES = {
+  'name-split': 'Three or more name parts — check where the surname starts.',
+  'excel-serial': 'The date arrived as a spreadsheet serial number. Check it reads right.',
+  'implausible-age': 'That birthday is outside the age range a school session normally has.',
+  'not-a-student': 'Born before 2000 — this is probably a teacher, not a student.',
+  'listed-twice': 'Listed twice in the paste. Collapsed to one student.',
+  'possible-siblings': 'Shares a surname and birthday with another row — twins, or one child twice.',
+  'empty-name': 'No name on this line.',
+  'date-orientation': 'This date could be day/month or month/day.',
+};
+
+const REASON_NOTES = {
+  unparseable: 'Sits after real students, so it may be one. Nothing runs until it is accounted for.',
+  'incomplete-block': 'A part-finished student at the end of the paste.',
+  'needs-orientation': 'This date could be day/month or month/day.',
+};
+
+const plural = (n, noun) => `${n} ${noun}${n === 1 ? '' : 's'}`;
+
+const noteFor = (flags, needs, fallback) => {
+  for (const flag of flags) if (NOTES[flag]) return NOTES[flag];
+  for (const need of needs) if (NOTES[need.kind]) return NOTES[need.kind];
+  return fallback ?? '';
+};
+
+const nameOf = (row) => [row.firstName, row.lastName].filter(Boolean).join(' ').trim();
+
+// A record built out of a line staff accepted as a student. It is deliberately
+// the same shape as one parse.js emits, down to `compare` — the identity read
+// in step 4 must not be able to tell an accepted row from a parsed one, or the
+// row that most needed a human would be the one that skipped the matching.
+function acceptedRecord(error, action, orientation) {
+  const firstName = writeForm(action.firstName);
+  const lastName = writeForm(action.lastName);
+  if (!firstName || !lastName) return null;
+
+  const read = readDate(action.dob, orientation);
+  if (read.error || !read.iso) return null;
+
+  return {
+    lineNumbers: [...error.lineNumbers],
+    raw: { firstName: action.firstName, lastName: action.lastName, dob: action.dob },
+    write: { firstName, lastName, dob: read.iso },
+    compare: { firstName: compareForm(firstName), lastName: compareForm(lastName) },
+    flags: [],
+    needs: [],
+    duplicateCount: 1,
+    state: 'clean',
+    accepted: true,
+  };
+}
+
+/**
+ * Everything step 3 shows, and everything it blocks on, from one call.
+ *
+ * @param {object} parsed  a parseStudentList result
+ * @param {object} context
+ * @param {object} context.declaration  a countDeclaration
+ * @param {object} context.resolutions  the resolution log
+ */
+export function review(parsed, { declaration, resolutions } = {}) {
+  const log = resolutions ?? {};
+  const gate = declaration ?? { ready: false, unknown: false, count: null };
+  const blockers = [];
+
+  if (!parsed) {
+    return {
+      rows: [], ignored: [], blockers: [], ready: false, reconciled: true,
+      declared: gate, recordsParsed: 0,
+      counts: { lines: 0, records: 0, recordLines: 0, ignored: 0, ignoredLines: 0, errors: 0, errorLines: 0, accounted: 0 },
+    };
+  }
+
+  // A refused paste blocks with the refusal alone. bail() re-buckets every
+  // non-blank line as an error, so listing those as well would bury the one
+  // sentence that says what is actually wrong under a wall of rows that are
+  // only errors because the list could not be read at all.
+  if (parsed.refusal) {
+    return {
+      rows: [],
+      ignored: parsed.ignored,
+      blockers: [{
+        key: 'refusal',
+        kind: 'refusal',
+        severity: 'block',
+        title: 'This list cannot be read safely',
+        detail: parsed.refusal.message,
+        lineNumbers: [],
+      }],
+      ready: false,
+      reconciled: parsed.counts.reconciled,
+      declared: gate,
+      recordsParsed: 0,
+      counts: parsed.counts,
+    };
+  }
+
+  const orientation = parsed.dateOrientation?.value ?? null;
+
+  // --- resolutions applied, bucket by bucket ------------------------------
+  const records = [];
+  const ignored = parsed.ignored.map((entry) => ({ ...entry }));
+  const errors = [];
+
+  for (const record of parsed.records) {
+    const action = log[record.lineNumbers[0]];
+    if (action?.kind === 'dismiss') {
+      ignored.push({
+        lineNumbers: [...record.lineNumbers],
+        text: nameOf(record.write) || record.raw.firstName,
+        reason: 'dismissed',
+      });
+      continue;
+    }
+    if (action?.kind === 'confirm') {
+      const firstName = writeForm(action.firstName ?? record.write.firstName);
+      const lastName = writeForm(action.lastName ?? record.write.lastName);
+      records.push({
+        ...record,
+        write: { ...record.write, firstName, lastName },
+        compare: { firstName: compareForm(firstName), lastName: compareForm(lastName) },
+        state: 'clean',
+        confirmed: true,
+      });
+      continue;
+    }
+    records.push(record);
+  }
+
+  for (const error of parsed.errors) {
+    const key = error.lineNumbers[0];
+    const action = log[key];
+    if (action?.kind === 'dismiss') {
+      ignored.push({ lineNumbers: [...error.lineNumbers], text: error.text, reason: 'dismissed' });
+      continue;
+    }
+    if (action?.kind === 'accept') {
+      // An acceptance that will not read is not an acceptance. Taking it
+      // anyway writes a permanent contact with a wrong or missing date of
+      // birth, which then poisons the surname + DOB identity key for every
+      // later term — so the row stays exactly where it was, still blocking.
+      const record = acceptedRecord(error, action, orientation);
+      if (record) {
+        records.push(record);
+        continue;
+      }
+    }
+    errors.push(error);
+  }
+
+  records.sort((a, b) => a.lineNumbers[0] - b.lineNumbers[0]);
+  ignored.sort((a, b) => a.lineNumbers[0] - b.lineNumbers[0]);
+  errors.sort((a, b) => a.lineNumbers[0] - b.lineNumbers[0]);
+
+  // --- P1, re-asserted after the resolutions, not only after the parse ----
+  const sum = (entries) => entries.reduce((n, e) => n + e.lineNumbers.length, 0);
+  const recordLines = sum(records);
+  const ignoredLines = sum(ignored);
+  const errorLines = sum(errors);
+  const accounted = recordLines + ignoredLines + errorLines;
+  const counts = {
+    lines: parsed.counts.lines,
+    records: records.length,
+    recordLines,
+    ignored: ignored.length,
+    ignoredLines,
+    errors: errors.length,
+    errorLines,
+    accounted,
+    reconciled: accounted === parsed.counts.lines,
+  };
+
+  // --- the rows on screen -------------------------------------------------
+  const rows = [
+    ...records.map((record) => ({
+      key: record.lineNumbers[0],
+      lineNumbers: [...record.lineNumbers],
+      bucket: 'record',
+      state: record.state,
+      firstName: record.write.firstName,
+      lastName: record.write.lastName,
+      dob: record.write.dob,
+      raw: '',
+      flags: [...record.flags],
+      needs: record.needs.map((need) => ({ ...need })),
+      note: record.state === 'clean' ? '' : noteFor(record.flags, record.needs),
+      needsHuman: record.state !== 'clean',
+      resolution: log[record.lineNumbers[0]]?.kind ?? null,
+    })),
+    ...errors.map((error) => ({
+      key: error.lineNumbers[0],
+      lineNumbers: [...error.lineNumbers],
+      bucket: 'error',
+      state: 'error',
+      firstName: '',
+      lastName: '',
+      dob: null,
+      raw: error.text,
+      flags: [],
+      needs: [],
+      note: REASON_NOTES[error.reason] ?? REASON_NOTES.unparseable,
+      needsHuman: true,
+      resolution: log[error.lineNumbers[0]]?.kind ?? null,
+    })),
+  ].sort((a, b) => a.key - b.key);
+
+  // --- what blocks --------------------------------------------------------
+  if (!counts.reconciled) {
+    // P1 applied literally. If this ever fires the run must not start: a line
+    // that is in no bucket is a student nobody can see.
+    blockers.push({
+      key: 'reconciliation',
+      kind: 'reconciliation',
+      severity: 'block',
+      title: 'The line counts do not add up',
+      detail: `${counts.accounted} of ${counts.lines} pasted lines are accounted for.`,
+      lineNumbers: [],
+    });
+  }
+
+  if (gate.unknown) {
+    blockers.push({
+      key: 'count-unknown',
+      kind: 'count-unknown',
+      severity: 'warn',
+      title: `We read ${plural(counts.records, 'student')}`,
+      detail: 'Nobody has said how many there should be, so nothing is checking this number.',
+      lineNumbers: [],
+    });
+  } else if (gate.ready && gate.count !== counts.records) {
+    blockers.push({
+      key: 'count-mismatch',
+      kind: 'count-mismatch',
+      severity: 'block',
+      title: `You expected ${gate.count}; we read ${counts.records}`,
+      detail: 'A layout read wrong, a header absorbed as a student or a truncated paste all '
+        + 'look like this. Fix the rows, or say the count has changed.',
+      lineNumbers: [],
+    });
+  }
+
+  const unreadable = rows.filter((row) => row.bucket === 'error');
+  if (unreadable.length > 0) {
+    blockers.push({
+      key: 'unparseable-rows',
+      kind: 'unparseable-rows',
+      severity: 'block',
+      title: `${plural(unreadable.length, 'line')} could not be read`,
+      detail: 'Each sits after a real student, so each may be one. Give it a name and a '
+        + 'birthday, or say it is not a student.',
+      lineNumbers: unreadable.flatMap((row) => row.lineNumbers),
+    });
+  }
+
+  const wanting = rows.filter((row) => row.bucket === 'record' && row.needsHuman);
+  if (wanting.length > 0) {
+    blockers.push({
+      key: 'needs-confirmation',
+      kind: 'needs-confirmation',
+      severity: 'block',
+      title: `${plural(wanting.length, 'row')} needs you`,
+      detail: wanting.map((row) => nameOf(row) || `line ${row.key}`).join(', '),
+      lineNumbers: wanting.flatMap((row) => row.lineNumbers),
+    });
+  }
+
+  for (const need of parsed.needs) {
+    // Two of these are answered by re-parsing — the page holds the answer and
+    // passes it back to parse.js, so the blocker disappears on its own. The
+    // other two have no parse option to answer: they are confirmations, and
+    // the log is where a confirmation goes.
+    const acknowledged = log[`list:${need.kind}`]?.kind === 'acknowledge';
+    if (acknowledged) continue;
+    blockers.push(listBlocker(need, parsed));
+  }
+
+  return {
+    rows,
+    ignored,
+    counts,
+    // The list-level inferences, carried through unchanged. §7 P2 is explicit
+    // that the dangerous decisions here are list-level rather than row-level,
+    // and a page that cannot see them cannot show, confirm or override them.
+    layout: parsed.layout,
+    blockSize: parsed.blockSize,
+    fieldCount: parsed.fieldCount,
+    header: parsed.header,
+    verdict: parsed.verdict,
+    columns: parsed.columns,
+    ignoredColumns: parsed.ignoredColumns,
+    dateOrientation: parsed.dateOrientation,
+    nameOrder: parsed.nameOrder,
+    reconciled: counts.reconciled,
+    blockers,
+    ready: !blockers.some((b) => b.severity === 'block'),
+    declared: gate,
+    // What the parser read before anybody touched it. The re-declare gate is
+    // the only thing that needs it, and it needs it for a reason: see below.
+    recordsParsed: parsed.counts.records,
+  };
+}
+
+function listBlocker(need, parsed) {
+  const base = { key: `list:${need.kind}`, kind: need.kind, severity: 'block', lineNumbers: [] };
+  if (need.kind === 'name-order') {
+    const shown = (need.samples ?? [])
+      .map((sample) => sample.values.join(' '))
+      .join(' · ');
+    return {
+      ...base,
+      title: 'Which way round are the names?',
+      detail: `No header names the columns, so this is a guess: ${shown}. Getting it wrong `
+        + 'creates a permanently reversed contact and nothing downstream would notice.',
+    };
+  }
+  if (need.kind === 'date-orientation') {
+    const sample = need.sample ?? {};
+    return {
+      ...base,
+      title: 'Day/month, or month/day?',
+      detail: `${sample.value} reads as ${sample.dmy} one way and ${sample.mdy} the other. `
+        + 'A wrong reading does not error — it turns March into May.',
+    };
+  }
+  if (need.kind === 'combined-name-comma') {
+    return {
+      ...base,
+      title: 'A name was split on a comma',
+      detail: 'Read as “Surname, Given”. Check the students below read the right way round.',
+    };
+  }
+  if (need.kind === 'excel-serial-dates') {
+    return {
+      ...base,
+      title: 'Some dates arrived as spreadsheet serial numbers',
+      detail: 'They have been converted. Check the birthdays below before going on.',
+    };
+  }
+  return { ...base, title: 'This list needs a decision', detail: need.kind };
+}
+
+/**
+ * Whether the count mismatch may offer a re-declare.
+ *
+ * Accepting an unreadable line as a student legitimately moves the count, so
+ * the mismatch has to be re-answerable — but **only once staff have moved it
+ * themselves.** Ungated, that button is a one-click dismissal of the gate P5
+ * exists to enforce: staff who cannot make the numbers agree would agree with
+ * the parser instead, which is the anchoring the gate's ordering was designed
+ * to prevent. The gate must survive its own escape hatch.
+ *
+ * The test is the sharpest one available: the record count has moved from what
+ * the parser read, and only a resolution can have moved it. Confirming a row
+ * does not qualify — nothing about the count changed — and neither does
+ * dismissing an unreadable line, which moves a line between two buckets nobody
+ * was ever asked to count.
+ */
+export function canRedeclare(reviewed) {
+  return Boolean(reviewed) && reviewed.counts.records !== reviewed.recordsParsed;
+}
+
+// ---------------------------------------------------------------------------
+// The lines step 3 puts on screen
+// ---------------------------------------------------------------------------
+
+/**
+ * The ignored columns, named. That line costs nothing and is the tell that the
+ * mapping went wrong (P6) — a column called `Email` sitting in the ignored list
+ * is fine, and one called `Surname` sitting there is the whole story.
+ */
+export function ignoredColumnsLine(reviewed) {
+  const columns = reviewed?.ignoredColumns;
+  if (!columns || columns.length === 0) return '';
+  return `${plural(columns.length, 'column')} ignored: ${columns.map((c) => c.label).join(', ')}.`;
+}
+
+/**
+ * The ignored count, which is always on screen while the lines themselves stay
+ * in a collapsed drawer (P9). Dismissals are counted apart from the rest: they
+ * are the lines staff put there, and folding them into the same number would
+ * hide a mis-click behind a header count nobody reads twice.
+ */
+export function ignoredSummary(reviewed) {
+  const entries = reviewed?.ignored ?? [];
+  const lines = (predicate) =>
+    entries.filter(predicate).reduce((n, e) => n + e.lineNumbers.length, 0);
+  const dismissed = lines((e) => e.reason === 'dismissed');
+  const rest = lines((e) => e.reason !== 'dismissed');
+
+  if (dismissed === 0 && rest === 0) return 'No lines ignored';
+  if (dismissed === 0) return `${plural(rest, 'line')} ignored before the first student`;
+  if (rest === 0) return `${plural(dismissed, 'line')} ignored, all dismissed by you`;
+  return `${plural(rest + dismissed, 'line')} ignored — ${rest} before the first student, `
+    + `${dismissed} you dismissed`;
+}
+
+/** P1, as a sentence. It is a sum, so it is shown as one. */
+export function reconciliationLine(reviewed) {
+  const c = reviewed?.counts;
+  if (!c) return '';
+  return `${plural(c.records, 'student')} + ${c.ignoredLines} ignored + ${c.errorLines} unreadable `
+    + `= ${plural(c.lines, 'line')} pasted.`;
+}
+
+/** The count gate, in the order it was asked: expected first, then read. */
+export function countLine(reviewed) {
+  const c = reviewed?.counts;
+  if (!c) return '';
+  const gate = reviewed.declared ?? {};
+  if (gate.unknown) {
+    return `We read ${plural(c.records, 'student')}. Nobody has said how many there should be.`;
+  }
+  if (!gate.ready) return `We read ${plural(c.records, 'student')}.`;
+  return `You expected ${plural(gate.count, 'student')}; we read ${c.records}.`;
+}

--- a/school-booking/test/alpine-bindings.test.js
+++ b/school-booking/test/alpine-bindings.test.js
@@ -39,16 +39,21 @@ const html = readFileSync(PAGE, 'utf8');
 // is *supposed* to be called from. Everything else — x-show, x-if, x-text,
 // x-html, x-model, x-init, x-effect, x-for and every `:attr` binding — is
 // evaluated on render.
-const DIRECTIVE = /(?:^|\s)(x-(?!on:)[a-z][a-z-]*|:[a-zA-Z][\w:-]*)\s*=\s*"([^"]*)"/g;
+const DIRECTIVE = /(?:^|\s)(x-(?!on:)[a-z][a-z-]*|:[a-zA-Z][\w:-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
 
 // Strings inside an expression are data, not references. Stripped so that
-// `x-text="'review'"` is not read as a reference to `review`.
+// `x-text="'review'"` is not read as a reference to `review`. Double quotes
+// cannot appear inside a double-quoted attribute, so single and template
+// quotes are the two that matter.
 const withoutStrings = (expression) => expression.replace(/'[^']*'/g, "''").replace(/`[^`]*`/g, '``');
 
 function directives(source) {
   const found = [];
-  for (const [, name, expression] of source.matchAll(DIRECTIVE)) {
-    found.push({ name, expression });
+  for (const [, name, doubled, singled] of source.matchAll(DIRECTIVE)) {
+    // Both quote styles. A guard that reads only `x-show="…"` is one
+    // apostrophe away from seeing nothing at all, which is the failure mode a
+    // static check has to be built against.
+    found.push({ name, expression: doubled ?? singled ?? '' });
   }
   return found;
 }
@@ -93,6 +98,64 @@ describe('the guard can see what it is guarding', () => {
     expect(offendersIn(directives('<div @click="b.review()">x</div>'))).toHaveLength(0);
     expect(offendersIn(directives('<div x-show="b.review()">x</div>'))).toHaveLength(0);
   });
+
+  test('it reads single-quoted attributes too', () => {
+    expect(offendersIn(directives("<div x-show='b.review'>x</div>"))).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The other half of the guard
+// ---------------------------------------------------------------------------
+// The check above catches a *name* the page publishes as a function. The bug it
+// was written for was `b.fix` — a function on a plain data object, which a text
+// check can only see if the property name happens to collide with one of those
+// names. Nothing static closes that.
+//
+// What closes it is the other end: every object an Alpine directive on this
+// page can reach comes out of `review()`. So if nothing in a review is ever a
+// function, there is nothing for a directive to invoke by accident, whatever it
+// is named. That is an invariant rather than a pattern match, and it is checked
+// here over the whole structure rather than one level of `blockers`.
+
+function functionsIn(value, path = '$', seen = new WeakSet()) {
+  if (typeof value === 'function') return [path];
+  if (value === null || typeof value !== 'object') return [];
+  if (seen.has(value)) return [];
+  seen.add(value);
+  return Object.entries(value).flatMap(([key, child]) =>
+    functionsIn(child, `${path}.${key}`, seen));
+}
+
+describe('nothing a review returns is ever a function', () => {
+  const fixture = (name) =>
+    readFileSync(new URL(`../../docs/school-lists/${name}`, import.meta.url), 'utf8');
+
+  const cases = {
+    'a clean list': [fixture('fixture-2-spreadsheet.tsv'), {}, {}],
+    'a vertical list': [fixture('fixture-1-vertical.txt'), {}, {}],
+    'a refused list': [['Katie\tFernsby\t23/4/2010\t1/2/2024'].join('\n'), {}, {}],
+    'a list with an unreadable line': [
+      ['First name\tSurname\tDOB', 'Katie\tFernsby\t23/4/2010', 'and Otto too'].join('\n'), {}, {},
+    ],
+    'a list with rows resolved': [
+      ['First name\tSurname\tDOB', 'Katie\tFernsby\t23/4/2010', 'and Otto too'].join('\n'),
+      { 3: { kind: 'dismiss' } }, {},
+    ],
+    'a list mid-question': [
+      ['Katie\tFernsby\t3/4/2010', 'Tomas\tOakhill\t7/11/2010'].join('\n'), {}, {},
+    ],
+  };
+
+  for (const [name, [text, resolutions, options]] of Object.entries(cases)) {
+    test(name, () => {
+      const reviewed = steps.review(parser.parseStudentList(text, options), {
+        declaration: steps.countDeclaration({ value: '3' }),
+        resolutions,
+      });
+      expect(functionsIn(reviewed)).toEqual([]);
+    });
+  }
 });
 
 function offendersIn(list) {
@@ -121,11 +184,24 @@ describe('school-booking.html', () => {
     expect(offenders, `\n${detail}\n`).toHaveLength(0);
   });
 
-  test('the two gate modules are imported with a cache-busting version', () => {
+  test('every module in the page\'s import chain is version-busted', () => {
     // A stale cached copy of a gate module breaks every check on the page at
     // once and in silence — the one failure the ?v= exists to prevent.
     expect(html).toMatch(/import \* as parser from '\.\/school-booking\/parse\.js\?v=\d+'/);
     expect(html).toMatch(/import \* as steps from '\.\/school-booking\/steps\.js\?v=\d+'/);
+
+    // Including the imports *inside* those modules. A specifier is a URL, so an
+    // unversioned `./parse.js` in steps.js is a second module the page's bump
+    // never reaches — leaving the file that holds every gate running against a
+    // parser the page has already moved on from.
+    const stepsSource = readFileSync(new URL('../steps.js', import.meta.url), 'utf8');
+    expect(stepsSource).not.toMatch(/from '\.\/parse\.js'/);
+
+    // And at the same version, or the page loads the parser twice.
+    const pageVersion = html.match(/school-booking\/parse\.js\?v=(\d+)/)[1];
+    const stepsVersion = stepsSource.match(/from '\.\/parse\.js\?v=(\d+)'/)[1];
+    expect(stepsVersion, 'bump parse.js\'s ?v= in the page and in steps.js together')
+      .toBe(pageVersion);
   });
 
   test('the page is not reachable from the hub yet', () => {

--- a/school-booking/test/alpine-bindings.test.js
+++ b/school-booking/test/alpine-bindings.test.js
@@ -1,0 +1,138 @@
+// The static guard from #78, on the class of bug recorded in §16 and found
+// during #54:
+//
+//     <div x-show="b.fix">…</div>     <!-- WRONG -->
+//
+// Alpine **invokes** a function returned by a directive expression, so this ran
+// the blocker's "confirm all" fix on **every render tick** — silently
+// confirming rows nobody had confirmed, with no user action and no error. The
+// confirmation gate was being defeated by its own affordance, continuously.
+//
+// It escapes both existing test seams. It is not a logic fault, so a unit test
+// of the rules cannot see it; and it is not a thrown error, so nothing at
+// runtime reports it. What it *is*, is a property of the page's text — which is
+// what this file reads.
+//
+// The rule: inside an Alpine **directive** expression, a name the page treats
+// as a function must be **called**. Calling one from `@click` is fine and is
+// the whole point; binding one to a directive is the fault.
+//
+// This is deliberately a text check rather than DOM infrastructure. The repo has
+// none and none is being introduced, and the fault is visible in the text — so
+// the cheap check is also the complete one for this class.
+//
+// Worth remembering how the original was caught at all: a screenshot showed
+// `CONFIRMED` pills on two rows while the blocker above them still named those
+// exact rows as needing confirmation. **Neither the state model nor the
+// rendered text was wrong on its own** — only the two together. Nobody gets a
+// second screenshot for free, so the check is here.
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as parser from '../parse.js';
+import * as steps from '../steps.js';
+
+const PAGE = new URL('../../school-booking.html', import.meta.url);
+const html = readFileSync(PAGE, 'utf8');
+
+// `x-on:` and `@` are excluded on purpose: an event handler is where a function
+// is *supposed* to be called from. Everything else — x-show, x-if, x-text,
+// x-html, x-model, x-init, x-effect, x-for and every `:attr` binding — is
+// evaluated on render.
+const DIRECTIVE = /(?:^|\s)(x-(?!on:)[a-z][a-z-]*|:[a-zA-Z][\w:-]*)\s*=\s*"([^"]*)"/g;
+
+// Strings inside an expression are data, not references. Stripped so that
+// `x-text="'review'"` is not read as a reference to `review`.
+const withoutStrings = (expression) => expression.replace(/'[^']*'/g, "''").replace(/`[^`]*`/g, '``');
+
+function directives(source) {
+  const found = [];
+  for (const [, name, expression] of source.matchAll(DIRECTIVE)) {
+    found.push({ name, expression });
+  }
+  return found;
+}
+
+// The names the page itself publishes as functions: every function-valued
+// export of the two modules, plus every method on the Alpine component. The
+// component's methods are the ones that matter most — they are what a directive
+// in this file can actually reach.
+function componentMethods(source) {
+  const script = source.slice(source.indexOf('function schoolBooking()'));
+  return [...script.matchAll(/^ {4}(?:async )?([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/gm)]
+    .map(([, name]) => name);
+}
+
+const moduleFunctions = [...Object.entries(parser), ...Object.entries(steps)]
+  .filter(([, value]) => typeof value === 'function')
+  .map(([name]) => name);
+
+const methods = componentMethods(html);
+const functionNames = [...new Set([...moduleFunctions, ...methods])];
+
+const bound = directives(html);
+
+describe('the guard can see what it is guarding', () => {
+  // A guard that matches nothing passes forever and protects nothing. These
+  // three are the ones that would silently empty it: renamed directives, a
+  // reindented component, a page that stopped importing the modules.
+  test('it found the page, its directives and its functions', () => {
+    expect(bound.length).toBeGreaterThan(40);
+    expect(methods.length).toBeGreaterThan(20);
+    expect(moduleFunctions).toContain('parseStudentList');
+    expect(moduleFunctions).toContain('review');
+  });
+
+  test('it recognises the bug it exists for', () => {
+    const offenders = offendersIn(directives('<div x-show="b.review">x</div>'));
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0].name).toBe('review');
+  });
+
+  test('it does not object to the same name called from a handler', () => {
+    expect(offendersIn(directives('<div @click="b.review()">x</div>'))).toHaveLength(0);
+    expect(offendersIn(directives('<div x-show="b.review()">x</div>'))).toHaveLength(0);
+  });
+});
+
+function offendersIn(list) {
+  const offenders = [];
+  for (const { name: directive, expression } of list) {
+    const text = withoutStrings(expression);
+    for (const name of functionNames) {
+      // Matches `review` and `b.review` alike — the `.` is not a word
+      // character, so the lookbehind lets a property access through while
+      // `prereview` and `reviewed` are excluded.
+      const bare = new RegExp(`(?<![\\w$])${name}\\b(?!\\s*\\()`);
+      if (bare.test(text)) offenders.push({ directive, expression, name });
+    }
+  }
+  return offenders;
+}
+
+describe('school-booking.html', () => {
+  test('no Alpine directive binds to a function without calling it', () => {
+    const offenders = offendersIn(bound);
+    // The failure message has to name the fix, because the next person to see
+    // it will be looking at markup that renders perfectly.
+    const detail = offenders
+      .map((o) => `  ${o.directive}="${o.expression}"  → "${o.name}" is a function; call it, or move it to @click`)
+      .join('\n');
+    expect(offenders, `\n${detail}\n`).toHaveLength(0);
+  });
+
+  test('the two gate modules are imported with a cache-busting version', () => {
+    // A stale cached copy of a gate module breaks every check on the page at
+    // once and in silence — the one failure the ?v= exists to prevent.
+    expect(html).toMatch(/import \* as parser from '\.\/school-booking\/parse\.js\?v=\d+'/);
+    expect(html).toMatch(/import \* as steps from '\.\/school-booking\/steps\.js\?v=\d+'/);
+  });
+
+  test('the page is not reachable from the hub yet', () => {
+    // §17: the hub entry is the last step of #46, and it is what makes every
+    // earlier step visible to staff. Landing it early ships a half-built tool
+    // to the front desk, because `main` is production.
+    const tools = readFileSync(new URL('../../tools.json', import.meta.url), 'utf8');
+    expect(tools).not.toContain('school-booking');
+  });
+});

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -1,0 +1,310 @@
+// The page's own component, driven without a DOM.
+//
+// Every method on `schoolBooking()` is plain JavaScript over the two modules —
+// Alpine supplies reactivity and nothing else — so the whole of steps 1–3 can
+// be walked here: pick a school, paste a list, declare a count, read it, fix a
+// row, override the mapping. What this catches is the half the pure-module
+// tests cannot see: a method calling an export that does not exist, passing the
+// wrong shape, or leaving the component in a state the markup then renders.
+//
+// It is extracted from the page rather than duplicated, so a page that stops
+// matching this file is a page that stops passing.
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as parser from '../parse.js';
+import * as steps from '../steps.js';
+
+const html = readFileSync(new URL('../../school-booking.html', import.meta.url), 'utf8');
+const fixture = (name) =>
+  readFileSync(new URL(`../../docs/school-lists/${name}`, import.meta.url), 'utf8');
+
+const SPREADSHEET = fixture('fixture-2-spreadsheet.tsv'); // 6 students, headed, 3 columns
+const VERTICAL = fixture('fixture-1-vertical.txt'); // 5 students, 6 fields each
+
+// The page's whole inline script, evaluated here — the block the factory lives
+// in, not just the factory, so a constant hoisted beside it comes too. Bounded
+// by its own tags at both ends, so a future second block cannot be swept in.
+const factorySource = (() => {
+  const anchor = html.indexOf('function schoolBooking()');
+  expect(anchor, 'schoolBooking() not found in the page').toBeGreaterThan(-1);
+  const open = html.lastIndexOf('<script>', anchor) + '<script>'.length;
+  return html.slice(open, html.indexOf('</script>', anchor));
+})();
+
+// eslint-disable-next-line no-new-func
+const makeComponent = new Function(`${factorySource}\nreturn schoolBooking();`);
+
+const SCHOOLS = [
+  { tag: 'newman', email: 'noreply+newman@urbanjungleirc.com', contacts: 63 },
+  { tag: 'harlow', email: 'noreply+harlow@urbanjungleirc.com', contacts: 4 },
+];
+
+function component({ schools = SCHOOLS, schoolsFail = false } = {}) {
+  globalThis.window = { schoolListParser: parser, schoolBookingSteps: steps };
+  globalThis.fetch = vi.fn(async (url) => {
+    if (String(url).includes('/api/clubworx/schools')) {
+      if (schoolsFail) return { ok: false, status: 502, json: async () => ({ error: 'upstream' }) };
+      return { ok: true, status: 200, json: async () => ({ ok: true, schools }) };
+    }
+    return { ok: true, status: 200, json: async () => ({ email: 'staff@urbanjungleirc.com' }) };
+  });
+  return makeComponent();
+}
+
+// init() kicks off two fetches without awaiting them — Alpine ignores what a
+// component's init() returns, so the page has no reason to hand back a promise
+// it would only be dropping. The wait belongs on this side.
+const settled = async (app) => {
+  app.init();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return app;
+};
+
+// The walk staff take: school, paste, count, read.
+async function upToStepThree(app, { text = SPREADSHEET, count = '6', unknown = false } = {}) {
+  await settled(app);
+  app.tag = 'newman';
+  app.go(1);
+  app.rawPaste = text;
+  app.countValue = count;
+  app.countUnknown = unknown;
+  app.readList();
+  return app;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('bootstrap', () => {
+  test('it loads the schools and the signed-in identity', async () => {
+    const app = await settled(component());
+    expect(app.bootstrapError).toBe('');
+    expect(app.schools).toHaveLength(2);
+    expect(app.accessEmail).toBe('staff@urbanjungleirc.com');
+  });
+
+  test('a failed schools read does not block step 1', async () => {
+    // Typing a tag is a first-class route — it is how a school gets its first
+    // one — so the list is an aid to reuse, never a permission to proceed.
+    const app = await settled(component({ schoolsFail: true }));
+    expect(app.schoolsState).toBe('error');
+    expect(app.schoolsNote()).toContain('still type a tag');
+    app.schoolQuery = 'Example Grammar';
+    app.useTypedTag();
+    expect(app.tag).toBe('examplegrammar');
+    expect(app.marker()).toBe('noreply+examplegrammar@urbanjungleirc.com');
+  });
+
+  test('a missing module refuses out loud instead of pretending to check', async () => {
+    globalThis.window = { schoolBookingSteps: steps };
+    globalThis.fetch = vi.fn();
+    const app = await settled(makeComponent());
+    expect(app.bootstrapError).toContain('list parser');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('step 1 — the school', () => {
+  test('the picker offers the busiest tags first, and marks a new one as new', async () => {
+    const app = await settled(component());
+    expect(app.filteredSchools().map((s) => s.tag)).toEqual(['newman', 'harlow']);
+
+    app.schoolQuery = 'new';
+    expect(app.filteredSchools().map((s) => s.tag)).toEqual(['newman']);
+    expect(app.knownTag(app.typedTag())).toBe(false); // 'new' is not 'newman'
+    app.schoolQuery = 'Newman';
+    expect(app.knownTag(app.typedTag())).toBe(true);
+  });
+});
+
+describe('step 2 — the count gate holds the door', () => {
+  test('the read button needs both a paste and a declaration', async () => {
+    const app = await settled(component());
+    app.tag = 'newman';
+    expect(app.canRead()).toBe(false);
+    app.rawPaste = SPREADSHEET;
+    expect(app.canRead()).toBe(false);
+    app.countValue = '6';
+    expect(app.canRead()).toBe(true);
+  });
+
+  test('"I don\'t know" is enough on its own', async () => {
+    const app = await settled(component());
+    app.rawPaste = SPREADSHEET;
+    app.countUnknown = true;
+    expect(app.canRead()).toBe(true);
+  });
+
+  test('nothing is parsed before the count is answered', async () => {
+    const app = await settled(component());
+    app.rawPaste = SPREADSHEET;
+    // The order is the whole point of P5 — a count displayed first is
+    // anchoring theatre. Nothing exists to display until readList() runs.
+    expect(app.parsed).toBeNull();
+    expect(app.reviewed).toBeNull();
+  });
+});
+
+describe('step 3 — reading the list', () => {
+  test('a matching count reads clean and is ready to go on', async () => {
+    const app = await upToStepThree(component());
+    expect(app.stepIndex).toBe(2);
+    expect(app.reviewed.counts.records).toBe(6);
+    expect(app.reviewed.ready).toBe(true);
+    expect(app.countLine()).toBe('You expected 6 students; we read 6.');
+    expect(app.countTone()).toContain('emerald');
+  });
+
+  test('a mismatch blocks, and offers no re-declare until staff move it', async () => {
+    const app = await upToStepThree(component(), { count: '21' });
+    expect(app.reviewed.ready).toBe(false);
+    expect(app.canRedeclare()).toBe(false);
+
+    app.dismissRow(2); // the first student
+    expect(app.reviewed.counts.records).toBe(5);
+    expect(app.canRedeclare()).toBe(true);
+
+    app.redeclare();
+    expect(app.countValue).toBe('5');
+    expect(app.reviewed.ready).toBe(true);
+  });
+
+  test('the drawer and the sums say the same thing as the module', async () => {
+    const app = await upToStepThree(component(), { text: VERTICAL, count: '5' });
+    expect(app.ignoredSummary()).toBe('7 lines ignored before the first student');
+    expect(app.ignoredColumnsLine()).toBe('3 columns ignored: FormGroup, YearLevel, Email.');
+    expect(app.reconciliationLine()).toBe('5 students + 7 ignored + 0 unreadable = 37 lines pasted.');
+  });
+
+  test('every row gets an edit buffer, and none is created during a render', async () => {
+    const app = await upToStepThree(component());
+    for (const row of app.reviewed.rows) {
+      expect(app.drafts[row.key], `draft for row ${row.key}`).toBeDefined();
+    }
+    const before = app.drafts;
+    app.draftFor(app.reviewed.rows[0].key);
+    app.draftFor(99); // a key that does not exist
+    expect(app.drafts).toBe(before);
+  });
+});
+
+describe('step 3 — the overrides', () => {
+  test('swapping the name chips reverses the names', async () => {
+    const app = await upToStepThree(component());
+    expect(app.reviewed.rows[0].firstName).toBe('Katie');
+    app.swapNames();
+    expect(app.reviewed.rows[0].firstName).toBe('Fernsby');
+    expect(app.reviewed.rows[0].lastName).toBe('Katie');
+  });
+
+  test('claiming a held column swaps the two roles rather than unnaming one', async () => {
+    // A column can only be one field, so something has to give. Clearing the
+    // other role leaves a named pair with one half missing, which the parser
+    // refuses outright — and a refused list is what a broken chip looks like
+    // from the front desk.
+    const app = await upToStepThree(component());
+    expect(app.currentColumns()).toMatchObject({ firstName: 0, lastName: 1, dob: 2 });
+    app.setColumn('lastName', 0);
+    expect(app.currentColumns()).toMatchObject({ firstName: 1, lastName: 0, dob: 2 });
+    expect(app.reviewed.blockers.some((b) => b.kind === 'refusal')).toBe(false);
+    expect(app.reviewed.rows[0]).toMatchObject({ firstName: 'Fernsby', lastName: 'Katie' });
+  });
+
+  test('a mapping that names no name columns never reaches the parser', async () => {
+    const app = await upToStepThree(component());
+    app.applyColumns({ dob: 2, firstName: null, lastName: null, combined: null });
+    app.applyColumns({ dob: 2, firstName: 0, lastName: 0, combined: null });
+    app.applyColumns({ dob: null, firstName: 0, lastName: 1, combined: null });
+    expect(app.reviewed.blockers.some((b) => b.kind === 'refusal')).toBe(false);
+    expect(app.currentColumns()).toMatchObject({ firstName: 0, lastName: 1, dob: 2 });
+  });
+
+  test('the chips describe whatever mapping is current, inferred or named', async () => {
+    const app = await upToStepThree(component());
+    expect(app.columnChips().map((c) => c.label)).toEqual(['First name', 'Surname', 'Birth date']);
+    expect(app.columnChoices()).toHaveLength(3);
+
+    app.setNameShape('combined');
+    expect(app.columnChips().map((c) => c.roleLabel)).toEqual(['Name', 'Birthday']);
+  });
+
+  test('a forced block size drives the read, and reading it again undoes it', async () => {
+    const app = await upToStepThree(component(), { text: VERTICAL, count: '5' });
+    expect(app.reviewed.blockSize).toBe(6);
+
+    app.setLayout('vertical');
+    app.setBlockSize('3');
+    expect(app.reviewed.blockSize).toBe(3);
+    expect(app.reviewed.verdict).toContain('3 fields per student');
+
+    app.clearOverrides();
+    expect(app.reviewed.blockSize).toBe(6);
+    expect(app.reviewed.counts.records).toBe(5);
+  });
+
+  test('a block size that cannot describe a list is not sent at all', async () => {
+    const app = await upToStepThree(component(), { text: VERTICAL, count: '5' });
+    app.setBlockSize('1');
+    app.setBlockSize('not a number');
+    expect(app.reviewed.blockSize).toBe(6);
+    expect(app.reviewed.blockers.some((b) => b.kind === 'refusal')).toBe(false);
+  });
+
+  test('an override keeps the resolutions — the source lines did not move', async () => {
+    const app = await upToStepThree(component());
+    app.dismissRow(2);
+    expect(app.reviewed.counts.records).toBe(5);
+    app.swapNames();
+    // A staff member who fixed the column mapping has not un-dismissed the
+    // teacher they dismissed.
+    expect(app.reviewed.counts.records).toBe(5);
+    expect(app.reviewed.reconciled).toBe(true);
+  });
+});
+
+describe('step 3 — resolving a row', () => {
+  const WITH_STRAY_LINE = [
+    ['First name', 'Surname', 'DOB'].join('\t'),
+    ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+    'Otto Brennan born 4 March 2011',
+  ].join('\n');
+
+  test('an unreadable line blocks, then becomes a student', async () => {
+    const app = await upToStepThree(component(), { text: WITH_STRAY_LINE, count: '2' });
+    expect(app.reviewed.ready).toBe(false);
+
+    app.toggleRow(3);
+    expect(app.expandedRow).toBe(3);
+    Object.assign(app.draftFor(3), { firstName: 'Otto', lastName: 'Brennan', dob: '4/3/2011' });
+    app.acceptRow(3);
+
+    expect(app.reviewed.counts.records).toBe(2);
+    expect(app.reviewed.ready).toBe(true);
+    expect(app.expandedRow).toBeNull();
+    const otto = app.reviewed.rows.find((r) => r.key === 3);
+    expect(otto).toMatchObject({ bucket: 'record', firstName: 'Otto', dob: '2011-03-04' });
+  });
+
+  test('dismissing moves the line to the drawer, and it can be put back', async () => {
+    const app = await upToStepThree(component(), { text: WITH_STRAY_LINE, count: '1' });
+    app.dismissRow(3);
+    expect(app.reviewed.ready).toBe(true);
+    expect(app.ignoredSummary()).toBe('2 lines ignored — 1 before the first student, 1 you dismissed');
+    expect(app.reviewed.reconciled).toBe(true);
+
+    app.undoRow(3);
+    expect(app.reviewed.ready).toBe(false);
+    expect(app.reviewed.rows.find((r) => r.key === 3).bucket).toBe('error');
+  });
+
+  test('the row helpers describe every row without throwing', async () => {
+    const app = await upToStepThree(component(), { text: WITH_STRAY_LINE, count: '2' });
+    for (const row of app.reviewed.rows) {
+      expect(typeof app.nameOf(row)).toBe('string');
+      expect(app.laneFor(row)).toMatch(/^lane-/);
+      expect(typeof app.stateTone(row)).toBe('string');
+    }
+  });
+});

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -78,11 +78,15 @@ beforeEach(() => {
 });
 
 describe('bootstrap', () => {
-  test('it loads the schools and the signed-in identity', async () => {
+  test('it loads the schools, and reads nothing else', async () => {
     const app = await settled(component());
     expect(app.bootstrapError).toBe('');
     expect(app.schools).toHaveLength(2);
-    expect(app.accessEmail).toBe('staff@urbanjungleirc.com');
+    // One call, to the one route the ticket asks for. #71 asks for the school
+    // list and nothing else; every other read is a page doing more than it
+    // was asked to.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(String(globalThis.fetch.mock.calls[0][0])).toContain('/api/clubworx/schools');
   });
 
   test('a failed schools read does not block step 1', async () => {
@@ -157,25 +161,58 @@ describe('step 3 — reading the list', () => {
     expect(app.countTone()).toContain('emerald');
   });
 
+  const redeclareAction = (app) =>
+    app.reviewed.blockers.find((b) => b.kind === 'count-mismatch')
+      ?.actions.find((a) => a.answers === 'redeclare');
+
   test('a mismatch blocks, and offers no re-declare until staff move it', async () => {
     const app = await upToStepThree(component(), { count: '21' });
     expect(app.reviewed.ready).toBe(false);
-    expect(app.canRedeclare()).toBe(false);
+    // The gate is carried on the blocker rather than tested in the markup, so
+    // there is no condition a template can forget.
+    expect(redeclareAction(app)).toBeUndefined();
 
     app.dismissRow(2); // the first student
     expect(app.reviewed.counts.records).toBe(5);
-    expect(app.canRedeclare()).toBe(true);
+    expect(redeclareAction(app)).toBeDefined();
 
-    app.redeclare();
+    app.answerBlocker(redeclareAction(app));
     expect(app.countValue).toBe('5');
     expect(app.reviewed.ready).toBe(true);
+  });
+
+  test('the Back button does not walk around the count gate', async () => {
+    // canRedeclare() refuses the in-place button; a Back to a freely editable
+    // count box with the read count on screen is the same move, one click
+    // further away, and it is the anchoring P5's ordering exists to prevent.
+    const app = await upToStepThree(component(), { count: '21' });
+    app.go(1);
+    expect(app.countLocked()).toBe(true);
+
+    // Editing the paste is a different list, so the declaration goes with it.
+    app.rawPaste = `${SPREADSHEET}\nOtto\tBrennan\t4/3/2011`;
+    app.pasteChanged();
+    expect(app.countLocked()).toBe(false);
+    expect(app.countValue).toBe('');
+    expect(app.canRead()).toBe(false);
+  });
+
+  test('Back then forward keeps the rows already sorted out', async () => {
+    const app = await upToStepThree(component(), { count: '6' });
+    app.dismissRow(2);
+    expect(app.reviewed.counts.records).toBe(5);
+
+    app.go(1);
+    app.readList();
+    expect(app.stepIndex).toBe(2);
+    expect(app.reviewed.counts.records).toBe(5);
   });
 
   test('the drawer and the sums say the same thing as the module', async () => {
     const app = await upToStepThree(component(), { text: VERTICAL, count: '5' });
     expect(app.ignoredSummary()).toBe('7 lines ignored before the first student');
     expect(app.ignoredColumnsLine()).toBe('3 columns ignored: FormGroup, YearLevel, Email.');
-    expect(app.reconciliationLine()).toBe('5 students + 7 ignored + 0 unreadable = 37 lines pasted.');
+    expect(app.reconciliationLine()).toBe('5 students on 30 lines + 7 ignored + 0 unreadable = 37 lines pasted.');
   });
 
   test('every row gets an edit buffer, and none is created during a render', async () => {
@@ -244,12 +281,38 @@ describe('step 3 — the overrides', () => {
     expect(app.reviewed.counts.records).toBe(5);
   });
 
-  test('a block size that cannot describe a list is not sent at all', async () => {
+  test('a block size that cannot describe a list is put back, not just ignored', async () => {
+    // Left in the box while the parse keeps the old block size, it is two
+    // plausible states contradicting each other with nothing thrown — §16's
+    // fault shape, which is the one this page is built to be careful about.
     const app = await upToStepThree(component(), { text: VERTICAL, count: '5' });
-    app.setBlockSize('1');
-    app.setBlockSize('not a number');
+    const input = { value: '1' };
+    app.setBlockSize('1', input);
+    expect(input.value).toBe(6);
+    app.setBlockSize('not a number', input);
+    expect(input.value).toBe(6);
     expect(app.reviewed.blockSize).toBe(6);
     expect(app.reviewed.blockers.some((b) => b.kind === 'refusal')).toBe(false);
+  });
+
+  test('a combined name only splits onto a column that holds names', async () => {
+    // `free[0]` would have picked whichever column was next — which is how
+    // `Email` or `YearLevel` becomes somebody's permanent surname, obeyed
+    // literally with nothing on screen to disagree with it.
+    const app = await upToStepThree(component(), { text: VERTICAL, count: '5' });
+    app.setNameShape('combined');
+    expect(app.currentColumns().combined).toBe(0);
+
+    const free = app.nameShapedFree();
+    expect(free).not.toContain(2); // Dob
+    expect(free).not.toContain(5); // Email — never name-shaped
+    app.setNameShape('split');
+    expect(app.currentColumns().lastName).toBe(free[0]);
+    // The surname is the column headed LastName, and Email stays where it
+    // belongs — named in the ignored list, which is P6's tell that the mapping
+    // is right.
+    expect(app.columnLabel(app.currentColumns().lastName)).toBe('LastName');
+    expect(app.reviewed.ignoredColumns.map((c) => c.label)).toContain('Email');
   });
 
   test('an override drops the edit buffers, so confirm cannot undo it', async () => {
@@ -331,6 +394,54 @@ describe('step 3 — resolving a row', () => {
     app.undoRow(3);
     expect(app.reviewed.ready).toBe(false);
     expect(app.reviewed.rows.find((r) => r.key === 3).bucket).toBe('error');
+  });
+
+  test('every blocker action dispatches to something', async () => {
+    // The page dispatches on `answers` and knows no blocker kinds, so a kind
+    // added in steps.js cannot arrive with no way out of it. This is the check
+    // that the dispatch actually covers what steps.js emits.
+    const KNOWN = ['nameOrder', 'dateOrientation', 'acknowledge', 'redeclare'];
+    const pastes = [
+      { text: WITH_STRAY_LINE, count: '9' },
+      // Headerless: the name-order question.
+      { text: [['Katie', 'Fernsby', '23/4/2010'].join('\t'), ['Tomas', 'Oakhill', '7/11/2010'].join('\t')].join('\n'), count: '2' },
+      // Every date ambiguous, so nothing proves the orientation: the day/month
+      // question, which is the one a wrong answer does not error on.
+      {
+        text: [
+          ['First name', 'Surname', 'DOB'].join('\t'),
+          ['Katie', 'Fernsby', '3/4/2010'].join('\t'),
+          ['Tomas', 'Oakhill', '7/11/2010'].join('\t'),
+        ].join('\n'),
+        count: '2',
+      },
+    ];
+    let seen = 0;
+    for (const paste of pastes) {
+      const app = await upToStepThree(component(), paste);
+      for (const blocker of app.reviewed.blockers) {
+        for (const action of blocker.actions) {
+          expect(KNOWN, `${blocker.kind} offers "${action.answers}"`).toContain(action.answers);
+          expect(typeof action.label).toBe('string');
+          seen += 1;
+        }
+      }
+    }
+    expect(seen).toBeGreaterThan(3);
+  });
+
+  test('answering a list question clears its blocker', async () => {
+    const headerless = [
+      ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+      ['Tomas', 'Oakhill', '7/11/2010'].join('\t'),
+    ].join('\n');
+    const app = await upToStepThree(component(), { text: headerless, count: '2' });
+    const order = app.reviewed.blockers.find((b) => b.kind === 'name-order');
+    expect(order.detail).toContain('Katie Fernsby / Fernsby Katie'); // P7: both ways
+
+    app.answerBlocker(order.actions.find((a) => a.value === 'last-first'));
+    expect(app.reviewed.blockers.some((b) => b.kind === 'name-order')).toBe(false);
+    expect(app.reviewed.rows[0]).toMatchObject({ firstName: 'Fernsby', lastName: 'Katie' });
   });
 
   test('the row helpers describe every row without throwing', async () => {

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -252,6 +252,40 @@ describe('step 3 — the overrides', () => {
     expect(app.reviewed.blockers.some((b) => b.kind === 'refusal')).toBe(false);
   });
 
+  test('an override drops the edit buffers, so confirm cannot undo it', async () => {
+    // The buffers were seeded from the rows the *previous* read produced. One
+    // that outlived its parse would hand the confirm button the pre-override
+    // names — quietly reverting the swap for that one row, with nothing thrown
+    // and the row looking confirmed.
+    const app = await upToStepThree(component());
+    expect(app.draftFor(2)).toMatchObject({ firstName: 'Katie', lastName: 'Fernsby' });
+
+    app.swapNames();
+    expect(app.draftFor(2)).toMatchObject({ firstName: 'Fernsby', lastName: 'Katie' });
+
+    app.confirmRow(2);
+    expect(app.reviewed.rows[0]).toMatchObject({ firstName: 'Fernsby', lastName: 'Katie' });
+  });
+
+  test('an acceptance survives an override — it lives in the resolution, not the buffer', async () => {
+    const app = await upToStepThree(component(), {
+      text: [
+        ['First name', 'Surname', 'DOB'].join('\t'),
+        ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+        'Otto Brennan born 4 March 2011',
+      ].join('\n'),
+      count: '2',
+    });
+    Object.assign(app.draftFor(3), { firstName: 'Otto', lastName: 'Brennan', dob: '4/3/2011' });
+    app.acceptRow(3);
+    expect(app.reviewed.counts.records).toBe(2);
+
+    app.swapNames();
+    expect(app.reviewed.rows.find((r) => r.key === 3)).toMatchObject({
+      bucket: 'record', firstName: 'Otto', lastName: 'Brennan',
+    });
+  });
+
   test('an override keeps the resolutions — the source lines did not move', async () => {
     const app = await upToStepThree(component());
     app.dismissRow(2);

--- a/school-booking/test/parse.test.js
+++ b/school-booking/test/parse.test.js
@@ -803,3 +803,165 @@ describe('P1 — the reconciliation holds through the messy cases', () => {
     expectReconciled(result);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #71 — the overrides behind the page's two affordances
+// ---------------------------------------------------------------------------
+// §7 P4 gives the layout verdict a one-click override and P6 gives the column
+// mapping three swappable chips. Both are *inferences with an affordance*
+// rather than questions, which is why they arrive as overrides rather than
+// through `needs` — the distinction this module's docblock draws and defers to
+// this ticket. The tests below are what "the override wins" has to mean: the
+// parse obeys it even when the inference was right, because a staff member who
+// disagrees with the verdict has no other way to say so.
+
+describe('#71 — the layout override', () => {
+  const VERTICAL_THREE = [
+    'Katie',
+    'Fernsby',
+    '23/4/2010',
+    'Tomas',
+    'Oakhill',
+    '7/11/2010',
+    'Priya',
+    'Van Dermeer',
+    '3/5/2011',
+  ].join('\n');
+
+  test('a forced block size overrides a verdict the anchor got wrong', () => {
+    // One missing date is all it takes: the stride breaks, the fallback offset
+    // reads the whole list as a single six-field student, and nothing errors.
+    // That is P4's failure mode from the other direction — 1 student out of 3
+    // rather than 126 out of 21 — and the override is the only way to say so.
+    const brokenStride = [
+      'Katie', 'Fernsby', '23/4/2010',
+      'Tomas', 'Oakhill', 'unknown',
+      'Priya', 'Van Dermeer', '3/5/2011',
+    ].join('\n');
+
+    const detected = parseStudentList(brokenStride);
+    expect(detected.blockSize).toBe(6);
+    expect(detected.records).toHaveLength(1);
+
+    const forced = parseStudentList(brokenStride, { layout: 'vertical', blockSize: 3 });
+    expect(forced.blockSize).toBe(3);
+    expect(forced.verdict).toContain('3 fields per student');
+    expect(forced.records.map((r) => r.write.lastName)).toEqual(['Fernsby', 'Van Dermeer']);
+    // The dateless block is the one Tomas is hiding in. It sits after a good
+    // record, so it blocks Apply (P15) rather than being quietly ignored.
+    expect(forced.errors.map((e) => e.reason)).toEqual(['unparseable', 'unparseable', 'unparseable']);
+    expectReconciled(forced);
+  });
+
+  test('forcing horizontal on a vertical list refuses rather than falling back', () => {
+    const forced = parseStudentList(VERTICAL_THREE, { layout: 'horizontal' });
+    expect(forced.layout).toBeNull();
+    expect(forced.refusal).not.toBeNull();
+    expect(forced.records).toHaveLength(0);
+    expectReconciled(forced);
+  });
+
+  test('a forced block size still finds the header and reconciles', () => {
+    // Fixture 1 opens with a blank line and six header lines; the anchor finds
+    // that offset on its own. Forcing the same block size must not lose it —
+    // the header block is before the first record, so P9 calls it a header,
+    // not six unparseable lines blocking the run.
+    const forced = parseStudentList(VERTICAL, { layout: 'vertical', blockSize: 6 });
+    expect(forced.records).toHaveLength(5);
+    expect(forced.header).toEqual(['PreferredName', 'LastName', 'Dob', 'FormGroup', 'YearLevel', 'Email']);
+    expect(forced.errors).toHaveLength(0);
+    expectReconciled(forced);
+  });
+
+  test('a block carrying no date is bucketed by position, never dropped', () => {
+    // P1 is the assertion everything leans on, and it is a forced block size
+    // that can put a dateless block among the records — the anchor cannot.
+    const withTrailingNote = `${VERTICAL_THREE}\nplus Otto\nif there is room\nplease`;
+    const forced = parseStudentList(withTrailingNote, { layout: 'vertical', blockSize: 3 });
+    expect(forced.records).toHaveLength(3);
+    expect(forced.errors).toHaveLength(3);
+    expect(forced.errors.every((e) => e.reason === 'unparseable')).toBe(true);
+    expectReconciled(forced);
+  });
+
+  test('a block size that cannot describe a list refuses', () => {
+    const forced = parseStudentList(VERTICAL_THREE, { layout: 'vertical', blockSize: 1 });
+    expect(forced.refusal?.code).toBe('override-out-of-range');
+    expectReconciled(forced);
+  });
+
+  test('forcing vertical without a block size falls back to the anchor', () => {
+    const forced = parseStudentList(VERTICAL_THREE, { layout: 'vertical' });
+    expect(forced.blockSize).toBe(3);
+    expect(forced.records).toHaveLength(3);
+    expectReconciled(forced);
+  });
+});
+
+describe('#71 — the column override', () => {
+  const TWO_DATE_COLUMNS = [
+    ['First name', 'Surname', 'DOB', 'Enrolled'].join('\t'),
+    ['Katie', 'Fernsby', '23/4/2010', '1/2/2024'].join('\t'),
+    ['Tomas', 'Oakhill', '7/11/2010', '3/3/2024'].join('\t'),
+  ].join('\n');
+
+  const HEADERLESS = [
+    ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+    ['Tomas', 'Oakhill', '7/11/2010'].join('\t'),
+  ].join('\n');
+
+  test('naming the DOB column resolves an ambiguity the parser refuses on', () => {
+    expect(parseStudentList(TWO_DATE_COLUMNS).refusal?.code).toBe('dob-column-ambiguous');
+
+    const fixed = parseStudentList(TWO_DATE_COLUMNS, { columns: { dob: 2 } });
+    expect(fixed.refusal).toBeNull();
+    expect(fixed.records).toHaveLength(2);
+    expect(fixed.columns.dob).toBe(2);
+    expect(fixed.records[0].write.dob).toBe('2010-04-23');
+    expect(fixed.ignoredColumns.map((c) => c.label)).toEqual(['Enrolled']);
+    expectReconciled(fixed);
+  });
+
+  test('swapping the name chips reverses the names and settles the order question', () => {
+    const inferred = parseStudentList(HEADERLESS);
+    expect(inferred.records[0].write).toMatchObject({ firstName: 'Katie', lastName: 'Fernsby' });
+    expect(inferred.needs.map((n) => n.kind)).toContain('name-order');
+
+    // Naming the columns *is* the answer to P7's question — a chip labelled
+    // "First name" says which one it is. Leaving the question standing would
+    // ask staff the same thing twice and let the two answers disagree.
+    const swapped = parseStudentList(HEADERLESS, { columns: { firstName: 1, lastName: 0 } });
+    expect(swapped.records[0].write).toMatchObject({ firstName: 'Fernsby', lastName: 'Katie' });
+    expect(swapped.needs.map((n) => n.kind)).not.toContain('name-order');
+    expectReconciled(swapped);
+  });
+
+  test('naming one column as the whole name reads it as a combined name', () => {
+    const withClassCode = [
+      ['Katie Fernsby', 'HARLOW', '23/4/2010'].join('\t'),
+      ['Tomas Oakhill', 'HARLOW', '7/11/2010'].join('\t'),
+    ].join('\n');
+
+    const inferred = parseStudentList(withClassCode);
+    expect(inferred.records[0].write).toMatchObject({ firstName: 'Katie Fernsby', lastName: 'HARLOW' });
+
+    const combined = parseStudentList(withClassCode, { columns: { combined: 0 } });
+    expect(combined.columns.combined).toBe(0);
+    expect(combined.records[0].write).toMatchObject({ firstName: 'Katie', lastName: 'Fernsby' });
+    expect(combined.ignoredColumns.map((c) => c.index)).toEqual([1]);
+    expectReconciled(combined);
+  });
+
+  test('an out-of-range column refuses rather than being quietly ignored', () => {
+    const bad = parseStudentList(SPREADSHEET, { columns: { dob: 9 } });
+    expect(bad.refusal?.code).toBe('override-out-of-range');
+    expect(bad.records).toHaveLength(0);
+    expectReconciled(bad);
+  });
+
+  test('a column named twice refuses — one column cannot be two fields', () => {
+    const bad = parseStudentList(SPREADSHEET, { columns: { firstName: 0, lastName: 0 } });
+    expect(bad.refusal?.code).toBe('override-out-of-range');
+    expectReconciled(bad);
+  });
+});

--- a/school-booking/test/steps.test.js
+++ b/school-booking/test/steps.test.js
@@ -1,0 +1,459 @@
+// The gates of steps 1–3, tested at the seam the page cannot reach around.
+//
+// Every check the page enforces lives in steps.js, so the tests below are the
+// gates themselves rather than a model of them: the count gate (P5), the
+// reconciliation after a dismissal (P1), the re-declare that must not become a
+// one-click dismissal of the gate it escapes, and the blocker list that decides
+// whether step 3 may be left at all.
+//
+// Blockers are asserted to be pure data as well as correct. That is the
+// structural half of the guard #78 asked for — the rendering half reads the
+// page markup in alpine-bindings.test.js. A blocker carrying a function is what
+// makes `x-show="b.fix"` possible in the first place.
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { parseStudentList } from '../parse.js';
+import {
+  canRedeclare,
+  countDeclaration,
+  countLine,
+  ignoredColumnsLine,
+  ignoredSummary,
+  reconciliationLine,
+  resolve,
+  review,
+  schoolMarker,
+  schoolTag,
+} from '../steps.js';
+
+const fixture = (name) =>
+  readFileSync(new URL(`../../docs/school-lists/${name}`, import.meta.url), 'utf8');
+
+const SPREADSHEET = fixture('fixture-2-spreadsheet.tsv'); // 6 students, headed, 3 columns
+const VERTICAL = fixture('fixture-1-vertical.txt'); // 5 students, 6 fields each
+
+const declared = (n) => countDeclaration({ value: n, unknown: false });
+const unknown = () => countDeclaration({ value: '', unknown: true });
+
+const reviewOf = (text, count, resolutions = {}, options = {}) =>
+  review(parseStudentList(text, options), { declaration: count, resolutions });
+
+// ---------------------------------------------------------------------------
+// Step 1 — the school tag
+// ---------------------------------------------------------------------------
+
+describe('step 1 — the school tag', () => {
+  test('a typed school becomes a tag safe to put in an address', () => {
+    expect(schoolTag('  Example Grammar College ')).toBe('examplegrammarcollege');
+    expect(schoolTag("St Mary's (Senior)")).toBe('stmaryssenior');
+    expect(schoolTag('Newman JHS')).toBe('newmanjhs');
+  });
+
+  test('a tag that survives normalisation unchanged is left alone', () => {
+    // The picker hands back tags Clubworx already holds. Normalising one into a
+    // *different* tag would write a second spelling of a school that already
+    // has one, on contacts that cannot be deleted.
+    expect(schoolTag('newman')).toBe('newman');
+    expect(schoolTag('stmarys')).toBe('stmarys');
+  });
+
+  test('nothing usable is left as an empty tag, never a partial one', () => {
+    expect(schoolTag('')).toBe('');
+    expect(schoolTag('   ')).toBe('');
+    expect(schoolTag('—')).toBe('');
+  });
+
+  test('the marker is the only provenance this system will ever have', () => {
+    expect(schoolMarker('newman')).toBe('noreply+newman@urbanjungleirc.com');
+    expect(schoolMarker('')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 2 — P5, the count gate
+// ---------------------------------------------------------------------------
+
+describe('step 2 — declaring the count', () => {
+  test('a whole positive number is a declaration', () => {
+    expect(declared('21')).toMatchObject({ ready: true, count: 21, unknown: false });
+    expect(declared(21)).toMatchObject({ ready: true, count: 21 });
+  });
+
+  test('"I don\'t know" is a declaration too, and forgets any number typed first', () => {
+    // The banner and the gate are different outcomes; carrying a stale number
+    // into the banner would let it block something it was never asked about.
+    expect(countDeclaration({ value: '21', unknown: true })).toMatchObject({
+      ready: true,
+      unknown: true,
+      count: null,
+    });
+  });
+
+  test('nothing, zero and nonsense are not declarations', () => {
+    expect(declared('').ready).toBe(false);
+    expect(declared('0').ready).toBe(false);
+    expect(declared('-3').ready).toBe(false);
+    expect(declared('twenty').ready).toBe(false);
+    expect(declared('21.5').ready).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 3 — the review, and what blocks
+// ---------------------------------------------------------------------------
+
+describe('step 3 — the count gate blocks, or downgrades to a banner', () => {
+  test('a matching count clears the gate', () => {
+    const r = reviewOf(SPREADSHEET, declared(6));
+    expect(r.counts.records).toBe(6);
+    expect(r.blockers.filter((b) => b.kind === 'count-mismatch')).toHaveLength(0);
+    expect(countLine(r)).toContain('6');
+  });
+
+  test('a mismatch blocks the run', () => {
+    const r = reviewOf(SPREADSHEET, declared(21));
+    const blocker = r.blockers.find((b) => b.kind === 'count-mismatch');
+    expect(blocker).toBeDefined();
+    expect(blocker.severity).toBe('block');
+    expect(r.ready).toBe(false);
+  });
+
+  test('"I don\'t know" downgrades the gate to a banner that does not block', () => {
+    const r = reviewOf(SPREADSHEET, unknown());
+    const banner = r.blockers.find((b) => b.kind === 'count-unknown');
+    expect(banner).toBeDefined();
+    expect(banner.severity).toBe('warn');
+    expect(r.blockers.some((b) => b.kind === 'count-mismatch')).toBe(false);
+    expect(r.ready).toBe(true);
+  });
+
+  test('every blocker is data — no property is a function', () => {
+    // #78. Alpine invokes a function returned by a directive expression, so a
+    // blocker carrying `fix` is a gate that defeats itself on every render
+    // tick. The fix is that there is nothing here to invoke.
+    const r = reviewOf(SPREADSHEET, declared(21));
+    expect(r.blockers.length).toBeGreaterThan(0);
+    for (const blocker of r.blockers) {
+      for (const [key, value] of Object.entries(blocker)) {
+        expect(typeof value, `blockers[].${key}`).not.toBe('function');
+      }
+    }
+  });
+});
+
+describe('step 3 — what the parse itself blocks on', () => {
+  const WITH_STRAY_LINE = [
+    ['First name', 'Surname', 'DOB'].join('\t'),
+    ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+    ['Tomas', 'Oakhill', '7/11/2010'].join('\t'),
+    'and Otto if there is room',
+  ].join('\n');
+
+  test('an unparseable line blocks Apply until it is accounted for (P15)', () => {
+    const r = reviewOf(WITH_STRAY_LINE, declared(2));
+    const blocker = r.blockers.find((b) => b.kind === 'unparseable-rows');
+    expect(blocker).toBeDefined();
+    expect(blocker.severity).toBe('block');
+    expect(blocker.lineNumbers).toEqual([4]);
+    expect(r.ready).toBe(false);
+  });
+
+  test('a row wanting confirmation blocks, and names itself', () => {
+    const headerless = [
+      ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+      ['Tomas', 'Oakhill', '7/11/2010'].join('\t'),
+    ].join('\n');
+    const r = reviewOf(headerless, declared(2));
+    // A headerless list cannot know its name order, which is a question about
+    // the list rather than a row — so it blocks as one.
+    expect(r.blockers.some((b) => b.kind === 'name-order')).toBe(true);
+    expect(r.ready).toBe(false);
+  });
+
+  test('a refused paste blocks with the refusal, not with a wall of row errors', () => {
+    const twoDateColumns = [
+      ['Katie', 'Fernsby', '23/4/2010', '1/2/2024'].join('\t'),
+      ['Tomas', 'Oakhill', '7/11/2010', '3/3/2024'].join('\t'),
+    ].join('\n');
+    const r = reviewOf(twoDateColumns, declared(2));
+    const blocker = r.blockers.find((b) => b.kind === 'refusal');
+    expect(blocker).toBeDefined();
+    expect(blocker.detail).toContain('ambiguous');
+    expect(r.rows).toHaveLength(0);
+    expect(r.ready).toBe(false);
+  });
+
+  test('the reconciliation is reported, not assumed', () => {
+    const r = reviewOf(VERTICAL, declared(5));
+    expect(r.reconciled).toBe(true);
+    expect(reconciliationLine(r)).toMatch(/5 students/);
+    expect(r.counts.accounted).toBe(r.counts.lines);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline resolution — the two rules that constrain it
+// ---------------------------------------------------------------------------
+
+describe('dismissing a row reclassifies it; it is never removed', () => {
+  const WITH_STRAY_LINE = [
+    ['First name', 'Surname', 'DOB'].join('\t'),
+    ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+    'and Otto if there is room',
+  ].join('\n');
+
+  test('a dismissed unreadable line moves to ignored and stops blocking', () => {
+    const resolutions = resolve({}, 3, { kind: 'dismiss' });
+    const r = reviewOf(WITH_STRAY_LINE, declared(1), resolutions);
+    expect(r.blockers.some((b) => b.kind === 'unparseable-rows')).toBe(false);
+    expect(r.ignored.some((i) => i.lineNumbers.includes(3) && i.reason === 'dismissed')).toBe(true);
+    expect(r.ready).toBe(true);
+  });
+
+  test('the reconciliation is asserted after the dismissal, not only after the parse', () => {
+    const resolutions = resolve({}, 3, { kind: 'dismiss' });
+    const r = reviewOf(WITH_STRAY_LINE, declared(1), resolutions);
+    expect(r.counts.accounted).toBe(r.counts.lines);
+    expect(r.reconciled).toBe(true);
+    // The line is still counted. Dropping it is what breaks P1, and the count
+    // that catches that is the one on screen.
+    expect(r.counts.ignoredLines).toBe(2); // the header, and the dismissed line
+  });
+
+  test('dismissing a student drops the record count, and P1 still holds', () => {
+    const r = reviewOf(SPREADSHEET, declared(6), resolve({}, 2, { kind: 'dismiss' }));
+    expect(r.counts.records).toBe(5);
+    expect(r.reconciled).toBe(true);
+    expect(r.counts.accounted).toBe(r.counts.lines);
+  });
+
+  test('a dismissal can be taken back', () => {
+    const dismissed = resolve({}, 2, { kind: 'dismiss' });
+    const restored = resolve(dismissed, 2, null);
+    expect(reviewOf(SPREADSHEET, declared(6), restored).counts.records).toBe(6);
+    // resolve() does not mutate what it is given — Alpine re-renders from the
+    // returned value, and a mutated original would make undo unobservable.
+    expect(reviewOf(SPREADSHEET, declared(6), dismissed).counts.records).toBe(5);
+  });
+});
+
+describe('accepting an unreadable line as a student', () => {
+  const WITH_STRAY_LINE = [
+    ['First name', 'Surname', 'DOB'].join('\t'),
+    ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+    'Otto Brennan born 4 March 2011',
+  ].join('\n');
+
+  const accepted = resolve({}, 3, {
+    kind: 'accept',
+    firstName: 'Otto',
+    lastName: 'Brennan',
+    dob: '4/3/2011',
+  });
+
+  test('the line becomes a student, read on the list\'s own date orientation', () => {
+    const r = reviewOf(WITH_STRAY_LINE, declared(1), accepted);
+    expect(r.counts.records).toBe(2);
+    const otto = r.rows.find((row) => row.key === 3);
+    expect(otto).toMatchObject({ bucket: 'record', state: 'clean', firstName: 'Otto', lastName: 'Brennan' });
+    expect(otto.dob).toBe('2011-03-04'); // dmy, proved by 23/4/2010 above
+    expect(r.reconciled).toBe(true);
+  });
+
+  test('a date that will not read leaves the row unaccounted for', () => {
+    // Silently accepting an unreadable date writes a permanent contact with a
+    // wrong or missing DOB, which then poisons the surname + DOB key for every
+    // later term. The row stays where it was.
+    const bad = resolve({}, 3, { kind: 'accept', firstName: 'Otto', lastName: 'Brennan', dob: 'march' });
+    const r = reviewOf(WITH_STRAY_LINE, declared(1), bad);
+    expect(r.counts.records).toBe(1);
+    expect(r.rows.find((row) => row.key === 3).bucket).toBe('error');
+    expect(r.ready).toBe(false);
+  });
+
+  test('a half-filled acceptance is not an acceptance', () => {
+    const half = resolve({}, 3, { kind: 'accept', firstName: 'Otto', lastName: '', dob: '4/3/2011' });
+    const r = reviewOf(WITH_STRAY_LINE, declared(1), half);
+    expect(r.counts.records).toBe(1);
+    expect(r.ready).toBe(false);
+  });
+});
+
+describe('the re-declare escape hatch, and the gate surviving it', () => {
+  const WITH_STRAY_LINE = [
+    ['First name', 'Surname', 'DOB'].join('\t'),
+    ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+    'Otto Brennan born 4 March 2011',
+  ].join('\n');
+
+  test('a plain mismatch offers no re-declare', () => {
+    // Ungated this button is a one-click dismissal of the gate P5 exists to
+    // enforce: staff who cannot make the numbers agree would simply agree with
+    // the parser instead.
+    const r = reviewOf(SPREADSHEET, declared(21));
+    expect(r.blockers.some((b) => b.kind === 'count-mismatch')).toBe(true);
+    expect(canRedeclare(r)).toBe(false);
+  });
+
+  test('accepting a line moves the count for a reason staff created, so it unlocks', () => {
+    const accepted = resolve({}, 3, {
+      kind: 'accept', firstName: 'Otto', lastName: 'Brennan', dob: '4/3/2011',
+    });
+    const r = reviewOf(WITH_STRAY_LINE, declared(1), accepted);
+    expect(r.counts.records).toBe(2);
+    expect(canRedeclare(r)).toBe(true);
+  });
+
+  test('dismissing a student unlocks it too — the number moved either way', () => {
+    const r = reviewOf(SPREADSHEET, declared(6), resolve({}, 2, { kind: 'dismiss' }));
+    expect(canRedeclare(r)).toBe(true);
+  });
+
+  test('confirming a row does not unlock it — nothing about the count changed', () => {
+    const headerless = [
+      ['Katie Fernsby van Aalst', 'HARLOW', '23/4/2010'].join('\t'),
+      ['Tomas Oakhill', 'HARLOW', '7/11/2010'].join('\t'),
+    ].join('\n');
+    const withoutConfirm = reviewOf(headerless, declared(9), {}, { columns: { combined: 0 } });
+    const confirmed = reviewOf(
+      headerless,
+      declared(9),
+      resolve({}, 1, { kind: 'confirm' }),
+      { columns: { combined: 0 } },
+    );
+    expect(confirmed.counts.records).toBe(withoutConfirm.counts.records);
+    expect(canRedeclare(confirmed)).toBe(false);
+  });
+
+  test('dismissing an unreadable line does not unlock it either', () => {
+    // It moves a line from `errors` to `ignored`. Nobody was ever asked to
+    // count either bucket, so the declared number has no reason to move.
+    const dismissed = resolve({}, 3, { kind: 'dismiss' });
+    const r = reviewOf(WITH_STRAY_LINE, declared(1), dismissed);
+    expect(r.counts.records).toBe(1);
+    expect(canRedeclare(r)).toBe(false);
+  });
+});
+
+describe('confirming a row that wanted a human', () => {
+  const COMBINED = [
+    ['Katie Fernsby van Aalst', '23/4/2010'].join('\t'),
+    ['Tomas Oakhill', '7/11/2010'].join('\t'),
+  ].join('\n');
+
+  test('a three-token name asks, and confirming settles it', () => {
+    const before = reviewOf(COMBINED, declared(2));
+    const katie = before.rows.find((r) => r.key === 1);
+    expect(katie.state).toBe('needs-confirmation');
+    expect(before.blockers.some((b) => b.kind === 'needs-confirmation')).toBe(true);
+
+    const after = reviewOf(COMBINED, declared(2), resolve({}, 1, { kind: 'confirm' }));
+    expect(after.rows.find((r) => r.key === 1).state).toBe('clean');
+  });
+
+  test('confirming with edited names keeps the edit', () => {
+    const after = reviewOf(
+      COMBINED,
+      declared(2),
+      resolve({}, 1, { kind: 'confirm', firstName: 'Katie', lastName: 'Fernsby van Aalst' }),
+    );
+    const katie = after.rows.find((r) => r.key === 1);
+    expect(katie).toMatchObject({ state: 'clean', firstName: 'Katie', lastName: 'Fernsby van Aalst' });
+  });
+
+  test('a confirmed row is still a row — the counts do not move', () => {
+    const after = reviewOf(COMBINED, declared(2), resolve({}, 1, { kind: 'confirm' }));
+    expect(after.counts.records).toBe(2);
+    expect(after.reconciled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// What step 3 says out loud
+// ---------------------------------------------------------------------------
+
+describe('the lines step 3 puts on screen', () => {
+  test('the ignored columns are named — that line is the tell that mapping went wrong', () => {
+    const r = reviewOf(VERTICAL, declared(5));
+    expect(ignoredColumnsLine(r)).toBe('3 columns ignored: FormGroup, YearLevel, Email.');
+  });
+
+  test('nothing ignored says nothing', () => {
+    expect(ignoredColumnsLine(reviewOf(SPREADSHEET, declared(6)))).toBe('');
+  });
+
+  test('the ignored count is always on screen, and separates the two kinds', () => {
+    const r = reviewOf(VERTICAL, declared(5));
+    expect(ignoredSummary(r)).toBe('7 lines ignored before the first student');
+
+    const withDismissal = reviewOf(VERTICAL, declared(5), resolve({}, 8, { kind: 'dismiss' }));
+    expect(ignoredSummary(withDismissal)).toBe(
+      '13 lines ignored — 7 before the first student, 6 you dismissed',
+    );
+  });
+
+  test('the reconciliation reads as a sum, because that is what it is (P1)', () => {
+    const r = reviewOf(VERTICAL, declared(5));
+    expect(reconciliationLine(r)).toBe(
+      '5 students + 7 ignored + 0 unreadable = 37 lines pasted.',
+    );
+  });
+
+  test('the count line says what was expected and what was read, in that order', () => {
+    expect(countLine(reviewOf(SPREADSHEET, declared(6)))).toBe(
+      'You expected 6 students; we read 6.',
+    );
+    expect(countLine(reviewOf(SPREADSHEET, declared(21)))).toBe(
+      'You expected 21 students; we read 6.',
+    );
+    expect(countLine(reviewOf(SPREADSHEET, unknown()))).toBe(
+      'We read 6 students. Nobody has said how many there should be.',
+    );
+  });
+});
+
+describe('list-level questions with no parse option to answer them', () => {
+  const COMMA_NAMES = [
+    ['Fernsby, Katie', '23/4/2010'].join('\t'),
+    ['Oakhill, Tomas', '7/11/2010'].join('\t'),
+  ].join('\n');
+
+  // A comma is deliberately not a delimiter (§7), so `Surname, Given` arrives
+  // as one field that is not name-shaped — the mapping refuses it and staff
+  // name the column themselves. That makes this the shortest route to the
+  // comma question, and it exercises the #71 chips on the way through.
+  // `nameOrder` answers P7 alongside it. A comma-split row decides its own
+  // order, but the parser asks about the list rather than the row — and
+  // leaving that question standing would make `ready` false for a reason this
+  // test is not about.
+  const AS_COMBINED = { columns: { combined: 0 }, nameOrder: 'first-last' };
+
+  test('a comma-split name blocks until it is acknowledged once for the list', () => {
+    // Unlike the name-order and date-orientation questions, this one has no
+    // option to pass back to the parser — it is a confirmation, so the
+    // resolution log is where it goes, keyed by the list rather than a row.
+    const before = reviewOf(COMMA_NAMES, declared(2), {}, AS_COMBINED);
+    expect(before.blockers.some((b) => b.kind === 'combined-name-comma')).toBe(true);
+    expect(before.ready).toBe(false);
+
+    const after = reviewOf(
+      COMMA_NAMES,
+      declared(2),
+      resolve({}, 'list:combined-name-comma', { kind: 'acknowledge' }),
+      AS_COMBINED,
+    );
+    expect(after.blockers.some((b) => b.kind === 'combined-name-comma')).toBe(false);
+    expect(after.ready).toBe(true);
+  });
+
+  test('acknowledging one question does not clear another', () => {
+    const r = reviewOf(
+      COMMA_NAMES,
+      declared(2),
+      resolve({}, 'list:excel-serial-dates', { kind: 'acknowledge' }),
+      AS_COMBINED,
+    );
+    expect(r.blockers.some((b) => b.kind === 'combined-name-comma')).toBe(true);
+  });
+});

--- a/school-booking/test/steps.test.js
+++ b/school-booking/test/steps.test.js
@@ -394,10 +394,39 @@ describe('the lines step 3 puts on screen', () => {
   });
 
   test('the reconciliation reads as a sum, because that is what it is (P1)', () => {
+    // The numbers on screen have to add up, which means counting the students'
+    // LINES. A vertical list puts one student on six of them, so a sentence
+    // reading "5 + 7 + 0 = 37" is the reconciliation failing quietly on the one
+    // screen whose job is making counts agree.
     const r = reviewOf(VERTICAL, declared(5));
     expect(reconciliationLine(r)).toBe(
-      '5 students + 7 ignored + 0 unreadable = 37 lines pasted.',
+      '5 students on 30 lines + 7 ignored + 0 unreadable = 37 lines pasted.',
     );
+  });
+
+  test('one student per line says it once — the two numbers are the same number', () => {
+    expect(reconciliationLine(reviewOf(SPREADSHEET, declared(6)))).toBe(
+      '6 students + 1 ignored + 0 unreadable = 7 lines pasted.',
+    );
+  });
+
+  test('the sentence adds up, on every fixture and after a dismissal', () => {
+    // The assertion the two above are examples of. Read the numbers back out of
+    // the rendered sentence and check the arithmetic, so a future rewording
+    // cannot quietly stop summing the way the first draft of this did.
+    const cases = [
+      reviewOf(VERTICAL, declared(5)),
+      reviewOf(SPREADSHEET, declared(6)),
+      reviewOf(VERTICAL, declared(5), resolve({}, 8, { kind: 'dismiss' })),
+      reviewOf(SPREADSHEET, declared(6), resolve({}, 2, { kind: 'dismiss' })),
+    ];
+    for (const r of cases) {
+      const numbers = reconciliationLine(r).match(/\d+/g).map(Number);
+      const total = numbers.pop();
+      const parts = numbers.length === 4 ? numbers.slice(1) : numbers; // "N students on M lines"
+      expect(parts.reduce((a, b) => a + b, 0), reconciliationLine(r)).toBe(total);
+      expect(total).toBe(r.counts.lines);
+    }
   });
 
   test('the count line says what was expected and what was read, in that order', () => {


### PR DESCRIPTION
Closes #71. Part of #46. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §7, §9, §16, §17.

⚠️ **Merging this deploys it.** `main` is production. What lands is *reachable by URL* but **not linked from `tools.json`** — §17's order, and the last step of #46 is what makes it visible to staff. A test asserts the absence, so landing the hub entry early fails rather than shipping a half-built tool to the front desk. Nothing on this page writes anything: steps 4–6 are #72 and #73.

## What's here

**`school-booking.html`** — Variant A, the gated stepper, decided on #54 against three built prototypes. Steps 1–3: pick or type the school tag, paste the list and declare the expected count, then the parse result with inline row resolution. Steps 4–6 sit in the strip disabled — six is the shape of the run, and a forward button that vanishes reads as "you are finished".

**`school-booking/steps.js`** — every gate the page enforces, pure and unit tested. One `review()` turns a parse plus a log of staff resolutions into the rows, the P1 reconciliation and the blockers.

**`school-booking/parse.js`** — the layout and column overrides the page's two affordances need. Its docblock on `main` already said their shape belonged here.

## Three things worth reading before merging

**Nothing `review()` returns is ever a function.** The gate this page enforces was defeated once already by its own affordance — `x-show="b.fix"` ran the blocker's "confirm all" on every render tick, silently confirming rows nobody had confirmed (§16). Two guards, both from #78's addition to this ticket: a text check over the page's markup, and a recursive assertion that no value anywhere in a review is a function. The second is the invariant behind the first, since every object a directive can reach comes out of `review()`. Both verified by mutation.

**P1 is re-asserted after every resolution, not only after a parse.** Dismissing reclassifies to `ignored` and never removes, so the three counts keep summing to the pasted line count.

**The count gate survives its own escape hatches.** The re-declare appears only once the record count has moved for a reason staff created — not from confirming a row, and not from dismissing an unreadable line. And a declaration is bound to the paste it was made about, so Back cannot walk around it either.

## Overrides are obeyed literally

Including where the inference was right. An override the parser may discard when it disagrees is not an override, and a staff member watching the verdict stay the same after clicking cannot tell a rejected override from a broken button. Out of range refuses rather than falling back — the values come from the page's own chips, so a bad one is a caller bug, and reading a different column than the chip names writes a permanent wrong contact with nothing on screen disagreeing. The page validates against the parser's own exported rule before sending, so a chip never produces a refusal.

## Bugs found and fixed while reviewing

- **`steps.js` imported `./parse.js` with no `?v=`** — a second parser instance the page's cache-bust could never reach, leaving the file that holds every gate running against a stale copy. Now versioned, and a test fails if the two versions drift.
- **The P1 sentence did not sum** — it counted students where P1 counts lines, so a vertical list read `5 + 7 + 0 = 37`. A test of mine had enshrined it. A new test reads the numbers back out of the sentence and checks the arithmetic.
- **An edit buffer outlived its parse** — confirming a row after a column swap wrote the pre-swap names back, reverting the override for that row with nothing thrown.
- **`setNameShape('split')` guessed a surname** — `free[0]`, which on the vertical fixture is `FormGroup`. The parser now reports which columns hold a name in every row.

## Verification

```
cd school-booking && npm install && npx vitest run     # 178 tests
npx vitest run                                          # 2314 across the repo
```

Both green. The page has no automated browser check — this repo has no DOM test infrastructure and none is introduced — but `test/page-component.test.js` lifts the page's own inline script and drives the whole walk without a DOM, so the component's logic is covered.

**Not yet done in a browser.** Worth a look at `ujstaff.happyk.au/school-booking.html` after merge, with one of the fixtures in `docs/school-lists/`.

## Also flagged, not changed

`school-booking/identity.js` has the same unversioned `./parse.js` import. Harmless today because no page loads it — #72 is where it starts to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn