### PR TITLE
School booking: the re-declare gate, and two banners saying one thing (#71)

### DIFF
--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -756,6 +756,28 @@ human fix it" a workflow rather than a dead end.
   edited rows themselves.** Ungated, that button is a one-click dismissal of the
   gate P5 exists to enforce. The gate must survive its own escape hatch.
 
+**Amended on #71: the gate asks whether staff worked the rows, not where the
+count sits.** Built first as "the record count has moved from what the parser
+read" — a tightening of the sentence above, on the reasoning that only a
+resolution can move it. Two faults, both found in use within a day:
+
+- **It swings shut behind an undo.** Dismiss a row, re-declare to the new
+  number, then put the row back: the count matches the parse again, the button
+  disappears, and the mismatch staff are now stuck on has no way out but
+  re-pasting the whole list. The milder daily version is the button reappearing
+  on every "put it back" except the last.
+- **It rewards dismissing a real student.** Staff who have read the rows and
+  concluded the list really is what the parser said cannot unlock the button
+  without moving the count — so the only route forward is to drop a child who
+  belongs there. A gate that makes the destructive action the unlocking one is
+  worse than the anchoring it was guarding against.
+
+So the log remembers a resolution that was taken back, rather than erasing it:
+the row returns to exactly where the parse put it, and the log still says it was
+worked on. Taking an edit back does not un-read the list. **Confirming a row
+still does not count** — that is agreeing with the parser about one row, which
+says nothing new about how many students there are.
+
 ### The preview table
 
 Three columns, one per state axis:

--- a/school-booking.html
+++ b/school-booking.html
@@ -340,9 +340,10 @@
              move the in-place re-declare refuses, one click further away.
              Editing the paste unlocks it, because that is a different list. -->
         <p x-show="countLocked()" x-cloak
-           class="text-xs text-neutral-500 mt-3 bg-neutral-100 border border-neutral-200 rounded-lg px-3 py-2 inline-block">
-          You have already answered this for this list. Edit the paste to answer it again — or,
-          if fixing the rows changed the number, say so on the next screen.
+           class="text-xs text-sky-900 mt-3 bg-sky-50 border border-sky-200 rounded-lg px-3 py-2 inline-block max-w-2xl">
+          <b>You have already answered this for this list.</b>
+          Edit the paste to answer it again — or, if sorting out the rows changed the number,
+          say so on the next screen.
         </p>
         <p x-show="countUnknown" x-cloak
            class="text-xs text-amber-700 mt-3 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 inline-block">
@@ -370,6 +371,9 @@
                  :class="countTone()">
               <div class="font-semibold" x-text="countLine()"></div>
               <div class="text-xs mt-1 opacity-90" x-text="reconciliationLine()"></div>
+              <div class="text-xs mt-0.5 opacity-90 font-medium" x-show="reviewed.ready" x-cloak>
+                Every line is accounted for.
+              </div>
             </div>
 
             <!-- The verdict, in plain English, with the override behind it. -->
@@ -485,11 +489,6 @@
                 </div>
               </div>
             </template>
-            </div>
-
-            <div x-show="reviewed.ready" x-cloak
-                 class="rounded-xl bg-emerald-50 border border-emerald-200 text-emerald-800 px-3.5 py-2.5 text-sm mb-2">
-              Every line is accounted for.
             </div>
 
             <!-- ── The rows ─────────────────────────────────────────────── -->

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -105,9 +105,16 @@ export function countDeclaration({ value, unknown } = {}) {
 // ---------------------------------------------------------------------------
 
 /**
- * Record — or clear — one resolution. Returns a new log; the original is left
- * alone, because Alpine re-renders from the returned value and a mutated
+ * Record — or take back — one resolution. Returns a new log; the original is
+ * left alone, because Alpine re-renders from the returned value and a mutated
  * original would make an undo unobservable.
+ *
+ * **Taking one back leaves a `reverted` entry rather than erasing the key.**
+ * The row goes back to exactly where the parse put it — nothing downstream
+ * treats `reverted` as a resolution — but the log still says the row was
+ * worked on, and that is what the re-declare gate is a question about. Erasing
+ * the key erases the evidence, and the gate then swings shut behind staff who
+ * undo their own edit; see canRedeclare().
  *
  * @param {object} resolutions  the current log
  * @param {number|string} key   a row's first source line, or `list:<kind>`
@@ -116,8 +123,14 @@ export function countDeclaration({ value, unknown } = {}) {
  */
 export function resolve(resolutions, key, action) {
   const next = { ...(resolutions ?? {}) };
-  if (action === null || action === undefined) delete next[key];
-  else next[key] = action;
+  if (action === null || action === undefined) {
+    const previous = next[key];
+    // Nothing to take back means nothing to remember.
+    if (!previous) delete next[key];
+    else next[key] = { kind: 'reverted', was: previous.was ?? previous.kind };
+  } else {
+    next[key] = action;
+  }
   return next;
 }
 
@@ -154,6 +167,21 @@ const noteFor = (flags, needs, fallback) => {
 };
 
 const nameOf = (row) => [row.firstName, row.lastName].filter(Boolean).join(' ').trim();
+
+// The resolution actually in force on a row. `reverted` is a record of what
+// staff did, not a state the row is in.
+const inForce = (entry) => (!entry || entry.kind === 'reverted' ? null : entry.kind);
+
+// Did staff work the rows themselves? The question the re-declare gate asks,
+// answered over the whole log rather than over the current counts — including
+// entries since taken back, because taking an edit back does not un-read the
+// list. Confirming is left out on purpose: it is agreeing with the parser
+// about a row, which tells nobody anything new about how many students there
+// are. Acknowledging a list-level question is not about a row at all.
+const EDIT_KINDS = ['accept', 'dismiss'];
+const rowsWorked = (log) =>
+  Object.entries(log).some(([key, entry]) =>
+    !String(key).startsWith('list:') && EDIT_KINDS.includes(entry.was ?? entry.kind));
 
 // A record built out of a line staff accepted as a student. It is deliberately
 // the same shape as one parse.js emits, down to `compare` — the identity read
@@ -316,7 +344,7 @@ export function review(parsed, { declaration, resolutions } = {}) {
       needs: record.needs.map((need) => ({ ...need })),
       note: record.state === 'clean' ? '' : noteFor(record.flags, record.needs),
       needsHuman: record.state !== 'clean',
-      resolution: log[record.lineNumbers[0]]?.kind ?? null,
+      resolution: inForce(log[record.lineNumbers[0]]),
     })),
     ...errors.map((error) => ({
       key: error.lineNumbers[0],
@@ -331,7 +359,7 @@ export function review(parsed, { declaration, resolutions } = {}) {
       needs: [],
       note: REASON_NOTES[error.reason] ?? REASON_NOTES.unparseable,
       needsHuman: true,
-      resolution: log[error.lineNumbers[0]]?.kind ?? null,
+      resolution: inForce(log[error.lineNumbers[0]]),
     })),
   ].sort((a, b) => a.key - b.key);
 
@@ -370,9 +398,9 @@ export function review(parsed, { declaration, resolutions } = {}) {
         + 'look like this. Fix the rows, or say the count has changed.',
       lineNumbers: [],
       // The escape hatch, offered only when the gate survives it — see
-      // countMoved() below. Carried as data so the markup cannot offer it
+      // canRedeclare() below. Carried as data so the markup cannot offer it
       // ungated by forgetting a condition.
-      actions: countMoved(counts.records, parsed.counts.records)
+      actions: rowsWorked(log)
         ? [{
           key: 'redeclare',
           label: `The count has changed \u2014 make it ${counts.records}`,
@@ -443,9 +471,9 @@ export function review(parsed, { declaration, resolutions } = {}) {
     blockers,
     ready: !blockers.some((b) => b.severity === 'block'),
     declared: gate,
-    // What the parser read before anybody touched it. The re-declare gate is
-    // the only thing that needs it, and it needs it for a reason: see below.
+    // What the parser read before anybody touched it, and whether anybody has.
     recordsParsed: parsed.counts.records,
+    rowsWorked: rowsWorked(log),
   };
 }
 
@@ -525,23 +553,31 @@ const acknowledgement = (kind) => ({
  * Whether the count mismatch may offer a re-declare.
  *
  * Accepting an unreadable line as a student legitimately moves the count, so
- * the mismatch has to be re-answerable — but **only once staff have moved it
- * themselves.** Ungated, that button is a one-click dismissal of the gate P5
- * exists to enforce: staff who cannot make the numbers agree would agree with
- * the parser instead, which is the anchoring the gate's ordering was designed
- * to prevent. The gate must survive its own escape hatch.
+ * the mismatch has to be re-answerable — but **only once staff have edited
+ * rows themselves.** Ungated, that button is a one-click dismissal of the gate
+ * P5 exists to enforce: staff who cannot make the numbers agree would agree
+ * with the parser instead, which is the anchoring the gate's ordering was
+ * designed to prevent. The gate must survive its own escape hatch.
  *
- * The test is the sharpest one available: the record count has moved from what
- * the parser read, and only a resolution can have moved it. Confirming a row
- * does not qualify — nothing about the count changed — and neither does
- * dismissing an unreadable line, which moves a line between two buckets nobody
- * was ever asked to count.
+ * The question is whether staff **worked the rows**, not where the count
+ * currently sits. Two things go wrong when it is tied to the count instead,
+ * and both were found in use:
+ *
+ *   - **It swings shut behind an undo.** Dismiss a row, re-declare to the new
+ *     number, then realise the dismissal was wrong and put the row back: the
+ *     count matches the parse again, the button disappears, and the mismatch
+ *     staff are now stuck on has no way out but re-pasting the whole list.
+ *   - **It rewards dismissing a real student.** Staff who have read the rows
+ *     and concluded the list really is what the parser said cannot unlock the
+ *     button without moving the count — so the only route forward is to drop
+ *     a child who belongs there.
+ *
+ * Confirming a row is still not an edit: it is agreeing with the parser about
+ * one row, which says nothing new about how many students there are.
  */
 export function canRedeclare(reviewed) {
-  return Boolean(reviewed) && countMoved(reviewed.counts.records, reviewed.recordsParsed);
+  return Boolean(reviewed) && reviewed.rowsWorked === true;
 }
-
-const countMoved = (records, recordsParsed) => records !== recordsParsed;
 
 // ---------------------------------------------------------------------------
 // The lines step 3 puts on screen

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -165,7 +165,7 @@ describe('step 3 — reading the list', () => {
     app.reviewed.blockers.find((b) => b.kind === 'count-mismatch')
       ?.actions.find((a) => a.answers === 'redeclare');
 
-  test('a mismatch blocks, and offers no re-declare until staff move it', async () => {
+  test('a mismatch blocks, and offers no re-declare until staff work the rows', async () => {
     const app = await upToStepThree(component(), { count: '21' });
     expect(app.reviewed.ready).toBe(false);
     // The gate is carried on the blocker rather than tested in the markup, so
@@ -179,6 +179,37 @@ describe('step 3 — reading the list', () => {
     app.answerBlocker(redeclareAction(app));
     expect(app.countValue).toBe('5');
     expect(app.reviewed.ready).toBe(true);
+  });
+
+  test('putting the row back does not strand staff behind the gate', async () => {
+    // Reported in use: the button reappears on every "put it back" except the
+    // last, because the last one returns the count to what the parser read.
+    // The worse version is the same rule one step on — re-declare, then undo,
+    // and the mismatch has no way out but re-pasting the list.
+    const app = await upToStepThree(component(), { count: '21' });
+    app.dismissRow(2);
+    app.dismissRow(3);
+    expect(redeclareAction(app)).toBeDefined();
+
+    app.undoRow(3);
+    expect(redeclareAction(app)).toBeDefined();
+    app.undoRow(2); // the last one back — the count now matches the parse again
+    expect(app.reviewed.counts.records).toBe(6);
+    expect(redeclareAction(app).label).toContain('6');
+  });
+
+  test('a fresh read locks the gate again', async () => {
+    // The log is what remembers the edits, and a new read starts a new one.
+    const app = await upToStepThree(component(), { count: '21' });
+    app.dismissRow(2);
+    expect(redeclareAction(app)).toBeDefined();
+
+    app.go(1);
+    app.rawPaste = SPREADSHEET.replace('Katie', 'Katherine');
+    app.pasteChanged();
+    app.countValue = '21';
+    app.readList();
+    expect(redeclareAction(app)).toBeUndefined();
   });
 
   test('the Back button does not walk around the count gate', async () => {

--- a/school-booking/test/steps.test.js
+++ b/school-booking/test/steps.test.js
@@ -305,12 +305,52 @@ describe('the re-declare escape hatch, and the gate surviving it', () => {
     expect(canRedeclare(r)).toBe(true);
   });
 
-  test('dismissing a student unlocks it too — the number moved either way', () => {
+  test('dismissing a student unlocks it too', () => {
     const r = reviewOf(SPREADSHEET, declared(6), resolve({}, 2, { kind: 'dismiss' }));
     expect(canRedeclare(r)).toBe(true);
   });
 
-  test('confirming a row does not unlock it — nothing about the count changed', () => {
+  test('putting the last row back keeps it unlocked — the rows were still read', () => {
+    // The gate is "staff have edited rows themselves", not "the count is
+    // currently different from what the parser read". Tying it to the current
+    // count dead-ends: re-declare to 5, realise the dismissal was wrong, put
+    // the row back, and the count matches the parse again — so the button
+    // vanishes and the only way out of the mismatch is re-pasting the list.
+    const dismissed = resolve({}, 2, { kind: 'dismiss' });
+    const restored = resolve(dismissed, 2, null);
+    const r = reviewOf(SPREADSHEET, declared(21), restored);
+    expect(r.counts.records).toBe(6); // back to what the parser read
+    expect(canRedeclare(r)).toBe(true);
+  });
+
+  test('the dead end it was built to escape', () => {
+    // The whole sequence, as one test: declare wrong, dismiss, re-declare to
+    // the new number, then undo the dismissal. Staff must not be stranded.
+    const dismissed = resolve({}, 2, { kind: 'dismiss' });
+    const afterRedeclare = reviewOf(SPREADSHEET, declared(5), dismissed);
+    expect(afterRedeclare.ready).toBe(true);
+
+    const undone = reviewOf(SPREADSHEET, declared(5), resolve(dismissed, 2, null));
+    expect(undone.blockers.some((b) => b.kind === 'count-mismatch')).toBe(true);
+    expect(canRedeclare(undone)).toBe(true);
+  });
+
+  test('dismissing an unreadable line unlocks it as well', () => {
+    // Gating on a *moved count* pushes staff who have decided the list really
+    // is what the parser read toward dismissing a real student to unlock the
+    // button. Sorting out an unreadable line is reading the rows, which is
+    // what the gate is there to make them do.
+    const withStray = [
+      ['First name', 'Surname', 'DOB'].join('\t'),
+      ['Katie', 'Fernsby', '23/4/2010'].join('\t'),
+      'and Otto if there is room',
+    ].join('\n');
+    const r = reviewOf(withStray, declared(9), resolve({}, 3, { kind: 'dismiss' }));
+    expect(r.counts.records).toBe(1);
+    expect(canRedeclare(r)).toBe(true);
+  });
+
+  test('confirming a row does not unlock it — that is agreeing with the parser', () => {
     const headerless = [
       ['Katie Fernsby van Aalst', 'HARLOW', '23/4/2010'].join('\t'),
       ['Tomas Oakhill', 'HARLOW', '7/11/2010'].join('\t'),
@@ -326,13 +366,12 @@ describe('the re-declare escape hatch, and the gate surviving it', () => {
     expect(canRedeclare(confirmed)).toBe(false);
   });
 
-  test('dismissing an unreadable line does not unlock it either', () => {
-    // It moves a line from `errors` to `ignored`. Nobody was ever asked to
-    // count either bucket, so the declared number has no reason to move.
-    const dismissed = resolve({}, 3, { kind: 'dismiss' });
-    const r = reviewOf(WITH_STRAY_LINE, declared(1), dismissed);
-    expect(r.counts.records).toBe(1);
-    expect(canRedeclare(r)).toBe(false);
+  test('nothing but reading the list leaves it locked', () => {
+    // The first read, untouched: the gate has not done its job yet, and an
+    // ungated button here is the one-click agreement with the parser that P5's
+    // ordering exists to prevent.
+    expect(canRedeclare(reviewOf(WITH_STRAY_LINE, declared(1)))).toBe(false);
+    expect(canRedeclare(reviewOf(SPREADSHEET, declared(21)))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Follow-up to #103, from the first real use of the page. Three things reported; one of them was hiding a worse bug.

⚠️ **Merging deploys.** `main` is production.

## 1. The re-declare button came and went

**Reported:** dismissing a student offers "the count has changed — make it X", and putting rows back re-offers it every time *except the last one*.

**Cause:** the gate was `records !== recordsParsed` — "the count has moved from what the parser read". Put the last row back and the count equals the parse again, so the rule says nothing moved.

**The worse version, not yet hit:** dismiss a row → re-declare to 5 → realise the dismissal was wrong → put the row back. Now declared 5, read 6, mismatch blocks, and `6 === 6` so no button. **No way forward but re-pasting the whole list.**

**And a perverse incentive:** staff who read the rows and concluded the list really is what the parser said could only unlock the button by *moving* the count — so the one route forward was dismissing a child who belongs there. A gate that makes the destructive action the unlocking one is worse than the anchoring it guards against.

**Fix:** the gate asks what §9 always said it asked — *"only once staff have edited rows themselves."* `resolve()` now leaves a `reverted` entry instead of erasing the key: the row goes back to exactly where the parse put it, and the log still records that it was worked on. Taking an edit back does not un-read the list.

Confirming a row still doesn't count — that's agreeing with the parser about one row, which says nothing new about how many students there are. And an untouched first read is still locked, so this is not the ungated one-click button the design rejects.

§9 amended to record the reasoning, since it stated the old rule.

## 2. Two banners, one meaning, same colour

The emerald "Every line is accounted for" strip carried nothing the reconciliation sum directly above it wasn't already carrying, in the same green. Folded into the count banner as its third line.

## 3. The step 2 lock notice was grey and got missed

Grey reads as disabled chrome. It's information — the count has already been answered for this paste, and here's how to answer it again — so it now uses the same blue as the verdict banner, with the first clause bolded.

## Verification

```
cd school-booking && npx vitest run     # 183
npx vitest run                           # 2319 across the repo
```

Both green. Five tests added, including the reported sequence end to end (dismiss two, put both back, button still offered) and the dead end it was built to escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn