### PR TITLE
School booking page: steps 4-5 — event picker, preview table, permanence line (#72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,10 +113,14 @@ school-booking/events.js - what a SELECTION of sessions is: the same-name,
                           same-location pre-tick (no recurrence field exists,
                           so any automatic rule is a guess), the lead-time and
                           past-session hard-stops with D9's one-click removal,
-                          and the spaces warning that never blocks. It reads
-                          `lead` and `bookable` as the Worker annotated them
-                          and never re-derives either, so the picker's grey-out
-                          and the write chain's refusal cannot disagree.
+                          and the spaces warning that never blocks.
+                          sessionRefusal() is the ONE place deciding what is
+                          wrong with a session and how serious — the blocker
+                          list and the picker's row styling both ask it. Do not
+                          read the Worker's `bookable` for this: it folds "no
+                          room" in with "too close to the start", and only the
+                          second refuses a booking, so reading it alone paints
+                          a warnable session as a refused one.
                           The paste-an-id fallback resolves HERE, against the
                           window already on screen — GET /events/:id answers 404
                           for every id, real or invented (#97), so a message

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,19 +38,24 @@ cloudflare-clubworx/src/events.js - the event picker's read, the 24-hour lead
                           paste-an-id lookup. It ANNOTATES and never filters:
                           a session missing from the picker is invisible, where
                           one greyed out with its reason is a human decision.
-                          GET /events/:id is UNMEASURED (#97) — see the
-                          resolveEvent header before assuming the paste works.
+                          GET /events/:id is MEASURED and DEAD: it answers 404
+                          for every id, real or invented (#97). resolveEvent
+                          stays as an honest refusal; the page resolves a pasted
+                          id itself, out of the window it already holds (#72).
 cloudflare-clubworx/src/paging.js - walking a Clubworx list when the response
                           carries no total, no next-page link and no header. A
                           full page is unfinished, never an answer; what the
                           ceiling MEANS is the caller's to decide, because on
                           /plan it is a refusal and on /events it is a flag.
-cloudflare-clubworx/src/plans.js - name -> membership_plan_id, and the plan's
-                          membership_duration. #60 saw 50 of 57 plans come back
-                          with School Pass among the missing, so a full page is
-                          "truncated", never "no such plan"; a duplicate name is
-                          refused rather than guessed. The number 26 lives in
-                          Clubworx, not here (ADR 0005).
+cloudflare-clubworx/src/plans.js - name -> membership_plan_id, the plan's
+                          membership_duration, and `coverage_end` — the last day
+                          a pass granted today still covers. #60 saw 50 of 57
+                          plans come back with School Pass among the missing, so
+                          a full page is "truncated", never "no such plan"; a
+                          duplicate name is refused rather than guessed. The
+                          number 26 lives in Clubworx, not here (ADR 0005), and
+                          `coverage_end` is computed here rather than in the
+                          browser so the calendar arithmetic has one home.
 cloudflare-clubworx/src/schools.js - the distinct School marker tags, across
                           all three status views. Returns tags and counts, never
                           contacts. A tag missing here is a staff member typing
@@ -95,13 +100,36 @@ cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, an
                           what they found. Start with probes/README.md — it carries
                           the rules (no production data recorded, pace under
                           75 req/min) that any new probe has to follow.
-school-booking.html     - the school booking page, steps 1-3 (#71): school,
-                          paste + declare the count, then the parse result with
-                          inline row resolution. Variant A of §9, decided on
-                          #54. NOT in tools.json and unreachable from the hub
-                          until #46's last step — §17's order, because `main`
-                          is production. Steps 4-6 are #72 and #73; nothing on
-                          this page writes anything.
+school-booking.html     - the school booking page, steps 1-5 (#71, #72): school,
+                          paste + declare the count, the parse result with
+                          inline row resolution, the session picker, and the
+                          preview. Variant A of §9, decided on #54. NOT in
+                          tools.json and unreachable from the hub until #46's
+                          last step — §17's order, because `main` is production.
+                          Step 6 (Apply, the run engine, the result table) is
+                          #73; every route this page calls is a GET, and a
+                          component test asserts that.
+school-booking/events.js - what a SELECTION of sessions is: the same-name,
+                          same-location pre-tick (no recurrence field exists,
+                          so any automatic rule is a guess), the lead-time and
+                          past-session hard-stops with D9's one-click removal,
+                          and the spaces warning that never blocks. It reads
+                          `lead` and `bookable` as the Worker annotated them
+                          and never re-derives either, so the picker's grey-out
+                          and the write chain's refusal cannot disagree.
+                          The paste-an-id fallback resolves HERE, against the
+                          window already on screen — GET /events/:id answers 404
+                          for every id, real or invented (#97), so a message
+                          built on it would tell staff a correct id is wrong.
+school-booking/preview.js - step 5: the STUDENT/DOB/READ/CLUBWORX/OUTCOME table,
+                          the match resolution log, the per-row consequence and
+                          the aggregate permanence line, plus every hard-stop
+                          that keeps Apply dark. It says only what it knows: the
+                          membership is read at Apply (D14) and there is no
+                          bookings read, so a matched row says "pass checked at
+                          Apply" rather than "pass already active". An absent
+                          answer is `pending`, never `new` — `new` writes a
+                          contact Clubworx cannot delete.
 school-booking/parse.js - turns a pasted school student list into rows plus the
                           list-level inferences (layout, column mapping, date
                           orientation). Pure and unit tested; §7 of the design
@@ -122,7 +150,13 @@ school-booking/test/alpine-bindings.test.js - reads school-booking.html and
                           without calling it (#78). A text check, because the
                           fault is a property of the text: it is not a logic
                           fault, so a unit test cannot see it, and it throws
-                          nothing, so runtime does not report it.
+                          nothing, so runtime does not report it. It also walks
+                          the page's whole ?v= import chain — every module, and
+                          every sibling import inside them, at one version. The
+                          walk replaced a hand-written list in #72, after
+                          identity.js joined the chain carrying an unversioned
+                          `./parse.js` that had been harmless only while no page
+                          imported it.
 school-booking/identity.js - the matching rule: surname + DOB narrows, first name
                           breaks ties, variance is surfaced never merged. §5 of
                           the design spec. Imports the two name forms from

--- a/cloudflare-clubworx/src/plans.js
+++ b/cloudflare-clubworx/src/plans.js
@@ -46,7 +46,7 @@
  * needed no code change at all.
  */
 
-import { parsePlanDuration } from './duration.js';
+import { parsePlanDuration, passCoverageEnd, perthDay } from './duration.js';
 import { PAGE_SIZE, pageThrough } from './paging.js';
 
 /**
@@ -121,11 +121,17 @@ const failure = ({ reason, message, upstreamStatus = null, requests, matches = 0
  * @param {{get: (path: string, params: object) => Promise<object>}} opts.client
  *   A `createClubworxClient` instance. Everything it sends is paced.
  * @param {string} opts.name The plan name, as the page asked for it.
+ * @param {string} [opts.today] The run day, `YYYY-MM-DD`, for `coverage_end`.
+ *   Defaults to the Perth day — everything this system does is in Perth, and a
+ *   pass counted from the UTC day is one day out for the eight hours a day the
+ *   two disagree. That is exactly the size of the edge this check exists for.
+ * @param {Date} [opts.now] The instant the run day is read from, when `today`
+ *   is not given. Injected so the answer is not clock-dependent in tests.
  * @returns {Promise<{ok: true, plan: object, plans: number, pages: number, requests: number}
  *                 | {ok: false, reason: string, message: string|null, upstreamStatus: number|null,
  *                    matches: number, plan: null, requests: number}>}
  */
-export async function lookupPlan({ client, name }) {
+export async function lookupPlan({ client, name, today = null, now = new Date() }) {
   const wanted = String(name ?? '').trim();
   if (!wanted) {
     return failure({
@@ -194,6 +200,8 @@ export async function lookupPlan({ client, name }) {
   }
 
   const rawDuration = found.plan.membership_duration ?? null;
+  const duration = parsePlanDuration(rawDuration);
+  const runDay = today ?? perthDay(now);
 
   return {
     ok: true,
@@ -209,7 +217,14 @@ export async function lookupPlan({ client, name }) {
       // Best-effort, and `ok: false` is a warning for the page, not a failure
       // here. A duration this cannot parse also cannot be guessed: a wrong
       // default is indistinguishable from a right one until a term is half over.
-      duration: parsePlanDuration(rawDuration),
+      duration,
+      // The last day a pass granted **today** still covers, so the page can
+      // hard-stop a run whose last selected session falls outside it (§11, ADR
+      // 0005) without re-deriving the calendar arithmetic in the browser. Null
+      // whenever it cannot be computed — `passCoverageEnd` returns null rather
+      // than a plausible date for exactly this reason, and the page turns the
+      // null into a named warning rather than a check quietly skipped.
+      coverage_end: passCoverageEnd(runDay, duration),
     },
     plans: rows.length,
     pages,

--- a/cloudflare-clubworx/test/plans.test.js
+++ b/cloudflare-clubworx/test/plans.test.js
@@ -230,3 +230,37 @@ describe('lookupPlan', () => {
     expect(result.requests).toBe(2);
   });
 });
+
+describe('lookupPlan — the coverage end (staff-site#72)', () => {
+  it('says when a pass granted today runs out, so the page never re-derives it', () => {
+    // The page has to hard-stop a run whose last session falls outside the
+    // pass (§11, ADR 0005), and the calendar arithmetic that answers that lives
+    // here, tested, beside `parsePlanDuration`. A second copy in the browser is
+    // the drift that decides a run is safe when it is not.
+    const client = clientWith({ 1: [plan()] });
+    return lookupPlan({ client, name: 'School Pass', today: '2026-08-21' }).then(result => {
+      // 26 weeks = 182 days, inclusive at both ends: 21 Aug + 181 days.
+      expect(result.plan.coverage_end).toBe('2027-02-18');
+    });
+  });
+
+  it('leaves the coverage end null when the duration will not parse', async () => {
+    // Never a plausible-looking date. Null is what makes the page warn out
+    // loud instead of checking a number nobody computed.
+    const client = clientWith({ 1: [plan({ membership_duration: 'one school term' })] });
+    const result = await lookupPlan({ client, name: 'School Pass', today: '2026-08-21' });
+
+    expect(result.plan.coverage_end).toBe(null);
+    expect(result.plan.duration.ok).toBe(false);
+  });
+
+  it('defaults the run day to the Perth day, not the UTC one', async () => {
+    // 23:30 UTC on the 21st is 07:30 on the 22nd in Perth. Counting a pass
+    // from the wrong day shortens or lengthens its coverage by one, which is
+    // exactly the size of the last-session edge case this check exists for.
+    const client = clientWith({ 1: [plan()] });
+    const result = await lookupPlan({ client, name: 'School Pass', now: new Date('2026-08-21T23:30:00Z') });
+
+    expect(result.plan.coverage_end).toBe('2027-02-19');
+  });
+});

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -712,6 +712,40 @@ name, or a window edge). The id is resolved and shown with its name, date and
 `spaces_available` for confirmation before it can be selected — it is a shortcut
 past the search, never past the confirmation.
 
+### The fallback resolves page-side — amended on #72
+
+#67 built the fallback on `GET /events/:id`. #97 then measured that route against
+production on 2026-08-21: it answers **404 for every id**, real or invented, with
+the date window and without it. A real currently-listed id and `999999999` come
+back identical, so nothing there reads the id at all.
+
+The Worker route survives only as an honest refusal — every call is a 502
+carrying Clubworx's own `"Not Found"` — and that message is the problem: it reads
+to a staff member as *this id does not exist* when the truth is *this endpoint
+does not exist*. A working id would look like a typo, and the person would go and
+"fix" something already correct.
+
+So **#72 resolves the pasted id in the page**, against the window the picker has
+already walked. `resolveEvent` is left in place, unreachable from the page, for
+the reason its own header gives: deleting it would decide a question #97 handed
+over rather than answering it.
+
+Two consequences, both accepted:
+
+- **The fallback cannot reach outside the loaded window.** It therefore says
+  *not in this window — widen the dates*, and **never** *no such event*. Those
+  are different problems with different fixes, and only one of them is knowable
+  here.
+- **It costs no request.** An id inside the window is already on screen, so the
+  lookup is a array scan rather than up to `MAX_PAGES` requests of a gym-wide
+  75-a-minute allowance — which is what the re-walking alternative would have
+  spent to find a row the page was already holding.
+
+What the paste still does not survive is Clubworx enforcing the `contact_key` its
+reference documents. That would take `/events` down as a whole, and the window
+this resolves against comes from the same endpoint. No page-side arrangement
+outlives its own API.
+
 ---
 
 ## 9. The page

--- a/school-booking.html
+++ b/school-booking.html
@@ -1,14 +1,20 @@
 <!--
-  School group booking — steps 1 to 3.
+  School group booking — steps 1 to 5.
 
-  staff-site#71, map #46. Design:
-  docs/superpowers/specs/2026-08-19-school-group-booking-design.md §7 and §9.
+  staff-site#71 and #72, map #46. Design:
+  docs/superpowers/specs/2026-08-19-school-group-booking-design.md §7, §8 and §9.
   Variant A, the gated stepper, decided on #54 against three built prototypes.
 
   NOT LINKED FROM tools.json. That is deliberate and is the last step of #46
   (§17): `main` is production here, so every step before the hub entry lands is
-  deployed but invisible to staff. Steps 4–6 — the session picker, the preview
-  and Apply — are #72 and #73, and nothing on this page can write anything.
+  deployed but invisible to staff. Step 6 — Apply, the run engine and the result
+  table — is #73, and nothing on this page can write anything: every route it
+  calls is a GET.
+
+  Steps 4 and 5 read Clubworx and nothing more. The Clubworx check between them
+  is strictly serial, one student at a time, because the 75-requests-a-minute
+  allowance is gym-wide and Clubworx publishes no rate-limit headers to throttle
+  from (§6).
 
   Two house rules this page is built around (§16):
 
@@ -55,10 +61,16 @@
      or missing module into a visible refusal rather than a page whose gates
      quietly do nothing. -->
 <script type="module">
-  import * as parser from './school-booking/parse.js?v=1';
-  import * as steps from './school-booking/steps.js?v=1';
+  import * as parser from './school-booking/parse.js?v=2';
+  import * as steps from './school-booking/steps.js?v=2';
+  import * as identity from './school-booking/identity.js?v=2';
+  import * as events from './school-booking/events.js?v=2';
+  import * as preview from './school-booking/preview.js?v=2';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
+  window.schoolBookingIdentity = identity;
+  window.schoolBookingEvents = events;
+  window.schoolBookingPreview = preview;
 </script>
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 
@@ -622,13 +634,284 @@
 
             <div class="flex justify-between mt-6">
               <button type="button" class="text-sm text-neutral-500 hover:text-neutral-800" @click="go(1)">← Back</button>
-              <!-- Step 4 is #72. Disabled rather than absent: the strip above
-                   shows six steps because six is the shape of the run, and a
-                   button that vanishes reads as "you are finished". -->
-              <button type="button" disabled title="The session picker is staff-site#72"
-                      class="rounded-xl px-5 py-2.5 text-sm font-semibold bg-neutral-100 text-neutral-400 cursor-not-allowed">
-                Choose sessions → (not built yet)
+              <button type="button" :disabled="!reviewed.ready"
+                      :class="reviewed.ready ? 'bg-uj text-white hover:bg-uj-dark' : 'bg-neutral-100 text-neutral-400 cursor-not-allowed'"
+                      class="rounded-xl px-5 py-2.5 text-sm font-semibold transition-all"
+                      @click="toSessions()">
+                Choose sessions →
               </button>
+            </div>
+          </div>
+        </template>
+      </section>
+
+      <!-- ── 4 · Sessions ────────────────────────────────────────────────── -->
+      <section x-show="stepIndex === 3">
+        <h2 class="text-lg font-bold mb-1">Which sessions?</h2>
+        <p class="text-sm text-neutral-500 mb-5 max-w-2xl">
+          Pick the <b>first</b> session. Every session with the same name at the same
+          location after it is ticked with it — Clubworx has no idea which classes
+          belong to a series, so that guess is yours to correct.
+        </p>
+
+        <!-- The window, and the search. Both are sent to the Worker: the date
+             window is required by Clubworx (omitting it is a 422, not
+             "everything"), and the name filter runs Worker-side over the walked
+             rows because no name parameter on /events has ever been measured. -->
+        <div class="flex items-end gap-3 flex-wrap mb-4">
+          <label class="block">
+            <span class="field-label">From</span>
+            <input type="date" x-model="eventsFrom"
+                   class="rounded-xl border border-neutral-200 px-3 py-2 text-sm mono">
+          </label>
+          <label class="block">
+            <span class="field-label">To</span>
+            <input type="date" x-model="eventsTo"
+                   class="rounded-xl border border-neutral-200 px-3 py-2 text-sm mono">
+          </label>
+          <label class="block flex-1 min-w-[200px]">
+            <span class="field-label">Session name contains</span>
+            <input type="text" x-model="eventsQuery" placeholder="e.g. the school's name"
+                   @keydown.enter.prevent="loadEvents()"
+                   class="w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm">
+          </label>
+          <button type="button" class="rounded-xl px-4 py-2 text-sm font-semibold bg-uj text-white hover:bg-uj-dark"
+                  :disabled="eventsState === 'loading'"
+                  @click="loadEvents()"
+                  x-text="eventsState === 'loading' ? 'Reading…' : 'Search'"></button>
+        </div>
+
+        <div class="text-xs text-neutral-500 mb-3" x-text="eventsNote()"></div>
+
+        <!-- The paste-an-id escape hatch. It resolves against the window
+             already loaded, NOT against Clubworx: GET /events/:id answers 404
+             for every id, real or invented (#97), so the Worker cannot tell a
+             good id from a bad one and neither can a message built on it. -->
+        <div class="rounded-xl bg-neutral-50 border border-neutral-200 px-3.5 py-2.5 mb-4">
+          <div class="flex items-end gap-2 flex-wrap">
+            <label class="block flex-1 min-w-[200px]">
+              <span class="field-label">Or paste a Clubworx event id</span>
+              <input type="text" x-model="pastedEventId" placeholder="event id"
+                     @keydown.enter.prevent="usePastedId()"
+                     class="w-full rounded-lg border border-neutral-200 px-3 py-1.5 text-sm mono">
+            </label>
+            <button type="button" class="rounded-lg px-3 py-1.5 text-sm font-semibold border border-neutral-300 hover:bg-white"
+                    @click="usePastedId()">Find it</button>
+          </div>
+          <div class="text-xs mt-2" :class="pastedIdTone()" x-show="pastedIdNote" x-cloak x-text="pastedIdNote"></div>
+        </div>
+
+        <!-- Every event in the window, including the ones that cannot be
+             booked. §8 annotates and never filters: a session missing from the
+             picker is invisible and unexplained, where one greyed out with its
+             reason beside it is a decision a human can make. -->
+        <div class="rounded-card border border-neutral-200 overflow-hidden bg-white" x-show="events.length > 0" x-cloak>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead class="bg-neutral-50 border-b border-neutral-200">
+                <tr class="text-left text-[0.68rem] uppercase tracking-wider text-neutral-500">
+                  <th class="px-3 py-2 w-10"></th>
+                  <th class="px-3 py-2">Session</th>
+                  <th class="px-3 py-2">Starts</th>
+                  <th class="px-3 py-2">Spaces</th>
+                  <th class="px-3 py-2">Series</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-for="event in events" :key="event.event_id">
+                  <tr class="border-b border-neutral-100 last:border-0 lane"
+                      :class="eventLane(event)">
+                    <td class="px-3 py-2">
+                      <input type="checkbox" :checked="isPicked(event.event_id)"
+                             :aria-label="'Book into ' + (event.event_name || 'this session')"
+                             @change="togglePick(event.event_id)">
+                    </td>
+                    <td class="px-3 py-2">
+                      <div x-text="event.event_name || '(unnamed session)'"></div>
+                      <div class="text-[0.7rem] text-neutral-500" x-text="event.location_name || ''"></div>
+                      <div class="text-[0.7rem] text-rose-700" x-show="!event.bookable" x-cloak
+                           x-text="eventWarning(event)"></div>
+                    </td>
+                    <td class="px-3 py-2 mono text-[0.75rem]" x-text="eventWhen(event)"></td>
+                    <td class="px-3 py-2 mono text-[0.75rem]"
+                        x-text="event.spaces_available === null ? '—' : event.spaces_available"></td>
+                    <td class="px-3 py-2">
+                      <button type="button" class="text-[0.72rem] text-uj underline underline-offset-2"
+                              @click="pickSeries(event.event_id)">
+                        Pick this first
+                      </button>
+                    </td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="rounded-xl px-3.5 py-2.5 text-sm mt-4"
+             :class="selection.ready ? 'bg-emerald-50 border border-emerald-200 text-emerald-800' : 'bg-neutral-50 border border-neutral-200 text-neutral-600'">
+          <span x-text="sessionsLine()"></span>
+        </div>
+
+        <div class="space-y-2 mt-3">
+          <template x-for="blocker in selection.blockers" :key="blocker.key">
+            <div class="rounded-xl px-3.5 py-2.5 text-sm"
+                 :class="blocker.severity === 'block' ? 'bg-rose-50 border border-rose-200 text-rose-800' : 'bg-amber-50 border border-amber-200 text-amber-900'">
+              <div class="font-semibold" x-text="blocker.title"></div>
+              <div class="text-xs mt-1 opacity-90" x-text="blocker.detail"></div>
+              <div class="flex gap-2 mt-2" x-show="blocker.actions.length > 0" x-cloak>
+                <template x-for="action in blocker.actions" :key="action.key">
+                  <button type="button" class="chip" @click="answerSelection(action)" x-text="action.label"></button>
+                </template>
+              </div>
+            </div>
+          </template>
+        </div>
+
+        <div class="flex justify-between mt-6">
+          <button type="button" class="text-sm text-neutral-500 hover:text-neutral-800" @click="go(2)">← Back</button>
+          <button type="button" :disabled="!selection.ready || checkState === 'running'"
+                  :class="selection.ready && checkState !== 'running' ? 'bg-uj text-white hover:bg-uj-dark' : 'bg-neutral-100 text-neutral-400 cursor-not-allowed'"
+                  class="rounded-xl px-5 py-2.5 text-sm font-semibold transition-all"
+                  @click="toPreview()"
+                  x-text="checkState === 'running' ? 'Checking…' : 'Check Clubworx →'"></button>
+        </div>
+      </section>
+
+      <!-- ── 5 · Preview ─────────────────────────────────────────────────── -->
+      <section x-show="stepIndex === 4">
+        <h2 class="text-lg font-bold mb-1">What will happen</h2>
+        <p class="text-sm text-neutral-500 mb-5 max-w-2xl">
+          Two of the three records below cannot be taken back. Read the sentence, then
+          the columns: <b>READ</b> is what the paste said, <b>CLUBWORX</b> is what
+          Clubworx already holds.
+        </p>
+
+        <!-- The check is serial and a class of 25 takes minutes, so the count
+             says which student it is on. It lives here rather than on step 4's
+             button because the page has already moved: answers are published
+             per student, so a check that stalls on 19 shows eighteen rows. -->
+        <div class="rounded-xl bg-sky-50 border border-sky-200 text-sky-900 px-3.5 py-2.5 text-sm mb-3"
+             x-show="checkState === 'running'" x-cloak>
+          <span x-text="checkProgress"></span>
+          One student at a time — the Clubworx allowance is shared with the whole gym.
+        </div>
+
+        <template x-if="preview">
+          <div>
+            <!-- The run's whole consequence, once. It is the same sentence the
+                 result table will show in past tense (D11) — one place to read
+                 what this run did, in both directions. -->
+            <div class="rounded-xl px-3.5 py-3 text-sm mb-3 bg-amber-50 border border-amber-300 text-amber-900"
+                 x-show="permanenceLine()" x-cloak>
+              <div class="font-semibold" x-text="permanenceLine()"></div>
+            </div>
+
+            <div class="space-y-2 mb-3">
+              <template x-for="blocker in preview.blockers" :key="blocker.key">
+                <div class="rounded-xl px-3.5 py-2.5 text-sm"
+                     :class="blocker.severity === 'block' ? 'bg-rose-50 border border-rose-200 text-rose-800' : 'bg-amber-50 border border-amber-200 text-amber-900'">
+                  <div class="font-semibold" x-text="blocker.title"></div>
+                  <div class="text-xs mt-1 opacity-90" x-text="blocker.detail"></div>
+                  <div class="flex gap-2 mt-2" x-show="blocker.actions.length > 0" x-cloak>
+                    <template x-for="action in blocker.actions" :key="action.key">
+                      <button type="button" class="chip" @click="answerSelection(action)" x-text="action.label"></button>
+                    </template>
+                  </div>
+                </div>
+              </template>
+            </div>
+
+            <div class="rounded-card border border-neutral-200 overflow-hidden bg-white">
+              <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead class="bg-neutral-50 border-b border-neutral-200">
+                  <tr class="text-left text-[0.68rem] uppercase tracking-wider text-neutral-500">
+                    <th class="px-4 py-2">Student</th>
+                    <th class="px-4 py-2">DOB</th>
+                    <th class="px-4 py-2">Read</th>
+                    <th class="px-4 py-2">Clubworx</th>
+                    <th class="px-4 py-2">Outcome</th>
+                  </tr>
+                </thead>
+                <template x-for="line in preview.rows" :key="line.key">
+                  <tbody>
+                      <tr class="border-b border-neutral-100 row-hit lane"
+                          :class="line.needsHuman ? 'lane-need' : 'lane-ok'"
+                          @click="togglePreviewRow(line.key)">
+                        <td class="px-4 py-2">
+                          <span class="mono text-[0.66rem] text-neutral-400 mr-1"
+                                x-text="expandedPreview === line.key ? '▾' : '▸'"></span>
+                          <span x-text="line.name"></span>
+                        </td>
+                        <td class="px-4 py-2 mono text-[0.75rem]" x-text="line.dob || '—'"></td>
+                        <td class="px-4 py-2">
+                          <span class="px-1.5 py-0.5 rounded text-[0.68rem] font-medium"
+                                :class="line.read === 'clean' ? 'text-emerald-700 bg-emerald-50' : 'text-amber-700 bg-amber-50'"
+                                x-text="line.read"></span>
+                        </td>
+                        <td class="px-4 py-2">
+                          <span class="px-1.5 py-0.5 rounded text-[0.68rem] font-medium"
+                                :class="clubworxTone(line)" x-text="line.clubworx || '—'"></span>
+                        </td>
+                        <td class="px-4 py-2 text-[0.8rem]"
+                            :class="line.outcome === 'blocked' ? 'text-rose-700 font-medium' : 'text-neutral-600'"
+                            x-text="line.outcome"></td>
+                      </tr>
+
+                      <!-- The per-row consequence, and the resolution controls,
+                           in the row itself. A single-column stepper has nowhere
+                           to put a detail panel and a modal would be a gate
+                           inside a gate, so the row expands in place (§9). -->
+                      <tr x-show="expandedPreview === line.key" x-cloak class="border-b border-neutral-100 bg-neutral-50/60">
+                        <td colspan="5" class="px-4 py-3">
+                          <div class="text-[0.78rem] text-neutral-600 mb-2">
+                            └ <span x-text="consequenceLine(line)"></span>
+                          </div>
+
+                          <div class="text-[0.78rem] text-amber-800 mb-2" x-show="line.note" x-cloak x-text="line.note"></div>
+
+                          <div x-show="line.candidates.length > 0" x-cloak>
+                            <span class="field-label">Clubworx already holds</span>
+                            <div class="space-y-1.5">
+                              <template x-for="candidate in line.candidates" :key="candidate.contact_key">
+                                <div class="flex items-center gap-2 flex-wrap text-[0.78rem]">
+                                  <span x-text="(candidate.first_name || '?') + ' ' + (candidate.last_name || '')"></span>
+                                  <span class="mono text-[0.7rem] text-neutral-500" x-text="candidate.dob || 'no birthday'"></span>
+                                  <span class="text-[0.68rem] text-neutral-400" x-text="candidate.status_view"></span>
+                                  <button type="button" class="chip"
+                                          :class="line.contactKey === candidate.contact_key ? 'border-solid border-uj text-uj' : ''"
+                                          @click="useContact(line.key, candidate.contact_key)">
+                                    This is them
+                                  </button>
+                                </div>
+                              </template>
+                            </div>
+                            <div class="flex gap-2 mt-2">
+                              <button type="button" class="chip" @click="createAnyway(line.key)">
+                                None of these — create a new contact (permanent)
+                              </button>
+                              <button type="button" class="chip" x-show="line.resolution" x-cloak
+                                      @click="undoMatch(line.key)">Undo</button>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                  </tbody>
+                </template>
+              </table>
+              </div>
+            </div>
+
+            <div class="flex justify-between mt-6">
+              <button type="button" class="text-sm text-neutral-500 hover:text-neutral-800" @click="go(3)">← Back</button>
+              <!-- Apply is staff-site#73. Gated here anyway: the gates are the
+                   deliverable of this step, and a button wired to nothing is
+                   safer than a button wired to half a write chain. -->
+              <button type="button" disabled
+                      :title="preview.ready ? 'Every gate is clear. The run engine is staff-site#73' : 'Something above is still blocking'"
+                      class="rounded-xl px-5 py-2.5 text-sm font-semibold bg-neutral-100 text-neutral-400 cursor-not-allowed"
+                      x-text="preview.ready ? 'Apply (not built yet)' : 'Apply — blocked'"></button>
             </div>
           </div>
         </template>
@@ -639,7 +922,7 @@
 
   <footer class="max-w-[1100px] mx-auto w-full px-4 pb-8 text-xs text-neutral-500">
     <div class="border-t border-neutral-200 pt-4 flex flex-wrap items-center justify-between gap-x-5 gap-y-1">
-      <span>Nothing on this page writes anything. Steps 4–6 are staff-site#72 and #73.</span>
+      <span>Nothing on this page writes anything. Apply and the result table are staff-site#73.</span>
     </div>
   </footer>
 
@@ -657,8 +940,8 @@ function schoolBooking() {
       { key: 'school',   label: 'School',   built: true },
       { key: 'paste',    label: 'Paste',    built: true },
       { key: 'rows',     label: 'Rows',     built: true },
-      { key: 'sessions', label: 'Sessions', built: false },
-      { key: 'preview',  label: 'Preview',  built: false },
+      { key: 'sessions', label: 'Sessions', built: true },
+      { key: 'preview',  label: 'Preview',  built: true },
       { key: 'result',   label: 'Result',   built: false },
     ],
     stepIndex: 0,
@@ -697,6 +980,39 @@ function schoolBooking() {
     showOverrides: false,
     chipMenu: null,
 
+    // Step 4
+    events: [],
+    eventsState: 'idle',
+    eventsError: '',
+    eventsTotal: 0,
+    eventsTruncated: false,
+    eventsFrom: '',
+    eventsTo: '',
+    eventsQuery: '',
+    pastedEventId: '',
+    pastedIdNote: '',
+    pastedIdOk: false,
+    picked: [],
+    // Never null. The markup reads `selection.blockers` and `selection.ready`
+    // on every render of step 4, including the first, and an Alpine expression
+    // that throws leaves its `:disabled` unapplied — which would *enable* the
+    // forward button on the one render where nothing has been checked.
+    selection: { events: [], blockers: [], ready: false, sessions: 0, students: 0, bookings: 0, firstSession: null, lastSession: null },
+
+    // The check between 4 and 5
+    // The plan name, not its id: an id is a number nobody can check against the
+    // Clubworx UI and is silently wrong the day the plan is rebuilt (plans.js).
+    planName: 'School Pass',
+    plan: null,
+    matches: {},
+    checkState: 'idle',
+    checkProgress: '',
+
+    // Step 5
+    preview: null,
+    decisions: {},
+    expandedPreview: null,
+
     init() {
       // Both modules or neither. Every gate on this page is one of their
       // exports, so a partial load is a page that looks like it is checking
@@ -704,6 +1020,9 @@ function schoolBooking() {
       const missing = [];
       if (!window.schoolListParser?.parseStudentList) missing.push('the list parser');
       if (!window.schoolBookingSteps?.review) missing.push('the step rules');
+      if (!window.schoolBookingIdentity?.matchStudent) missing.push('the matching rule');
+      if (!window.schoolBookingEvents?.selectionReport) missing.push('the session rules');
+      if (!window.schoolBookingPreview?.buildPreview) missing.push('the preview rules');
       if (missing.length) {
         this.bootstrapError = `Could not load ${missing.join(' and ')}.`;
         return;
@@ -1098,6 +1417,268 @@ function schoolBooking() {
       if (row.bucket === 'error') return 'text-rose-700 bg-rose-50';
       if (row.needsHuman) return 'text-amber-700 bg-amber-50';
       return 'text-emerald-700 bg-emerald-50';
+    },
+
+
+    // --- step 4 ----------------------------------------------------------
+    // The picker's window is a request parameter, not a filter: Clubworx
+    // refuses `/events` with no date window (422, empty body — #51), so there
+    // is no "everything" to fall back to and the page always has to name one.
+    async loadEvents() {
+      this.eventsState = 'loading';
+      this.pastedIdNote = '';
+      const params = new URLSearchParams({ from: this.eventsFrom, to: this.eventsTo });
+      if (this.eventsQuery.trim()) params.set('q', this.eventsQuery.trim());
+      try {
+        const res = await fetch(`/api/clubworx/events?${params}`, { headers: { accept: 'application/json' } });
+        const body = await res.json();
+        if (!res.ok || !body.ok) throw new Error(body.error || `HTTP ${res.status}`);
+        this.events = body.events ?? [];
+        this.eventsTotal = body.total ?? this.events.length;
+        this.eventsTruncated = body.truncated === true;
+        this.eventsState = 'ready';
+        // A tick pointing at a session this window no longer holds is a tick
+        // nobody can see. Dropped rather than carried: `selectionReport` would
+        // drop it anyway, and a count that disagrees with the table is how a
+        // group ends up booked into a session nobody chose.
+        const present = new Set(this.events.map((e) => String(e.event_id)));
+        this.picked = this.picked.filter((id) => present.has(String(id)));
+      } catch (error) {
+        this.events = [];
+        this.eventsTotal = 0;
+        this.eventsTruncated = false;
+        this.eventsState = 'error';
+        this.eventsError = String(error.message || error);
+      }
+      this.refreshSelection();
+    },
+
+    eventsNote() {
+      if (this.eventsState === 'loading') return 'Reading the timetable…';
+      if (this.eventsState === 'error') return `Could not read the sessions: ${this.eventsError}`;
+      if (this.eventsState === 'idle') return 'Pick a date window and search.';
+      if (this.events.length === 0) return 'No sessions in this window.';
+      const shown = this.eventsQuery.trim()
+        ? `${this.events.length} of ${this.eventsTotal} sessions match "${this.eventsQuery.trim()}"`
+        : `${this.events.length} sessions`;
+      return this.eventsTruncated
+        ? `${shown} — the window holds more than could be read. Narrow the dates.`
+        : shown;
+    },
+
+    isPicked(id) {
+      return this.picked.includes(String(id));
+    },
+
+    togglePick(id) {
+      const key = String(id);
+      this.picked = this.isPicked(key) ? this.picked.filter((p) => p !== key) : [...this.picked, key];
+      this.refreshSelection();
+    },
+
+    // §8's one-click series. The rule is same name, same location, ahead of the
+    // anchor — the whole of what "the same weekly class" can mean, since no
+    // recurrence field exists. Replaces the selection rather than adding to it:
+    // "pick this first" is a statement about which session is first.
+    pickSeries(id) {
+      this.picked = window.schoolBookingEvents.preTicked(this.events, id);
+      this.refreshSelection();
+    },
+
+    usePastedId() {
+      const found = window.schoolBookingEvents.resolvePastedId(this.events, this.pastedEventId);
+      if (!found.ok) {
+        this.pastedIdNote = found.message;
+        this.pastedIdOk = false;
+        return;
+      }
+      // Resolved, then confirmed — never selected outright. The paste is a
+      // shortcut past the search, never past the confirmation (§8), so it ticks
+      // the session and names it, leaving the tick as the thing staff read.
+      this.pickSeries(found.event.event_id);
+      this.pastedIdOk = true;
+      this.pastedIdNote = `Found and ticked: ${window.schoolBookingEvents.sessionLabel(found.event)}.`;
+    },
+
+    pastedIdTone() {
+      return this.pastedIdOk ? 'text-emerald-700' : 'text-rose-700';
+    },
+
+    eventWhen(event) {
+      return String(event.event_start_at ?? '').replace('T', ' ').slice(0, 16);
+    },
+
+    eventLane(event) {
+      if (!event.bookable) return 'lane-bad';
+      return this.isPicked(event.event_id) ? 'lane-ok' : 'lane';
+    },
+
+    // Why a session is greyed, in the words that name the cause. Clubworx's own
+    // refusal — "Sorry! This class is now closed for bookings." — names none of
+    // them and reads like a capacity problem (D9).
+    eventWarning(event) {
+      const lead = event.lead ?? {};
+      if (lead.unreadable) return 'No readable start time.';
+      if (lead.past) return 'Already started.';
+      if (lead.withinLeadTime) return `Starts in under ${lead.minLeadHours ?? 24} hours — Clubworx would refuse it.`;
+      if (event.event_full === true || event.spaces_available === 0) return 'Reported full.';
+      return '';
+    },
+
+    refreshSelection() {
+      this.selection = window.schoolBookingEvents.selectionReport({
+        events: this.events,
+        selected: this.picked,
+        studentCount: this.reviewed?.counts.records ?? 0,
+        truncated: this.eventsTruncated,
+      });
+    },
+
+    sessionsLine() {
+      return window.schoolBookingEvents.sessionsLine(this.selection)
+        || 'No sessions picked yet.';
+    },
+
+    // The one-click removal D9 asks for. Removing is the only thing a blocker
+    // here can do, and the page dispatches on `answers` exactly as step 3 does,
+    // so a blocker kind added in the module cannot arrive without its control.
+    answerSelection(action) {
+      if (action.answers === 'remove') this.togglePick(action.value);
+    },
+
+    toSessions() {
+      if (!this.reviewed?.ready) return;
+      if (this.eventsState === 'idle') {
+        const window_ = window.schoolBookingEvents.defaultWindow();
+        this.eventsFrom = window_.from;
+        this.eventsTo = window_.to;
+        this.loadEvents();
+      }
+      this.refreshSelection();
+      this.go(3);
+    },
+
+    // --- the check between steps 4 and 5 ---------------------------------
+    // Strictly serial, one student at a time. The 75-a-minute allowance is
+    // gym-wide and Clubworx sends no rate-limit headers at all, so pacing is a
+    // design constant rather than something a client can read off a response
+    // (§6). Concurrency here would spend the whole gym's allowance at once.
+    async toPreview() {
+      if (!this.selection.ready || this.checkState === 'running') return;
+      this.checkState = 'running';
+      this.matches = {};
+      this.decisions = {};
+      // The previous run's answers are about a different selection, and this
+      // screen is one the operator reads to approve permanent writes. Cleared
+      // before the move, so nothing stale is on screen for even one render.
+      this.preview = null;
+      this.go(4);
+
+      this.plan = await this.lookupPlan();
+
+      const students = (this.reviewed?.rows ?? []).filter((r) => r.bucket === 'record' && !r.needsHuman);
+      const found = {};
+      for (let i = 0; i < students.length; i += 1) {
+        const row = students[i];
+        this.checkProgress = `Checking ${i + 1} of ${students.length}…`;
+        found[row.key] = await this.checkStudent(row);
+        // Published per student rather than at the end, so a check that stalls
+        // on student 19 shows eighteen answers instead of an empty table.
+        this.matches = { ...found };
+        this.refreshPreview();
+      }
+
+      this.checkState = 'done';
+      this.checkProgress = '';
+      this.refreshPreview();
+    },
+
+    async lookupPlan() {
+      try {
+        const res = await fetch(`/api/clubworx/plan?name=${encodeURIComponent(this.planName)}`,
+          { headers: { accept: 'application/json' } });
+        const body = await res.json();
+        if (!res.ok || !body.ok) {
+          return { ok: false, reason: body.reason ?? 'upstream-error', message: body.error ?? `HTTP ${res.status}` };
+        }
+        return body;
+      } catch (error) {
+        return { ok: false, reason: 'network', message: String(error.message || error) };
+      }
+    },
+
+    // One student's dedup read, turned into a match state by identity.js. A
+    // failure is carried on the row as an error rather than thrown: a run of
+    // 25 students must not lose the 24 answers that did come back, and a row
+    // with no answer must never read as `new` — `new` writes a contact
+    // Clubworx cannot delete.
+    async checkStudent(row) {
+      const params = new URLSearchParams({ last_name: row.lastName ?? '', dob: row.dob ?? '' });
+      try {
+        const res = await fetch(`/api/clubworx/contacts?${params}`, { headers: { accept: 'application/json' } });
+        const body = await res.json();
+        if (!res.ok) return { error: body.error || `Clubworx answered ${res.status}.` };
+        return window.schoolBookingIdentity.matchStudent(
+          { write: { firstName: row.firstName, lastName: row.lastName, dob: row.dob },
+            compare: { firstName: this.compareForm(row.firstName), lastName: this.compareForm(row.lastName) } },
+          body.candidates ?? [],
+          this.reviewed?.columns ?? null,
+        );
+      } catch (error) {
+        return { error: String(error.message || error) };
+      }
+    },
+
+    // The parser's own normalisation, asked rather than restated. A second
+    // table here is the drift that reports an existing student as `new` and
+    // writes them a second permanent contact, with nothing thrown.
+    compareForm(value) {
+      return window.schoolListParser.compareForm(value);
+    },
+
+    // --- step 5 ----------------------------------------------------------
+    refreshPreview() {
+      this.preview = window.schoolBookingPreview.buildPreview({
+        rows: this.reviewed?.rows ?? [],
+        matches: this.matches,
+        selection: this.selection,
+        plan: this.plan,
+        decisions: this.decisions,
+      });
+    },
+
+    togglePreviewRow(key) {
+      this.expandedPreview = this.expandedPreview === key ? null : key;
+    },
+
+    useContact(key, contactKey) {
+      this.decisions = window.schoolBookingPreview.resolveMatch(this.decisions, key, { kind: 'use', contactKey });
+      this.refreshPreview();
+    },
+
+    createAnyway(key) {
+      this.decisions = window.schoolBookingPreview.resolveMatch(this.decisions, key, { kind: 'create' });
+      this.refreshPreview();
+    },
+
+    undoMatch(key) {
+      this.decisions = window.schoolBookingPreview.resolveMatch(this.decisions, key, null);
+      this.refreshPreview();
+    },
+
+    permanenceLine() {
+      return window.schoolBookingPreview.permanenceLine(this.preview);
+    },
+
+    consequenceLine(line) {
+      return window.schoolBookingPreview.consequenceLine(line);
+    },
+
+    clubworxTone(line) {
+      if (line.clubworx === 'matched') return 'text-emerald-700 bg-emerald-50';
+      if (line.clubworx === 'new') return 'text-sky-700 bg-sky-50';
+      if (line.clubworx === '') return 'text-neutral-500 bg-neutral-100';
+      return 'text-amber-700 bg-amber-50';
     },
 
     go(index) {

--- a/school-booking.html
+++ b/school-booking.html
@@ -1576,6 +1576,19 @@ function schoolBooking() {
 
       this.plan = await this.lookupPlan();
 
+      // The plan first, and nothing else if it did not resolve. §11 hard-stops
+      // the *run* on an unresolved or ambiguous plan, and the dedup reads are
+      // three requests a student out of an allowance the whole gym shares —
+      // spent on answers nothing caches, for a run that cannot proceed, before
+      // an operator who has to go and fix a Clubworx plan either way. The
+      // preview is still built, so the refusal has a screen to be read on.
+      if (!this.plan.ok) {
+        this.checkState = 'done';
+        this.checkProgress = '';
+        this.refreshPreview();
+        return;
+      }
+
       const students = (this.reviewed?.rows ?? []).filter((r) => r.bucket === 'record' && !r.needsHuman);
       const found = {};
       for (let i = 0; i < students.length; i += 1) {

--- a/school-booking.html
+++ b/school-booking.html
@@ -699,6 +699,19 @@
                     @click="usePastedId()">Find it</button>
           </div>
           <div class="text-xs mt-2" :class="pastedIdTone()" x-show="pastedIdNote" x-cloak x-text="pastedIdNote"></div>
+
+          <!-- The confirmation. The picker rests on an undocumented Clubworx
+               behaviour, so a human agreeing this is the right class is the
+               safeguard — not the id resolving. -->
+          <div class="mt-2 rounded-lg bg-white border border-neutral-300 px-3 py-2"
+               x-show="pastedIdEvent" x-cloak>
+            <div class="text-[0.78rem] text-neutral-700" x-text="pastedIdConfirmLine()"></div>
+            <div class="flex gap-2 mt-2">
+              <button type="button" class="chip border-solid border-uj text-uj"
+                      @click="confirmPastedId()">Yes, use this session</button>
+              <button type="button" class="chip" @click="cancelPastedId()">Cancel</button>
+            </div>
+          </div>
         </div>
 
         <!-- Every event in the window, including the ones that cannot be
@@ -710,11 +723,11 @@
             <table class="w-full text-sm">
               <thead class="bg-neutral-50 border-b border-neutral-200">
                 <tr class="text-left text-[0.68rem] uppercase tracking-wider text-neutral-500">
-                  <th class="px-3 py-2 w-10"></th>
-                  <th class="px-3 py-2">Session</th>
-                  <th class="px-3 py-2">Starts</th>
-                  <th class="px-3 py-2">Spaces</th>
-                  <th class="px-3 py-2">Series</th>
+                  <th scope="col" class="px-3 py-2 w-10"><span class="sr-only">Book</span></th>
+                  <th scope="col" class="px-3 py-2">Session</th>
+                  <th scope="col" class="px-3 py-2">Starts</th>
+                  <th scope="col" class="px-3 py-2">Spaces</th>
+                  <th scope="col" class="px-3 py-2">Series</th>
                 </tr>
               </thead>
               <tbody>
@@ -729,7 +742,8 @@
                     <td class="px-3 py-2">
                       <div x-text="event.event_name || '(unnamed session)'"></div>
                       <div class="text-[0.7rem] text-neutral-500" x-text="event.location_name || ''"></div>
-                      <div class="text-[0.7rem] text-rose-700" x-show="!event.bookable" x-cloak
+                      <div class="text-[0.7rem]" :class="eventWarningTone(event)"
+                           x-show="eventWarning(event)" x-cloak
                            x-text="eventWarning(event)"></div>
                     </td>
                     <td class="px-3 py-2 mono text-[0.75rem]" x-text="eventWhen(event)"></td>
@@ -827,11 +841,11 @@
               <table class="w-full text-sm">
                 <thead class="bg-neutral-50 border-b border-neutral-200">
                   <tr class="text-left text-[0.68rem] uppercase tracking-wider text-neutral-500">
-                    <th class="px-4 py-2">Student</th>
-                    <th class="px-4 py-2">DOB</th>
-                    <th class="px-4 py-2">Read</th>
-                    <th class="px-4 py-2">Clubworx</th>
-                    <th class="px-4 py-2">Outcome</th>
+                    <th scope="col" class="px-4 py-2">Student</th>
+                    <th scope="col" class="px-4 py-2">DOB</th>
+                    <th scope="col" class="px-4 py-2">Read</th>
+                    <th scope="col" class="px-4 py-2">Clubworx</th>
+                    <th scope="col" class="px-4 py-2">Outcome</th>
                   </tr>
                 </thead>
                 <template x-for="line in preview.rows" :key="line.key">
@@ -992,6 +1006,9 @@ function schoolBooking() {
     pastedEventId: '',
     pastedIdNote: '',
     pastedIdOk: false,
+    // The resolved session, waiting to be confirmed. Never a selection on its
+    // own — see usePastedId.
+    pastedIdEvent: null,
     picked: [],
     // Never null. The markup reads `selection.blockers` and `selection.ready`
     // on every render of step 4, including the first, and an Alpine expression
@@ -1142,6 +1159,25 @@ function schoolBooking() {
         resolutions: this.resolutions,
       });
       this.syncDrafts();
+      // Any step-3 edit makes the preview a statement about a list that has
+      // changed underneath it — different rows, or the same rows with a gate
+      // reopened. Dropped rather than refreshed: the match states came from
+      // reads keyed on the *old* rows, so refreshing would keep answers about
+      // students who may no longer be on the list. The check is cheap to
+      // re-run and wrong to reuse.
+      this.discardPreview();
+    },
+
+    // The step strip lets staff jump to any step already reached, so this is
+    // also what stops a jump straight back to a preview whose list has moved.
+    // `x-if="preview"` renders nothing without it, and step 5's own forward
+    // button reads `preview.ready`.
+    discardPreview() {
+      if (!this.preview && Object.keys(this.matches).length === 0) return;
+      this.preview = null;
+      this.matches = {};
+      this.decisions = {};
+      this.checkState = 'idle';
     },
 
     // Edit buffers are seeded here, once per review, rather than lazily from
@@ -1485,19 +1521,54 @@ function schoolBooking() {
       this.refreshSelection();
     },
 
+    // Resolved, then confirmed — never selected outright. §8: the paste is a
+    // shortcut past the *search*, never past the *confirmation*. The picker is
+    // built on an undocumented behaviour that contradicts Clubworx's own
+    // reference, so a human agreeing this is the right class is the whole
+    // safeguard, and `spaces_available` travels because it is one of the three
+    // facts they agree on.
     usePastedId() {
       const found = window.schoolBookingEvents.resolvePastedId(this.events, this.pastedEventId);
+      this.pastedIdEvent = null;
       if (!found.ok) {
         this.pastedIdNote = found.message;
         this.pastedIdOk = false;
         return;
       }
-      // Resolved, then confirmed — never selected outright. The paste is a
-      // shortcut past the search, never past the confirmation (§8), so it ticks
-      // the session and names it, leaving the tick as the thing staff read.
-      this.pickSeries(found.event.event_id);
       this.pastedIdOk = true;
-      this.pastedIdNote = `Found and ticked: ${window.schoolBookingEvents.sessionLabel(found.event)}.`;
+      this.pastedIdNote = '';
+      this.pastedIdEvent = found.event;
+    },
+
+    // Name, date and spaces, in one sentence — plus what confirming costs.
+    // Confirming ticks the series from this session, which *replaces* whatever
+    // is ticked now, because pasting an id is the same statement as "pick this
+    // first". Discarding six already-ticked sessions in silence is what would
+    // make that surprising, so the count is named before the click.
+    pastedIdConfirmLine() {
+      const event = this.pastedIdEvent;
+      if (!event) return '';
+      const spaces = event.spaces_available === null
+        ? 'no space count'
+        : `${event.spaces_available} spaces`;
+      const line = `${window.schoolBookingEvents.sessionLabel(event)} — ${spaces}.`;
+      if (this.picked.length === 0) return line;
+      return `${line} Taking it will replace the ${this.picked.length} session`
+        + `${this.picked.length === 1 ? '' : 's'} already ticked.`;
+    },
+
+    confirmPastedId() {
+      const event = this.pastedIdEvent;
+      if (!event) return;
+      this.pickSeries(event.event_id);
+      this.pastedIdEvent = null;
+      this.pastedEventId = '';
+      this.pastedIdNote = `Ticked from the pasted id: ${window.schoolBookingEvents.sessionLabel(event)}.`;
+    },
+
+    cancelPastedId() {
+      this.pastedIdEvent = null;
+      this.pastedIdNote = '';
     },
 
     pastedIdTone() {
@@ -1508,21 +1579,29 @@ function schoolBooking() {
       return String(event.event_start_at ?? '').replace('T', ' ').slice(0, 16);
     },
 
+    // Both of these ask `sessionRefusal` rather than reading `bookable`. The
+    // Worker's flag folds "no room" in with "too close to the start", and only
+    // the second refuses a booking — so a row with an unknown space count was
+    // being painted the same red as a lead-time hard-stop, with no reason
+    // beside it, against §11's "warn, never block".
     eventLane(event) {
-      if (!event.bookable) return 'lane-bad';
+      const refusal = window.schoolBookingEvents.sessionRefusal(event);
+      if (refusal?.severity === 'block') return 'lane-bad';
+      if (refusal) return 'lane-need';
       return this.isPicked(event.event_id) ? 'lane-ok' : 'lane';
     },
 
-    // Why a session is greyed, in the words that name the cause. Clubworx's own
-    // refusal — "Sorry! This class is now closed for bookings." — names none of
-    // them and reads like a capacity problem (D9).
+    // Why a session is flagged, in the words that name the cause. Clubworx's
+    // own refusal — "Sorry! This class is now closed for bookings." — names
+    // none of them and reads like a capacity problem (D9).
     eventWarning(event) {
-      const lead = event.lead ?? {};
-      if (lead.unreadable) return 'No readable start time.';
-      if (lead.past) return 'Already started.';
-      if (lead.withinLeadTime) return `Starts in under ${lead.minLeadHours ?? 24} hours — Clubworx would refuse it.`;
-      if (event.event_full === true || event.spaces_available === 0) return 'Reported full.';
-      return '';
+      return window.schoolBookingEvents.sessionRefusal(event)?.message ?? '';
+    },
+
+    eventWarningTone(event) {
+      return window.schoolBookingEvents.sessionRefusal(event)?.severity === 'block'
+        ? 'text-rose-700'
+        : 'text-amber-700';
     },
 
     refreshSelection() {
@@ -1655,6 +1734,10 @@ function schoolBooking() {
         rows: this.reviewed?.rows ?? [],
         matches: this.matches,
         selection: this.selection,
+        // Step 3's gates travel too. §11 hard-stops on "any unresolved gate",
+        // and a gate visible only on the screen that raised it is not a gate on
+        // the screen that commits.
+        review: this.reviewed,
         plan: this.plan,
         decisions: this.decisions,
       });

--- a/school-booking/events.js
+++ b/school-booking/events.js
@@ -205,6 +205,71 @@ export function sessionLabel(event) {
   return day ? `${name}, ${day}` : name;
 }
 
+/**
+ * What is wrong with one session, and how serious.
+ *
+ * **The one place that decides this.** It lived in two before — the blocker
+ * list here and the page's own row styling — and the two disagreed: a session
+ * Clubworx reported full was painted red as refused while this report called it
+ * a warning, which is what §11 actually says. Two surfaces contradicting each
+ * other about whether a run can proceed is the fault shape §16 records, and the
+ * severity is the half that matters.
+ *
+ * The Worker's `bookable` is deliberately not the answer. It folds *no room in
+ * the class* in with *too close to the start*, and only the second of those
+ * refuses a booking: #50 measured `spaces_available` wrong in both directions,
+ * so §11 makes it "warn, never block". Reading `bookable` alone paints a
+ * warnable session as a refused one.
+ *
+ * @returns {{kind: string, severity: 'block'|'warn', message: string}|null}
+ *   null when there is nothing wrong with the session.
+ */
+export function sessionRefusal(event) {
+  const lead = event?.lead ?? {};
+
+  if (lead.unreadable === true) {
+    return {
+      kind: 'unreadable-session',
+      severity: 'block',
+      message: 'No readable start time, so the 24-hour rule cannot be checked against it.',
+    };
+  }
+
+  if (lead.past === true) {
+    return { kind: 'past-session', severity: 'block', message: 'Already started.' };
+  }
+
+  if (lead.withinLeadTime === true) {
+    return {
+      kind: 'lead-time',
+      severity: 'block',
+      // Named here rather than met as Clubworx's own refusal — D9. Its message,
+      // "Sorry! This class is now closed for bookings.", names no cause and
+      // reads like the class is full.
+      message: `Starts in under ${lead.minLeadHours ?? 24} hours, so Clubworx would refuse it.`,
+    };
+  }
+
+  // Ranked below the lead time on purpose: a session that is both too soon and
+  // full is refused for the reason that actually refuses it.
+  if (event?.event_full === true || event?.spaces_available === 0) {
+    return {
+      kind: 'full',
+      severity: 'warn',
+      message: 'Clubworx reports no spaces — a number that has been wrong in both directions.',
+    };
+  }
+
+  return null;
+}
+
+const REFUSAL_TITLES = {
+  'unreadable-session': 'A session has no readable start time',
+  'past-session': 'A session has already started',
+  'lead-time': 'A session starts too soon to book',
+  full: 'Clubworx reports no spaces on a session',
+};
+
 const removal = (event) => ({
   key: `remove:${event.event_id}`,
   label: 'Remove this session',
@@ -253,55 +318,27 @@ export function selectionReport({ events, selected, studentCount = 0, truncated 
   }
 
   for (const event of picked) {
-    const lead = event.lead ?? {};
-
-    if (lead.unreadable === true) {
+    // Asked, never re-decided — see sessionRefusal. A blocker is only offered a
+    // removal when it is a `block`: D9's one-click fix answers a session that
+    // refuses the run, and offering it beside a warning turns "worth a look"
+    // into "click here to make this go away".
+    const refusal = sessionRefusal(event);
+    if (refusal) {
       blockers.push({
-        key: `unreadable:${event.event_id}`,
-        kind: 'unreadable-session',
-        severity: 'block',
-        title: 'A session has no readable start time',
-        detail: `${sessionLabel(event)} came back without a start time this page can read, so `
-          + 'the 24-hour rule cannot be checked against it.',
-        actions: [removal(event)],
+        key: `${refusal.kind}:${event.event_id}`,
+        kind: refusal.kind,
+        severity: refusal.severity,
+        title: REFUSAL_TITLES[refusal.kind],
+        detail: `${sessionLabel(event)} — ${refusal.message}`,
+        actions: refusal.severity === 'block' ? [removal(event)] : [],
       });
-      continue;
     }
 
-    if (lead.past === true) {
-      blockers.push({
-        key: `past:${event.event_id}`,
-        kind: 'past-session',
-        severity: 'block',
-        title: 'A session has already started',
-        detail: `${sessionLabel(event)} has already begun.`,
-        actions: [removal(event)],
-      });
-      continue;
-    }
-
-    if (lead.withinLeadTime === true) {
-      blockers.push({
-        key: `lead:${event.event_id}`,
-        kind: 'lead-time',
-        severity: 'block',
-        title: 'A session starts too soon to book',
-        // Named here rather than met as Clubworx's own refusal — D9. Its
-        // message, "Sorry! This class is now closed for bookings.", names no
-        // cause and reads like the class is full.
-        detail: `${sessionLabel(event)} starts in under ${lead.minLeadHours ?? 24} hours. `
-          + 'Clubworx closes a class to bookings before it starts, so this one would be refused.',
-        actions: [removal(event)],
-      });
-      continue;
-    }
-
-    // Warn, never block: #50 measured this number wrong in both directions, in
-    // a way that has nothing to do with the room in the class. A null is not a
-    // zero — it is Clubworx declining to say, passed through untouched by the
-    // Worker for exactly this reason.
+    // Room is a second question from "is it full", and both are warnings.
+    // A null is not a zero — it is Clubworx declining to say, passed through
+    // untouched by the Worker for exactly this reason.
     const spaces = event.spaces_available;
-    if (typeof spaces === 'number' && studentCount > 0 && spaces < studentCount) {
+    if (refusal?.kind !== 'full' && typeof spaces === 'number' && studentCount > 0 && spaces < studentCount) {
       blockers.push({
         key: `spaces:${event.event_id}`,
         kind: 'spaces',

--- a/school-booking/events.js
+++ b/school-booking/events.js
@@ -1,0 +1,349 @@
+// school-booking/events.js
+//
+// Step 4 — what a *selection of sessions* is, as a pure module. The page
+// imports this and publishes it as `window.schoolBookingEvents`, the same seam
+// parse.js and steps.js already use.
+//
+// staff-site#72. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+// §8 (event selection) and §11 (the hard-stops).
+//
+// ---------------------------------------------------------------------------
+// The division of labour with the Worker
+// ---------------------------------------------------------------------------
+// `cloudflare-clubworx/src/events.js` decides what an **event** is: it walks the
+// date window to exhaustion, annotates each row with its lead time and answers
+// a `bookable` verdict. It deliberately does not filter — §8 — because a
+// session missing from a picker is invisible and unexplained.
+//
+// This module decides what a **selection** is: which sessions arrive pre-ticked,
+// what a pasted id resolves to, and what stops the run. Nothing here re-derives
+// a lead time; `lead` and `bookable` are read as given, so the picker's grey-out
+// and the write chain's refusal can never disagree.
+//
+// ---------------------------------------------------------------------------
+// The pasted id is resolved here, and that is a change of plan
+// ---------------------------------------------------------------------------
+// §8 asks for an event-ID fallback and #67 built one on `GET /events/:id`. #97
+// then measured that route against production: it answers **404 for every id**,
+// real or invented, with or without a date window. The Worker route survives
+// only as an honest refusal — every call is a 502 carrying Clubworx's own
+// `"Not Found"`, which reads to staff as *this id does not exist* when the truth
+// is *this endpoint does not exist*. Putting that in front of the front desk
+// would make a working id look like a typo.
+//
+// So the fallback resolves **page-side**, against the window the picker has
+// already walked — the option `cloudflare-clubworx/src/events.js` hands to #54
+// at the end of its `resolveEvent` header, and the cheaper one either way: an id
+// inside the window is already on screen, and re-walking to find it would spend
+// up to ten requests of a gym-wide 75-a-minute allowance on a lookup that costs
+// nothing here.
+//
+// What it therefore cannot do is find an event **outside** the window. That is
+// why `resolvePastedId` says *not in this window* and never *not found*: the two
+// are different problems with different fixes — widen the window, or check the
+// id — and the second sends staff to correct something that is already correct.
+
+// The picker's opening window. A term, near enough: the tool is used to book a
+// school's term of sessions, and a window this wide holds one comfortably while
+// staying far short of `MAX_PAGES` in the Worker.
+const WINDOW_DAYS = 90;
+
+// Everything this system does is in Perth, so the run day is the Perth day.
+// Same constant and the same reasoning as `cloudflare-clubworx/src/duration.js`;
+// this file cannot import that one — it runs in the browser, and that module
+// ships with the Worker.
+const AWST_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+const plural = (n, noun) => `${n} ${noun}${n === 1 ? '' : 's'}`;
+
+/** Timetable order. Clubworx timestamps are ISO with an offset, so they sort as strings. */
+const byStart = (a, b) => String(a.event_start_at).localeCompare(String(b.event_start_at));
+
+/** The calendar day an instant falls on **in Perth**, or null if it cannot be read. */
+function perthDay(instant) {
+  const at = new Date(instant);
+  if (Number.isNaN(at.getTime())) return null;
+  return new Date(at.getTime() + AWST_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+/**
+ * The date window the picker opens with: today in Perth, and a term ahead.
+ *
+ * The Perth day rather than the UTC one is load-bearing for eight hours of every
+ * day. Between midnight and 08:00 AWST the UTC date is still yesterday, so a
+ * window opened on it starts a day early — harmless — while an *end* computed
+ * from it stops a day early, and a window opened on the UTC day by a page whose
+ * events are all stamped +08:00 leaves this morning's sessions out of the list
+ * at exactly the hour someone is setting up a morning school group.
+ *
+ * @param {string|Date} [now] The instant of the run. Injected so the picker's
+ *   window is testable without a clock.
+ * @returns {{from: string, to: string}} `YYYY-MM-DD` days, or two empty strings
+ *   when the instant could not be read — the Worker refuses a window that is not
+ *   two real days (#51), and inventing one here would send it a window nobody
+ *   chose.
+ */
+export function defaultWindow(now = new Date()) {
+  const from = perthDay(now);
+  if (!from) return { from: '', to: '' };
+
+  const end = new Date(`${from}T00:00:00Z`);
+  end.setUTCDate(end.getUTCDate() + WINDOW_DAYS);
+  return { from, to: end.toISOString().slice(0, 10) };
+}
+
+/**
+ * Two events are the same series when their names and locations match.
+ *
+ * There is **no series or recurrence field in the API** (§8), so this is the
+ * whole of what "the same weekly class" can mean here. Names are compared on
+ * their trimmed, case-folded form because a school's sessions are created by
+ * hand, one a week, and `School Session — Newman` acquires a stray space or a
+ * lower-case s somewhere in a term.
+ *
+ * A nameless event matches nothing but itself. Two events with no name are not
+ * evidence of a series — they are two rows nobody filled in — and grouping them
+ * would pre-tick an unrelated class on the strength of a missing field.
+ */
+const seriesKey = (event) => {
+  const name = String(event?.event_name ?? '').trim().toLowerCase();
+  if (!name) return null;
+  return `${name}@@${event?.location_id ?? ''}`;
+};
+
+/**
+ * The sessions that arrive ticked when staff pick one.
+ *
+ * §8: staff pick the **first** session, and same-name, same-location events
+ * **ahead of it** arrive pre-ticked and correctable. Ahead of it, not around it:
+ * ticking the sessions behind the anchor would book a group into classes that
+ * have already run, and the anchor is the first session precisely so that the
+ * rest of the term follows from one click.
+ *
+ * An unbookable session ahead of the anchor is still ticked. It is part of the
+ * series, and §8 annotates rather than filters — a too-soon session arriving
+ * unticked looks like a session that is not in the series at all, where a ticked
+ * one carries its own reason and D9's one-click removal.
+ *
+ * @param {Array<object>} events The window, as the Worker projected it.
+ * @param {string|number|null} anchorId The session staff clicked.
+ * @returns {Array<string>} Event ids, in timetable order, the anchor included.
+ */
+export function preTicked(events, anchorId) {
+  const list = Array.isArray(events) ? events : [];
+  const wanted = anchorId === null || anchorId === undefined ? '' : String(anchorId);
+  const anchor = list.find((e) => String(e?.event_id) === wanted);
+  if (!anchor) return [];
+
+  const key = seriesKey(anchor);
+  if (key === null) return [String(anchor.event_id)];
+
+  return list
+    .filter((e) => seriesKey(e) === key && String(e.event_start_at) >= String(anchor.event_start_at))
+    .sort(byStart)
+    .map((e) => String(e.event_id));
+}
+
+/**
+ * Resolve a pasted Clubworx event id against the window already on screen.
+ *
+ * See the header for why this is page-side. The three failures are told apart
+ * because they send staff to three different places: an empty box, a picker that
+ * has not loaded, and an id the window does not reach.
+ *
+ * @param {Array<object>} events The loaded window.
+ * @param {string} pasted The id exactly as it was pasted.
+ */
+export function resolvePastedId(events, pasted) {
+  const wanted = String(pasted ?? '').trim();
+  if (!wanted) {
+    return { ok: false, reason: 'no-id', message: 'Paste a Clubworx event id first.', event: null };
+  }
+
+  const list = Array.isArray(events) ? events : [];
+  if (list.length === 0) {
+    return {
+      ok: false,
+      reason: 'no-events',
+      message: 'No sessions have been loaded yet, so there is nothing to look the id up in.',
+      event: null,
+    };
+  }
+
+  const hit = list.find((e) => String(e?.event_id) === wanted);
+  if (hit) return { ok: true, reason: 'resolved', message: '', event: hit };
+
+  return {
+    ok: false,
+    reason: 'not-in-window',
+    // Never "no such event". #97 measured that Clubworx answers 404 for a real
+    // id and an invented one alike, so nothing here can tell them apart — and
+    // the wrong half of that guess sends staff to re-check an id that is fine.
+    message: `That id is not in the dates currently loaded. Widen the window and search again.`,
+    event: null,
+  };
+}
+
+/**
+ * The selected events, in timetable order.
+ *
+ * A selected id with no event behind it is dropped rather than carried as a
+ * placeholder: it can only come from a window that has been reloaded under a
+ * tick, and a run must never be counted against a session nobody can name.
+ */
+export function selectedEvents(events, selected) {
+  const wanted = new Set((Array.isArray(selected) ? selected : []).map(String));
+  return (Array.isArray(events) ? events : [])
+    .filter((e) => wanted.has(String(e?.event_id)))
+    .sort(byStart);
+}
+
+/** A session, in the words that identify it on screen: name, day, time. */
+export function sessionLabel(event) {
+  const name = String(event?.event_name ?? '').trim() || 'Unnamed session';
+  const day = perthDay(event?.event_start_at);
+  return day ? `${name}, ${day}` : name;
+}
+
+const removal = (event) => ({
+  key: `remove:${event.event_id}`,
+  label: 'Remove this session',
+  answers: 'remove',
+  value: String(event.event_id),
+});
+
+/**
+ * Everything step 4 blocks on, and the two numbers step 5 needs from it.
+ *
+ * Each too-soon session gets **its own** blocker with its own removal, rather
+ * than one blocker listing them. D9 makes removing a session a decision staff
+ * take one at a time; a single "remove them all" is the silent adjustment with
+ * a button on it.
+ *
+ * @param {object} opts
+ * @param {Array<object>} opts.events The loaded window.
+ * @param {Array<string>} opts.selected Ticked event ids.
+ * @param {number} opts.studentCount Students the run would book.
+ * @param {boolean} [opts.truncated] Whether the Worker said it could not read the window to the end.
+ */
+export function selectionReport({ events, selected, studentCount = 0, truncated = false } = {}) {
+  const picked = selectedEvents(events, selected);
+  const blockers = [];
+
+  if (picked.length === 0) {
+    blockers.push({
+      key: 'no-events',
+      kind: 'no-events',
+      severity: 'block',
+      title: 'No sessions picked',
+      detail: 'Pick the first session of the series. The rest of the term is ticked with it.',
+      actions: [],
+    });
+  }
+
+  if (studentCount === 0) {
+    blockers.push({
+      key: 'no-students',
+      kind: 'no-students',
+      severity: 'block',
+      title: 'No students to book',
+      detail: 'Nothing came out of the paste as a student, so there is nobody to put in a session.',
+      actions: [],
+    });
+  }
+
+  for (const event of picked) {
+    const lead = event.lead ?? {};
+
+    if (lead.unreadable === true) {
+      blockers.push({
+        key: `unreadable:${event.event_id}`,
+        kind: 'unreadable-session',
+        severity: 'block',
+        title: 'A session has no readable start time',
+        detail: `${sessionLabel(event)} came back without a start time this page can read, so `
+          + 'the 24-hour rule cannot be checked against it.',
+        actions: [removal(event)],
+      });
+      continue;
+    }
+
+    if (lead.past === true) {
+      blockers.push({
+        key: `past:${event.event_id}`,
+        kind: 'past-session',
+        severity: 'block',
+        title: 'A session has already started',
+        detail: `${sessionLabel(event)} has already begun.`,
+        actions: [removal(event)],
+      });
+      continue;
+    }
+
+    if (lead.withinLeadTime === true) {
+      blockers.push({
+        key: `lead:${event.event_id}`,
+        kind: 'lead-time',
+        severity: 'block',
+        title: 'A session starts too soon to book',
+        // Named here rather than met as Clubworx's own refusal — D9. Its
+        // message, "Sorry! This class is now closed for bookings.", names no
+        // cause and reads like the class is full.
+        detail: `${sessionLabel(event)} starts in under ${lead.minLeadHours ?? 24} hours. `
+          + 'Clubworx closes a class to bookings before it starts, so this one would be refused.',
+        actions: [removal(event)],
+      });
+      continue;
+    }
+
+    // Warn, never block: #50 measured this number wrong in both directions, in
+    // a way that has nothing to do with the room in the class. A null is not a
+    // zero — it is Clubworx declining to say, passed through untouched by the
+    // Worker for exactly this reason.
+    const spaces = event.spaces_available;
+    if (typeof spaces === 'number' && studentCount > 0 && spaces < studentCount) {
+      blockers.push({
+        key: `spaces:${event.event_id}`,
+        kind: 'spaces',
+        severity: 'warn',
+        title: 'A session may not have room',
+        detail: `${sessionLabel(event)} reports ${plural(spaces, 'space')} for ${plural(studentCount, 'student')}. `
+          + 'That number has been wrong in both directions, so it is worth a look and not worth obeying.',
+        actions: [],
+      });
+    }
+  }
+
+  if (truncated) {
+    blockers.push({
+      key: 'truncated',
+      kind: 'truncated',
+      severity: 'warn',
+      title: 'The session list was cut short',
+      detail: 'The date window holds more sessions than could be read. Narrow the dates if the '
+        + 'session you want is missing.',
+      actions: [],
+    });
+  }
+
+  const days = picked.map((e) => perthDay(e.event_start_at)).filter(Boolean).sort();
+
+  return {
+    events: picked,
+    blockers,
+    ready: !blockers.some((b) => b.severity === 'block'),
+    sessions: picked.length,
+    students: studentCount,
+    bookings: picked.length * studentCount,
+    firstSession: days[0] ?? null,
+    // What the pass has to cover (§10 D4, ADR 0005) — the **last** selected
+    // session, not today.
+    lastSession: days[days.length - 1] ?? null,
+  };
+}
+
+/** The multiplication, on screen, because it is the number that surprises people. */
+export function sessionsLine({ sessions = 0, students = 0, bookings = 0 } = {}) {
+  if (sessions === 0) return '';
+  return `${plural(sessions, 'session')} × ${plural(students, 'student')} = ${plural(bookings, 'booking')}.`;
+}

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -24,7 +24,7 @@
 // already has a contact comes back as `new`, and a second permanent contact is
 // written for them. Nothing throws: both spellings are individually valid, and
 // contacts cannot be deleted.
-import { compareForm } from './parse.js';
+import { compareForm } from './parse.js?v=2';
 
 // ---------------------------------------------------------------------------
 // Match states (P2b)

--- a/school-booking/preview.js
+++ b/school-booking/preview.js
@@ -252,10 +252,11 @@ export function permanenceLine(preview) {
  * @param {Array<object>} opts.rows step 3's rows, in step 3's order
  * @param {object} opts.matches `matchStudent` results (or `{error}`) keyed by row key
  * @param {object} opts.selection a `selectionReport`
+ * @param {object} [opts.review] step 3's own `review()`, for its gates — see below
  * @param {object|null} opts.plan the `/plan` response body
  * @param {object} opts.decisions the match resolution log
  */
-export function buildPreview({ rows, matches, selection, plan, decisions } = {}) {
+export function buildPreview({ rows, matches, selection, review, plan, decisions } = {}) {
   const log = decisions ?? {};
   const found = matches ?? {};
   const picked = selection ?? { events: [], blockers: [], sessions: 0 };
@@ -282,10 +283,15 @@ export function buildPreview({ rows, matches, selection, plan, decisions } = {})
     bookings: runnable.length * sessions,
   };
 
-  // Step 4's blockers come first and unchanged. Apply reads one list, so a
-  // session inside the lead time and an unresolved name variant stop the run
-  // the same way and in the same place.
-  const blockers = [...(picked.blockers ?? [])];
+  // Steps 3 and 4's blockers come first and unchanged. Apply reads **one**
+  // list: §11 hard-stops on "any unresolved gate", and a gate that is only
+  // visible on the screen that raised it is not a gate on the screen that
+  // commits. It also closes the step 5 → 3 → 5 walk, where reopening the count
+  // gate would otherwise leave a preview still saying it was ready.
+  //
+  // Carried verbatim, actions included, so a control that clears a gate on
+  // step 3 clears it from here too rather than being a dead label.
+  const blockers = [...(review?.blockers ?? []), ...(picked.blockers ?? [])];
 
   blockers.push(...planBlockers(plan, picked.lastSession));
 

--- a/school-booking/preview.js
+++ b/school-booking/preview.js
@@ -1,0 +1,408 @@
+// school-booking/preview.js
+//
+// Step 5 — the preview table, the permanence line, and the hard-stops that keep
+// Apply dark. A pure module over what steps 3 and 4 produced plus the Clubworx
+// check between them; the page publishes it as `window.schoolBookingPreview`.
+//
+// staff-site#72. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+// §9 (the preview table, where the per-row consequence lives), §11 (the
+// refusals), §12 (irreversibility).
+//
+// ---------------------------------------------------------------------------
+// Three columns, because there are three state axes
+// ---------------------------------------------------------------------------
+// `READ` is the parse state and `CLUBWORX` the match state — P2b's separation
+// made **structural** rather than folded into the student cell as a pill.
+// Reading *down* a column is how you spot that every row is `clean` but three
+// are `new`, which is the scan this screen exists for.
+//
+// ---------------------------------------------------------------------------
+// What this screen does NOT know, and says so
+// ---------------------------------------------------------------------------
+// §9's sketch of the expanded row reads *"create nothing · pass already active ·
+// 4 bookings (2 already booked)"*. Two thirds of that sentence is not knowable
+// here, and the module says the knowable part instead:
+//
+//   - **The pass.** D4 reads the membership only for matched contacts, and D14
+//     re-reads it **at Apply, immediately before its own write**, because
+//     preview reads go stale and the membership is the one write with no
+//     server-side idempotency. §6's route table has no read-only membership
+//     route at all. So a matched row says *pass checked at Apply* — the true
+//     statement — rather than *pass already active*, which nothing checked.
+//   - **Already-booked bookings.** Booking idempotency is Clubworx refusing the
+//     duplicate at write time (D5); there is no bookings read on the Worker.
+//     The count of bookings a student would be *offered* is known; how many of
+//     them already exist is not, until §12's result table says it in past tense.
+//
+// The alternative — showing the sentence §9 sketches and filling it from
+// nothing — is the failure mode #50 is the cautionary tale for: a
+// truthful-sounding line pointed at entirely the wrong mechanism.
+//
+// The permanence line above the table carries the same honesty: new students
+// are counted exactly, and returning students are named as a pass that has not
+// been settled rather than folded into the total either way.
+
+const plural = (n, noun) => `${n} ${noun}${n === 1 ? '' : 's'}`;
+// "School Pass" does not take a bare -s, and it is the noun this line is most
+// about. Spelled here rather than patched after the fact.
+const passes = (n) => `${n} School ${n === 1 ? 'Pass' : 'Passes'}`;
+
+// Why a row cannot run, in the words staff would use. Every state
+// `matchStudent` can return that is not `new` or `matched` has a line here: a
+// row that blocks the run without saying why is a row that gets resolved the
+// quickest way rather than the right way.
+const MATCH_NOTES = {
+  'no-dob': 'No date of birth, so this student cannot be told apart from anyone else with '
+    + 'their surname. Go back and fix the row.',
+  'no-surname': 'No surname, so there is no identity to search on. Go back and fix the row.',
+  'first-name-differs': 'A contact matches the surname and birthday but not the first name. '
+    + 'Katie and Katherine are the same child; two children are not.',
+  'duplicate-contacts': 'Clubworx holds more than one contact with this name and birthday. '
+    + 'Contacts cannot be deleted, so which one gets the pass is not a guess this page makes.',
+  'no-first-name-match': 'Two contacts share this surname and birthday and neither first name '
+    + 'matches — siblings, probably twins. Pick the right child or create a new contact.',
+  'candidate-dob-unknown': 'A contact with this exact name has no birthday recorded, so it '
+    + 'cannot be confirmed or ruled out. Creating a new one risks a permanent duplicate.',
+};
+
+const PREFERRED_NAME_NOTE = ' The school listed a preferred name column, so a first-name '
+  + 'mismatch here is what a correct match looks like.';
+
+/** The states a row can be resolved out of. `unmatchable` is not one of them — see below. */
+const RESOLVABLE = new Set(['name-variant', 'ambiguous']);
+
+/**
+ * Record — or take back — one match decision.
+ *
+ * A simpler log than step 3's: there is no gate here asking *did staff work the
+ * rows*, so a decision taken back leaves nothing behind. Returns a new object,
+ * because Alpine re-renders from the returned value and a mutated original
+ * would make an undo unobservable.
+ *
+ * @param {object} decisions the current log, keyed by row key
+ * @param {number|string} key the row's key, as step 3 assigned it
+ * @param {{kind: 'use', contactKey: string}|{kind: 'create'}|null} action
+ */
+export function resolveMatch(decisions, key, action) {
+  const next = { ...(decisions ?? {}) };
+  if (action === null || action === undefined) delete next[key];
+  else next[key] = action;
+  return next;
+}
+
+/** The decision in force on a row, or null. */
+export function matchDecision(decisions, key) {
+  return (decisions ?? {})[key] ?? null;
+}
+
+/**
+ * Apply a decision to a match result.
+ *
+ * A `use` naming a contact the current candidate list does not hold is
+ * **ignored**. The check re-runs whenever staff go back and forth, and a
+ * decision that outlived its candidates would attach a permanent pass to a
+ * contact key nothing on screen ever showed.
+ *
+ * `unmatchable` is deliberately not resolvable. It means the identity key
+ * itself is missing — no date of birth, or no surname — so there is nothing to
+ * decide *between*: choosing a contact would be choosing on a birthday alone,
+ * and creating one writes a permanent record that then poisons the surname +
+ * DOB key for every later term. The fix is back on step 3, on the row.
+ */
+function decided(result, decision) {
+  if (!decision || !RESOLVABLE.has(result.state)) return { result, applied: null };
+
+  if (decision.kind === 'create') {
+    return { result: { ...result, state: 'new', contact: null }, applied: 'create' };
+  }
+
+  if (decision.kind === 'use') {
+    const hit = (result.candidates ?? []).find((c) => String(c?.contact_key) === String(decision.contactKey));
+    if (!hit) return { result, applied: null };
+    return { result: { ...result, state: 'matched', contact: hit }, applied: 'use' };
+  }
+
+  return { result, applied: null };
+}
+
+/**
+ * One preview row: the three state cells, the outcome, and everything the
+ * expanded row needs.
+ */
+function previewRow(source, rawMatch, decision, sessions) {
+  const name = [source.firstName, source.lastName].filter(Boolean).join(' ').trim();
+  const base = {
+    key: source.key,
+    lineNumbers: [...(source.lineNumbers ?? [])],
+    name: name || '(no name)',
+    dob: source.dob ?? null,
+    read: source.state,
+    sessions,
+    candidates: [],
+    contactKey: null,
+    resolution: null,
+    firstNameIsPreferred: false,
+  };
+
+  // A row step 3 has not settled was never sent to the search, and its cell is
+  // empty rather than guessing. Sending a row with a wrong or missing date of
+  // birth is how the identity key gets poisoned permanently.
+  if (source.needsHuman) {
+    return { ...base, clubworx: '', outcome: 'blocked', needsHuman: true, note: source.note ?? '' };
+  }
+
+  if (!rawMatch) {
+    // Absent is not `new`. `new` writes a permanent contact, and doing that on
+    // the strength of a request nobody made is a duplicate with no cause.
+    return {
+      ...base,
+      clubworx: 'pending',
+      outcome: 'blocked',
+      needsHuman: true,
+      note: 'Clubworx has not been checked for this student yet.',
+    };
+  }
+
+  if (rawMatch.error) {
+    return {
+      ...base,
+      clubworx: 'error',
+      outcome: 'blocked',
+      needsHuman: true,
+      // Verbatim, attributed, never re-worded — D6.
+      note: rawMatch.error,
+    };
+  }
+
+  const { result, applied } = decided(rawMatch, decision);
+  const preferred = result.firstNameIsPreferred === true;
+  const note = (MATCH_NOTES[result.reason] ?? '') + (preferred && result.state !== 'matched' ? PREFERRED_NAME_NOTE : '');
+
+  const common = {
+    ...base,
+    clubworx: result.state,
+    candidates: [...(result.candidates ?? [])],
+    resolution: applied,
+    firstNameIsPreferred: preferred,
+  };
+
+  if (result.state === 'new') {
+    return { ...common, outcome: `will book ×${sessions}`, needsHuman: false, note: applied === 'create' ? note : '' };
+  }
+
+  if (result.state === 'matched') {
+    return {
+      ...common,
+      outcome: `will book ×${sessions}`,
+      needsHuman: false,
+      note: '',
+      contactKey: result.contact?.contact_key ?? null,
+    };
+  }
+
+  return { ...common, outcome: 'blocked', needsHuman: true, note };
+}
+
+/**
+ * The per-row consequence, in full. It lives in the **expanded row** — the
+ * aggregate line above the table is what staff read to approve the run, and a
+ * permanence sentence repeated on 63 rows is the repetition that trains people
+ * to stop reading a region (§9, and P9's argument against struck-through junk).
+ */
+export function consequenceLine(previewed) {
+  if (!previewed) return '';
+  if (previewed.outcome === 'blocked') return previewed.note || 'This row will not run.';
+
+  const bookings = `${plural(previewed.sessions, 'booking')} (cancellable)`;
+  if (previewed.clubworx === 'new') {
+    return `create a contact (permanent) · grant a School Pass (permanent) · ${bookings}`;
+  }
+  // See the header: the membership is read at Apply (D14), so this is what is
+  // actually known here.
+  return `create nothing · pass checked at Apply · ${bookings}`;
+}
+
+/**
+ * The run's whole consequence, above the table.
+ *
+ * Preview and result are the same line in two tenses (D11), so this is the
+ * future-tense half; #73 writes the past-tense one over the same rows. The
+ * three permanence classes stay separate rather than collapsing into a success
+ * count, because they are three different kinds of irreversible.
+ */
+export function permanenceLine(preview) {
+  const t = preview?.totals;
+  if (!t || t.students === 0) return '';
+
+  const created = t.contacts > 0
+    ? `create ${plural(t.contacts, 'contact')} (permanent) and ${passes(t.passes)} (permanent)`
+    : 'create no contacts and no new School Passes';
+
+  const sentence = `This will ${created}, and make ${plural(t.bookings, 'booking')} (cancellable).`;
+
+  if (t.returning === 0) return sentence;
+  return `${sentence} ${plural(t.returning, 'returning student')} may also need a pass `
+    + '— checked at Apply.';
+}
+
+/**
+ * Everything step 5 shows, and everything that keeps Apply dark, from one call.
+ *
+ * @param {object} opts
+ * @param {Array<object>} opts.rows step 3's rows, in step 3's order
+ * @param {object} opts.matches `matchStudent` results (or `{error}`) keyed by row key
+ * @param {object} opts.selection a `selectionReport`
+ * @param {object|null} opts.plan the `/plan` response body
+ * @param {object} opts.decisions the match resolution log
+ */
+export function buildPreview({ rows, matches, selection, plan, decisions } = {}) {
+  const log = decisions ?? {};
+  const found = matches ?? {};
+  const picked = selection ?? { events: [], blockers: [], sessions: 0 };
+  const sessions = picked.sessions ?? 0;
+
+  const students = (Array.isArray(rows) ? rows : []).filter((r) => r.bucket === 'record');
+  const previewed = students
+    .map((source) => previewRow(source, found[source.key], matchDecision(log, source.key), sessions))
+    .sort((a, b) => a.key - b.key);
+
+  const runnable = previewed.filter((r) => !r.needsHuman);
+  const creating = runnable.filter((r) => r.clubworx === 'new');
+  const returning = runnable.filter((r) => r.clubworx === 'matched');
+
+  const totals = {
+    students: runnable.length,
+    blocked: previewed.length - runnable.length,
+    contacts: creating.length,
+    // One pass per new contact, exactly — a contact this run creates provably
+    // holds none (D4). A returning student's pass is D14's, and is counted
+    // apart rather than guessed at.
+    passes: creating.length,
+    returning: returning.length,
+    bookings: runnable.length * sessions,
+  };
+
+  // Step 4's blockers come first and unchanged. Apply reads one list, so a
+  // session inside the lead time and an unresolved name variant stop the run
+  // the same way and in the same place.
+  const blockers = [...(picked.blockers ?? [])];
+
+  blockers.push(...planBlockers(plan, picked.lastSession));
+
+  const unresolved = previewed.filter((r) => r.needsHuman);
+  if (unresolved.length > 0) {
+    blockers.push({
+      key: 'unresolved-matches',
+      kind: 'unresolved-matches',
+      severity: 'block',
+      title: `${plural(unresolved.length, 'student')} still needs you`,
+      detail: unresolved.map((r) => r.name).join(', '),
+      actions: [],
+    });
+  }
+
+  if (runnable.length === 0) {
+    blockers.push({
+      key: 'nobody-to-book',
+      kind: 'nobody-to-book',
+      severity: 'block',
+      title: 'No student can be booked',
+      detail: 'Every row is held up on something. Nothing will run until at least one is clear.',
+      actions: [],
+    });
+  }
+
+  return {
+    rows: previewed,
+    totals,
+    blockers,
+    ready: !blockers.some((b) => b.severity === 'block'),
+    plan: plan?.ok ? plan.plan : null,
+    sessions: picked.events ?? [],
+    lastSession: picked.lastSession ?? null,
+  };
+}
+
+/**
+ * What the School Pass plan stops.
+ *
+ * §11: an unresolved or ambiguous plan hard-stops the run, an unparseable
+ * `membership_duration` warns **naming the raw value**, and a last session
+ * outside the pass's coverage hard-stops.
+ *
+ * The coverage end is computed by the Worker (`/plan`), not here: the calendar
+ * arithmetic lives in `cloudflare-clubworx/src/duration.js` with its own tests,
+ * and a second copy in the browser is the drift that decides a run is safe when
+ * it is not. A `coverage_end` the Worker did not send is therefore a **named
+ * warning** rather than a check quietly skipped — which §11 forbids, and which
+ * is also what an older Worker deployed behind this page looks like.
+ */
+function planBlockers(plan, lastSession) {
+  if (!plan) {
+    return [{
+      key: 'plan',
+      kind: 'plan',
+      severity: 'block',
+      title: 'The School Pass plan has not been looked up',
+      detail: 'Nothing can be granted until Clubworx names exactly one plan.',
+      actions: [],
+    }];
+  }
+
+  if (!plan.ok) {
+    return [{
+      key: 'plan',
+      kind: 'plan',
+      severity: 'block',
+      title: 'The School Pass plan could not be resolved',
+      // Clubworx's own sentence, or the Worker's. Both already say which of
+      // "missing", "ambiguous" and "the list was never read to the end" this is,
+      // and those three send an operator to three different places.
+      detail: plan.message || 'Clubworx did not name exactly one School Pass plan.',
+      actions: [],
+    }];
+  }
+
+  const out = [];
+  const resolved = plan.plan ?? {};
+
+  if (resolved.duration?.ok !== true) {
+    out.push({
+      key: 'plan-duration',
+      kind: 'plan-duration',
+      severity: 'warn',
+      title: 'The pass length could not be read',
+      detail: `The plan's duration is "${resolved.membership_duration ?? ''}", which this page cannot `
+        + 'turn into a date. Check by hand that the pass will still be live at the last session.',
+      actions: [],
+    });
+  }
+
+  const coverage = resolved.coverage_end ?? null;
+  if (!coverage) {
+    out.push({
+      key: 'coverage-unknown',
+      kind: 'coverage-unknown',
+      severity: 'warn',
+      title: 'The pass coverage was not checked',
+      detail: 'Clubworx did not say when a pass granted today would run out, so nothing has '
+        + 'confirmed it reaches the last session.',
+      actions: [],
+    });
+  } else if (lastSession && lastSession > coverage) {
+    out.push({
+      key: 'coverage',
+      kind: 'coverage',
+      severity: 'block',
+      title: 'The pass runs out before the last session',
+      // ADR 0005: *covers the last selected session*, not *active today*. Every
+      // booking is written on a day the pass is live, so "active today" is the
+      // answer that hides this until a session weeks away that nobody watches.
+      detail: `A School Pass granted today covers to ${coverage}, and the last session picked is `
+        + `${lastSession}. Book the sessions that fall inside the pass, or use a longer plan.`,
+      actions: [],
+    });
+  }
+
+  return out;
+}

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -43,7 +43,7 @@
 //
 // Bump this in lockstep with school-booking.html. alpine-bindings.test.js
 // fails if the two ever disagree.
-import { compareForm, readDate, writeForm } from './parse.js?v=1';
+import { compareForm, readDate, writeForm } from './parse.js?v=2';
 
 const DOMAIN = 'urbanjungleirc.com';
 

--- a/school-booking/test/alpine-bindings.test.js
+++ b/school-booking/test/alpine-bindings.test.js
@@ -184,24 +184,41 @@ describe('school-booking.html', () => {
     expect(offenders, `\n${detail}\n`).toHaveLength(0);
   });
 
-  test('every module in the page\'s import chain is version-busted', () => {
+  test('every module in the page\'s import chain is version-busted, at one version', () => {
     // A stale cached copy of a gate module breaks every check on the page at
     // once and in silence — the one failure the ?v= exists to prevent.
-    expect(html).toMatch(/import \* as parser from '\.\/school-booking\/parse\.js\?v=\d+'/);
-    expect(html).toMatch(/import \* as steps from '\.\/school-booking\/steps\.js\?v=\d+'/);
+    //
+    // Walked rather than listed. #72 added three modules to this chain and one
+    // of them, identity.js, arrived carrying an unversioned `./parse.js` that
+    // had been harmless only because no page imported it yet. A hand-written
+    // list of files to check is a list that goes stale exactly when a module
+    // joins the chain — which is the moment the check matters.
+    const imports = [...html.matchAll(/from '\.\/school-booking\/([\w.-]+)\?v=(\d+)'/g)];
+    expect(imports.length, 'the page imports its modules with a ?v=').toBeGreaterThan(1);
 
-    // Including the imports *inside* those modules. A specifier is a URL, so an
-    // unversioned `./parse.js` in steps.js is a second module the page's bump
-    // never reaches — leaving the file that holds every gate running against a
-    // parser the page has already moved on from.
-    const stepsSource = readFileSync(new URL('../steps.js', import.meta.url), 'utf8');
-    expect(stepsSource).not.toMatch(/from '\.\/parse\.js'/);
+    // Every page-side import at the same version, or the browser instantiates
+    // two copies of a module the page has already moved on from.
+    const versions = new Set(imports.map(([, , version]) => version));
+    expect([...versions], 'bump every ?v= on the page together').toHaveLength(1);
+    const pageVersion = [...versions][0];
 
-    // And at the same version, or the page loads the parser twice.
-    const pageVersion = html.match(/school-booking\/parse\.js\?v=(\d+)/)[1];
-    const stepsVersion = stepsSource.match(/from '\.\/parse\.js\?v=(\d+)'/)[1];
-    expect(stepsVersion, 'bump parse.js\'s ?v= in the page and in steps.js together')
-      .toBe(pageVersion);
+    // Unversioned page imports would slip past the walk above, so they are
+    // named separately rather than counted.
+    expect(html, 'a page import with no ?v= is a module the bump never reaches')
+      .not.toMatch(/from '\.\/school-booking\/[\w.-]+'/);
+
+    // And the imports *inside* those modules. A specifier is a URL, so an
+    // unversioned `./parse.js` inside steps.js is a second module the page's
+    // bump never reaches — leaving the file that holds every gate running
+    // against a parser the page has already moved on from.
+    for (const [, file] of imports) {
+      const source = readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
+      for (const [, target, version] of source.matchAll(/from '\.\/([\w.-]+)\?v=(\d+)'/g)) {
+        expect(version, `bump ${target}'s ?v= in ${file} and on the page together`).toBe(pageVersion);
+      }
+      expect(source, `${file} imports a sibling module with no ?v=`)
+        .not.toMatch(/from '\.\/[\w.-]+\.js'/);
+    }
   });
 
   test('the page is not reachable from the hub yet', () => {

--- a/school-booking/test/events.test.js
+++ b/school-booking/test/events.test.js
@@ -1,0 +1,297 @@
+// Step 4's rules, exercised without a network or a clock.
+//
+// staff-site#72. The Worker (#67) decides what an event *is* — its lead time,
+// whether it is bookable — and this module decides what a **selection** is:
+// which events arrive pre-ticked, what a pasted id resolves to, and what stops
+// the run. Those are two different questions and only the second one has to
+// survive `GET /events/:id` not being a route (#97).
+
+import { describe, expect, test } from 'vitest';
+import {
+  defaultWindow,
+  preTicked,
+  resolvePastedId,
+  selectedEvents,
+  selectionReport,
+  sessionsLine,
+} from '../events.js';
+
+// A projected event, in the shape `cloudflare-clubworx/src/events.js` emits.
+const event = (over = {}) => ({
+  event_id: '1',
+  event_name: 'School Session — Newman',
+  event_start_at: '2026-09-01T09:00:00+08:00',
+  event_end_at: '2026-09-01T10:30:00+08:00',
+  location_id: 'loc-1',
+  location_name: 'Urban Jungle',
+  free_class: false,
+  event_full: false,
+  spaces_available: 30,
+  lead: { hoursAhead: 240, past: false, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+  bookable: true,
+  ...over,
+});
+
+describe('defaultWindow', () => {
+  test('it opens on the run day and runs a term ahead', () => {
+    expect(defaultWindow('2026-08-21T14:00:00+08:00')).toEqual({
+      from: '2026-08-21',
+      to: '2026-11-19',
+    });
+  });
+
+  test('it reads the day in Perth, not in UTC', () => {
+    // 07:30 on the 22nd in Perth is 23:30 on the 21st in UTC. A window opening
+    // on the UTC day would leave this morning's sessions out of the picker for
+    // the eight hours that matter most.
+    expect(defaultWindow('2026-08-21T23:30:00Z').from).toBe('2026-08-22');
+  });
+
+  test('an unreadable instant gets no window rather than a wrong one', () => {
+    expect(defaultWindow('not a date')).toEqual({ from: '', to: '' });
+  });
+});
+
+describe('preTicked', () => {
+  const series = [
+    event({ event_id: 'a', event_start_at: '2026-09-01T09:00:00+08:00' }),
+    event({ event_id: 'b', event_start_at: '2026-09-08T09:00:00+08:00' }),
+    event({ event_id: 'c', event_start_at: '2026-09-15T09:00:00+08:00' }),
+  ];
+
+  test('the anchor and every same-name, same-location session ahead of it', () => {
+    expect(preTicked(series, 'a')).toEqual(['a', 'b', 'c']);
+  });
+
+  test('sessions before the anchor are left alone', () => {
+    // Staff pick the *first* session. Ticking last term's leftovers behind it
+    // would book a group into a class that has already happened.
+    expect(preTicked(series, 'b')).toEqual(['b', 'c']);
+  });
+
+  test('a different name is a different series', () => {
+    const mixed = [...series, event({ event_id: 'd', event_name: 'Open Climb', event_start_at: '2026-09-08T09:00:00+08:00' })];
+    expect(preTicked(mixed, 'a')).toEqual(['a', 'b', 'c']);
+  });
+
+  test('a different location is a different series', () => {
+    const mixed = [...series, event({ event_id: 'e', location_id: 'loc-2', event_start_at: '2026-09-08T09:00:00+08:00' })];
+    expect(preTicked(mixed, 'a')).toEqual(['a', 'b', 'c']);
+  });
+
+  test('names are compared on their trimmed, case-folded form', () => {
+    const mixed = [
+      event({ event_id: 'a' }),
+      event({ event_id: 'f', event_name: '  school session — newman ', event_start_at: '2026-09-08T09:00:00+08:00' }),
+    ];
+    expect(preTicked(mixed, 'a')).toEqual(['a', 'f']);
+  });
+
+  test('an unbookable session ahead is still pre-ticked, so its reason is on screen', () => {
+    // §8 annotates rather than filters, and D9 refuses to drop a session
+    // silently. A too-soon session that arrives unticked looks like a session
+    // that is not part of the series.
+    const soon = event({
+      event_id: 'g',
+      event_start_at: '2026-09-08T09:00:00+08:00',
+      bookable: false,
+      lead: { hoursAhead: 4, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+    });
+    expect(preTicked([event({ event_id: 'a' }), soon], 'a')).toEqual(['a', 'g']);
+  });
+
+  test('an anchor that is not in the list ticks nothing', () => {
+    expect(preTicked(series, 'zzz')).toEqual([]);
+    expect(preTicked(series, null)).toEqual([]);
+  });
+
+  test('an event with no name only matches its own id', () => {
+    // Two nameless events are not evidence of a series. Grouping them would
+    // pre-tick an unrelated class on the strength of a field nobody filled in.
+    const nameless = [
+      event({ event_id: 'a', event_name: null }),
+      event({ event_id: 'b', event_name: null, event_start_at: '2026-09-08T09:00:00+08:00' }),
+    ];
+    expect(preTicked(nameless, 'a')).toEqual(['a']);
+  });
+});
+
+describe('resolvePastedId', () => {
+  const window = [event({ event_id: 'a' }), event({ event_id: 'b', event_start_at: '2026-09-08T09:00:00+08:00' })];
+
+  test('an id in the loaded window resolves to its event', () => {
+    const found = resolvePastedId(window, 'b');
+    expect(found.ok).toBe(true);
+    expect(found.event.event_id).toBe('b');
+  });
+
+  test('surrounding whitespace is forgiven; a pasted id often carries it', () => {
+    expect(resolvePastedId(window, '  a \n').ok).toBe(true);
+  });
+
+  test('ids are compared as strings, so a numeric id pastes as text', () => {
+    const numeric = [event({ event_id: 4321 })];
+    expect(resolvePastedId(numeric, '4321').ok).toBe(true);
+  });
+
+  test('an empty paste is a refusal, not a miss', () => {
+    const answer = resolvePastedId(window, '   ');
+    expect(answer).toMatchObject({ ok: false, reason: 'no-id' });
+  });
+
+  test('an id outside the loaded window says so, and never says "not found"', () => {
+    // #97 measured that `GET /events/:id` answers 404 for every id, real or
+    // invented, so the Worker cannot tell these apart and neither can this.
+    // Reporting "no such event" would send staff to fix a correct id.
+    const answer = resolvePastedId(window, '9999');
+    expect(answer.ok).toBe(false);
+    expect(answer.reason).toBe('not-in-window');
+    expect(answer.message).toMatch(/window/i);
+    expect(answer.message).not.toMatch(/not found|no such/i);
+  });
+
+  test('an empty window is reported as an unloaded picker, not as a miss', () => {
+    expect(resolvePastedId([], 'a')).toMatchObject({ ok: false, reason: 'no-events' });
+  });
+});
+
+describe('selectedEvents', () => {
+  test('selected events come back in timetable order, whatever order they were ticked', () => {
+    const list = [
+      event({ event_id: 'a', event_start_at: '2026-09-15T09:00:00+08:00' }),
+      event({ event_id: 'b', event_start_at: '2026-09-01T09:00:00+08:00' }),
+    ];
+    expect(selectedEvents(list, ['a', 'b']).map((e) => e.event_id)).toEqual(['b', 'a']);
+  });
+
+  test('a selected id with no event behind it is dropped rather than faked', () => {
+    expect(selectedEvents([event({ event_id: 'a' })], ['a', 'ghost'])).toHaveLength(1);
+  });
+});
+
+describe('selectionReport', () => {
+  const ok = event({ event_id: 'a' });
+  const later = event({ event_id: 'b', event_start_at: '2026-09-08T09:00:00+08:00' });
+
+  test('nothing selected is a hard-stop', () => {
+    const report = selectionReport({ events: [ok], selected: [], studentCount: 6 });
+    expect(report.ready).toBe(false);
+    expect(report.blockers.map((b) => b.kind)).toContain('no-events');
+  });
+
+  test('a workable selection is ready and carries its dates', () => {
+    const report = selectionReport({ events: [ok, later], selected: ['a', 'b'], studentCount: 6 });
+    expect(report.ready).toBe(true);
+    expect(report.blockers).toEqual([]);
+    expect(report.firstSession).toBe('2026-09-01');
+    expect(report.lastSession).toBe('2026-09-08');
+    expect(report.bookings).toBe(12);
+  });
+
+  test('a session inside the lead time is a hard-stop naming that session', () => {
+    const soon = event({
+      event_id: 'c',
+      event_start_at: '2026-08-21T18:00:00+08:00',
+      bookable: false,
+      lead: { hoursAhead: 4, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+    });
+    const report = selectionReport({ events: [ok, soon], selected: ['a', 'c'], studentCount: 6 });
+    expect(report.ready).toBe(false);
+
+    const blocker = report.blockers.find((b) => b.kind === 'lead-time');
+    expect(blocker.severity).toBe('block');
+    // D9: the fix is offered, never taken. A session dropped on the page's own
+    // initiative is the silent adjustment the whole design refuses.
+    expect(blocker.actions).toEqual([
+      { key: 'remove:c', label: 'Remove this session', answers: 'remove', value: 'c' },
+    ]);
+    expect(blocker.detail).toMatch(/24 hours/);
+  });
+
+  test('every too-soon session gets its own removal, not one blocker for the set', () => {
+    const soon = (id, at) => event({
+      event_id: id,
+      event_start_at: at,
+      bookable: false,
+      lead: { hoursAhead: 4, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+    });
+    const report = selectionReport({
+      events: [soon('c', '2026-08-21T18:00:00+08:00'), soon('d', '2026-08-21T19:00:00+08:00')],
+      selected: ['c', 'd'],
+      studentCount: 6,
+    });
+    expect(report.blockers.filter((b) => b.kind === 'lead-time')).toHaveLength(2);
+  });
+
+  test('a session that has already started blocks on its own reason', () => {
+    const past = event({
+      event_id: 'e',
+      event_start_at: '2026-08-01T09:00:00+08:00',
+      bookable: false,
+      lead: { hoursAhead: -480, past: true, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+    });
+    const report = selectionReport({ events: [past], selected: ['e'], studentCount: 6 });
+    const blocker = report.blockers.find((b) => b.kind === 'past-session');
+    expect(blocker.severity).toBe('block');
+    expect(blocker.actions[0].answers).toBe('remove');
+  });
+
+  test('an unreadable start time blocks rather than being assumed bookable', () => {
+    const broken = event({
+      event_id: 'f',
+      event_start_at: 'whenever',
+      bookable: false,
+      lead: { hoursAhead: null, past: null, withinLeadTime: null, minLeadHours: 24, unreadable: true },
+    });
+    const report = selectionReport({ events: [broken], selected: ['f'], studentCount: 6 });
+    expect(report.blockers.map((b) => b.kind)).toContain('unreadable-session');
+    expect(report.ready).toBe(false);
+  });
+
+  test('too few spaces warns and never blocks', () => {
+    // #50: this number has been wrong in both directions, so it is worth
+    // saying and not worth obeying.
+    const tight = event({ event_id: 'g', spaces_available: 4 });
+    const report = selectionReport({ events: [tight], selected: ['g'], studentCount: 25 });
+    const warning = report.blockers.find((b) => b.kind === 'spaces');
+    expect(warning.severity).toBe('warn');
+    expect(warning.detail).toMatch(/4/);
+    expect(report.ready).toBe(true);
+  });
+
+  test('a null spaces count is not read as zero', () => {
+    const unknown = event({ event_id: 'h', spaces_available: null });
+    const report = selectionReport({ events: [unknown], selected: ['h'], studentCount: 25 });
+    expect(report.blockers.some((b) => b.kind === 'spaces')).toBe(false);
+  });
+
+  test('no students is a hard-stop even with sessions picked', () => {
+    const report = selectionReport({ events: [ok], selected: ['a'], studentCount: 0 });
+    expect(report.blockers.map((b) => b.kind)).toContain('no-students');
+    expect(report.ready).toBe(false);
+  });
+
+  test('a truncated listing warns, because the session wanted may be off the end', () => {
+    const report = selectionReport({ events: [ok], selected: ['a'], studentCount: 6, truncated: true });
+    const warning = report.blockers.find((b) => b.kind === 'truncated');
+    expect(warning.severity).toBe('warn');
+    expect(report.ready).toBe(true);
+  });
+});
+
+describe('sessionsLine', () => {
+  test('it counts sessions, students and the bookings they multiply out to', () => {
+    const line = sessionsLine({ sessions: 6, students: 4, bookings: 24 });
+    expect(line).toBe('6 sessions × 4 students = 24 bookings.');
+  });
+
+  test('it stays grammatical at one of each', () => {
+    expect(sessionsLine({ sessions: 1, students: 1, bookings: 1 })).toBe(
+      '1 session × 1 student = 1 booking.',
+    );
+  });
+
+  test('nothing picked yet says nothing', () => {
+    expect(sessionsLine({ sessions: 0, students: 4, bookings: 0 })).toBe('');
+  });
+});

--- a/school-booking/test/events.test.js
+++ b/school-booking/test/events.test.js
@@ -9,6 +9,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   defaultWindow,
+  sessionRefusal,
   preTicked,
   resolvePastedId,
   selectedEvents,
@@ -293,5 +294,79 @@ describe('sessionsLine', () => {
 
   test('nothing picked yet says nothing', () => {
     expect(sessionsLine({ sessions: 0, students: 4, bookings: 0 })).toBe('');
+  });
+});
+
+describe('sessionRefusal', () => {
+  // The one place that decides what is wrong with a session and how serious.
+  // It existed twice before — once in `selectionReport`, once in the page's own
+  // `eventWarning` — and the two disagreed: a session Clubworx reported full
+  // was painted red as refused while the report called it a warning, which is
+  // what §11 actually says ("warn, never block").
+  test('a bookable session has nothing wrong with it', () => {
+    expect(sessionRefusal(event())).toBe(null);
+  });
+
+  test('too soon to book is a block, and names the hours', () => {
+    const soon = event({
+      bookable: false,
+      lead: { hoursAhead: 4, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+    });
+    expect(sessionRefusal(soon)).toMatchObject({ kind: 'lead-time', severity: 'block' });
+    expect(sessionRefusal(soon).message).toMatch(/under 24 hours/);
+  });
+
+  test('already started is a block', () => {
+    const past = event({
+      bookable: false,
+      lead: { hoursAhead: -10, past: true, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+    });
+    expect(sessionRefusal(past)).toMatchObject({ kind: 'past-session', severity: 'block' });
+  });
+
+  test('an unreadable start time is a block', () => {
+    const broken = event({
+      bookable: false,
+      lead: { hoursAhead: null, past: null, withinLeadTime: null, minLeadHours: 24, unreadable: true },
+    });
+    expect(sessionRefusal(broken)).toMatchObject({ kind: 'unreadable-session', severity: 'block' });
+  });
+
+  test('a session reported full is a WARNING, never a block', () => {
+    // §11, and #50 behind it: that number has been wrong in both directions.
+    // The Worker's `bookable` folds no-room in with the lead time, so reading
+    // `bookable` alone paints a warnable session as a refused one.
+    const full = event({ event_full: true, spaces_available: 0, bookable: false });
+    expect(sessionRefusal(full)).toMatchObject({ kind: 'full', severity: 'warn' });
+  });
+
+  test('the lead time outranks the room, because only one of them refuses', () => {
+    const both = event({
+      event_full: true,
+      spaces_available: 0,
+      bookable: false,
+      lead: { hoursAhead: 2, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+    });
+    expect(sessionRefusal(both).severity).toBe('block');
+  });
+});
+
+describe('the picker and the report agree about severity', () => {
+  test('a full session does not stop a run the report calls ready', () => {
+    const full = event({ event_id: 'f', event_full: true, spaces_available: 0, bookable: false });
+    const report = selectionReport({ events: [full], selected: ['f'], studentCount: 6 });
+    expect(report.ready).toBe(true);
+    expect(sessionRefusal(full).severity).toBe('warn');
+  });
+
+  test('a too-soon session stops it, and says so on the row too', () => {
+    const soon = event({
+      event_id: 's',
+      bookable: false,
+      lead: { hoursAhead: 4, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+    });
+    const report = selectionReport({ events: [soon], selected: ['s'], studentCount: 6 });
+    expect(report.ready).toBe(false);
+    expect(sessionRefusal(soon).severity).toBe('block');
   });
 });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -664,6 +664,7 @@ describe('step 4 — the session picker', () => {
     expect(app.events).toHaveLength(1); // annotated, never filtered
     expect(app.eventLane(past)).toBe('lane-bad');
     expect(app.eventWarning(past)).toBe('Already started.');
+    expect(app.eventWarningTone(past)).toBe('text-rose-700');
   });
 
   test('too few spaces warns without blocking', async () => {
@@ -693,13 +694,16 @@ describe('step 4 — the session picker', () => {
     expect(app.selection.ready).toBe(false);
   });
 
-  test('a pasted id resolves against the loaded window and ticks its series', async () => {
+  test('a pasted id resolves against the loaded window, then waits to be confirmed', async () => {
     const app = await upToSessions(component());
     app.pastedEventId = ' e1 ';
     app.usePastedId();
     expect(app.pastedIdOk).toBe(true);
+    expect(app.pastedIdConfirmLine()).toContain('School Session');
+    // Nothing is ticked until a human agrees this is the right class — §8.
+    expect(app.picked).toEqual([]);
+    app.confirmPastedId();
     expect(app.picked).toEqual(['e1', 'e2']);
-    expect(app.pastedIdNote).toContain('School Session');
   });
 
   test('an id outside the window never claims the id is wrong', async () => {
@@ -894,5 +898,110 @@ describe('an unresolvable plan stops the run before it spends the allowance', ()
     expect(app.preview.blockers.some((b) => b.kind === 'plan' && b.severity === 'block')).toBe(true);
     expect(app.preview.ready).toBe(false);
     expect(app.checkState).toBe('done');
+  });
+});
+
+describe('the pasted id is a shortcut past the search, never past the confirmation', () => {
+  test('resolving offers the session for confirmation and ticks nothing yet', async () => {
+    // §8: "The id is resolved and shown with its name, date and
+    // `spaces_available` for confirmation before it can be selected."
+    const app = await upToSessions(component());
+    app.pastedEventId = 'e1';
+    app.usePastedId();
+
+    expect(app.picked).toEqual([]);
+    expect(app.pastedIdEvent).toMatchObject({ event_id: 'e1', spaces_available: 30 });
+    expect(app.pastedIdConfirmLine()).toContain('School Session');
+    expect(app.pastedIdConfirmLine()).toContain('2026-09-01');
+    expect(app.pastedIdConfirmLine()).toContain('30'); // spaces_available, on screen
+  });
+
+  test('confirming ticks the series from that session', async () => {
+    const app = await upToSessions(component());
+    app.pastedEventId = 'e1';
+    app.usePastedId();
+    app.confirmPastedId();
+    expect(app.picked).toEqual(['e1', 'e2']);
+    expect(app.pastedIdEvent).toBe(null);
+  });
+
+  test('it says out loud that confirming replaces what is already ticked', async () => {
+    // It replaces because pasting an id is the same statement as "pick this
+    // first". Silently discarding six ticked sessions is what makes that
+    // surprising, so the sentence names the count before the click.
+    const app = await upToSessions(component());
+    app.togglePick('e3');
+    app.pastedEventId = 'e1';
+    app.usePastedId();
+    expect(app.pastedIdConfirmLine()).toMatch(/replace/i);
+    expect(app.pastedIdConfirmLine()).toContain('1');
+  });
+
+  test('an unresolvable id offers nothing to confirm', async () => {
+    const app = await upToSessions(component());
+    app.togglePick('e1');
+    app.pastedEventId = '999999';
+    app.usePastedId();
+    expect(app.pastedIdEvent).toBe(null);
+    expect(app.pastedIdNote).toMatch(/window/i);
+    expect(app.picked).toEqual(['e1']); // and takes nothing away
+  });
+
+  test('a resolved session can be dismissed without being taken', async () => {
+    const app = await upToSessions(component());
+    app.pastedEventId = 'e1';
+    app.usePastedId();
+    app.cancelPastedId();
+    expect(app.pastedIdEvent).toBe(null);
+    expect(app.picked).toEqual([]);
+  });
+});
+
+describe('a preview cannot outlive the list it describes', () => {
+  test('reopening a step 3 gate drops the preview rather than leaving it ready', async () => {
+    // The step strip lets staff jump to any step already reached, so without
+    // this a walk of 5 → 3 → (edit) → 5 lands on a preview that still says
+    // "ready" about a list that has changed underneath it.
+    const app = await upToPreview(component());
+    expect(app.preview.ready).toBe(true);
+
+    app.go(2);
+    app.dismissRow(app.reviewed.rows[0].key); // a real edit: one student fewer
+
+    expect(app.preview).toBe(null);
+    expect(app.matches).toEqual({});
+    expect(app.checkState).toBe('idle');
+  });
+
+  test('a match decision is dropped with it, not carried onto different rows', async () => {
+    const app = await upToPreview(component({
+      candidatesFor: (lastName, dob) => (lastName === 'Fernsby'
+        ? [{ contact_key: 'ck-1', first_name: 'Katherine', last_name: 'Fernsby', dob, status_view: 'members' }]
+        : []),
+    }));
+    const variant = app.preview.rows.find((r) => r.clubworx === 'name-variant');
+    app.useContact(variant.key, 'ck-1');
+    expect(app.decisions[variant.key]).toBeTruthy();
+
+    app.go(2);
+    app.dismissRow(app.reviewed.rows[0].key);
+    expect(app.decisions).toEqual({});
+  });
+
+  test('a step 3 gate still open is a hard-stop on the preview itself', async () => {
+    // Belt as well as braces: even a preview that was somehow built while a
+    // gate was open reports that gate, because buildPreview carries them.
+    const app = await upToSessions(component());
+    app.pickSeries('e1');
+    await app.toPreview();
+    expect(app.preview.ready).toBe(true);
+
+    // Reopen the count gate the way staff would, then rebuild in place.
+    app.countValue = '99';
+    app.refresh();
+    expect(app.preview).toBe(null);
+    app.refreshPreview();
+    expect(app.preview.blockers.some((b) => b.kind === 'count-mismatch')).toBe(true);
+    expect(app.preview.ready).toBe(false);
   });
 });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -14,6 +14,9 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import * as parser from '../parse.js';
 import * as steps from '../steps.js';
+import * as identity from '../identity.js';
+import * as events from '../events.js';
+import * as preview from '../preview.js';
 
 const html = readFileSync(new URL('../../school-booking.html', import.meta.url), 'utf8');
 const fixture = (name) =>
@@ -40,12 +43,86 @@ const SCHOOLS = [
   { tag: 'harlow', email: 'noreply+harlow@urbanjungleirc.com', contacts: 4 },
 ];
 
-function component({ schools = SCHOOLS, schoolsFail = false } = {}) {
-  globalThis.window = { schoolListParser: parser, schoolBookingSteps: steps };
+// The four routes steps 1–5 read, all of them GETs. Nothing on this page has a
+// write path yet — Apply is #73 — so a component test that ever sees a POST is
+// a test that has caught the page doing something it must not.
+const EVENTS = [
+  {
+    event_id: 'e1', event_name: 'School Session — Newman', event_start_at: '2026-09-01T09:00:00+08:00',
+    event_end_at: '2026-09-01T10:30:00+08:00', location_id: 'loc-1', location_name: 'Urban Jungle',
+    free_class: false, event_full: false, spaces_available: 30,
+    lead: { hoursAhead: 240, past: false, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+    bookable: true,
+  },
+  {
+    event_id: 'e2', event_name: 'School Session — Newman', event_start_at: '2026-09-08T09:00:00+08:00',
+    event_end_at: '2026-09-08T10:30:00+08:00', location_id: 'loc-1', location_name: 'Urban Jungle',
+    free_class: false, event_full: false, spaces_available: 30,
+    lead: { hoursAhead: 408, past: false, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+    bookable: true,
+  },
+  {
+    event_id: 'e3', event_name: 'Open Climb', event_start_at: '2026-09-02T17:00:00+08:00',
+    event_end_at: '2026-09-02T19:00:00+08:00', location_id: 'loc-1', location_name: 'Urban Jungle',
+    free_class: false, event_full: false, spaces_available: 4,
+    lead: { hoursAhead: 260, past: false, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+    bookable: true,
+  },
+];
+
+const PLAN = {
+  ok: true,
+  plan: {
+    membership_plan_id: 'mp-school',
+    name: 'School Pass',
+    membership_duration: '26 weeks',
+    duration: { ok: true, count: 26, unit: 'week', raw: '26 weeks' },
+    coverage_end: '2027-02-18',
+  },
+};
+
+function component({
+  schools = SCHOOLS,
+  schoolsFail = false,
+  eventList = EVENTS,
+  eventsFail = false,
+  plan = PLAN,
+  candidatesFor = () => [],
+  contactsFail = false,
+} = {}) {
+  globalThis.window = {
+    schoolListParser: parser,
+    schoolBookingSteps: steps,
+    schoolBookingIdentity: identity,
+    schoolBookingEvents: events,
+    schoolBookingPreview: preview,
+  };
   globalThis.fetch = vi.fn(async (url) => {
-    if (String(url).includes('/api/clubworx/schools')) {
+    const target = String(url);
+    if (target.includes('/api/clubworx/schools')) {
       if (schoolsFail) return { ok: false, status: 502, json: async () => ({ error: 'upstream' }) };
       return { ok: true, status: 200, json: async () => ({ ok: true, schools }) };
+    }
+    if (target.includes('/api/clubworx/events')) {
+      if (eventsFail) return { ok: false, status: 502, json: async () => ({ error: 'the Clubworx read failed' }) };
+      const query = new URL(target, 'https://example.test').searchParams.get('q') ?? '';
+      const matched = query
+        ? eventList.filter((e) => e.event_name.toLowerCase().includes(query.toLowerCase()))
+        : eventList;
+      return { ok: true, status: 200, json: async () => ({ ok: true, events: matched, total: eventList.length, truncated: false }) };
+    }
+    if (target.includes('/api/clubworx/plan')) {
+      if (plan.ok) return { ok: true, status: 200, json: async () => plan };
+      return { ok: false, status: 502, json: async () => ({ error: plan.message, reason: plan.reason }) };
+    }
+    if (target.includes('/api/clubworx/contacts')) {
+      if (contactsFail) return { ok: false, status: 429, json: async () => ({ error: 'Clubworx is busy' }) };
+      const params = new URL(target, 'https://example.test').searchParams;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ candidates: candidatesFor(params.get('last_name'), params.get('dob')) }),
+      };
     }
     return { ok: true, status: 200, json: async () => ({ email: 'staff@urbanjungleirc.com' }) };
   });
@@ -102,7 +179,12 @@ describe('bootstrap', () => {
   });
 
   test('a missing module refuses out loud instead of pretending to check', async () => {
-    globalThis.window = { schoolBookingSteps: steps };
+    globalThis.window = {
+      schoolBookingSteps: steps,
+      schoolBookingIdentity: identity,
+      schoolBookingEvents: events,
+      schoolBookingPreview: preview,
+    };
     globalThis.fetch = vi.fn();
     const app = await settled(makeComponent());
     expect(app.bootstrapError).toContain('list parser');
@@ -482,5 +564,310 @@ describe('step 3 — resolving a row', () => {
       expect(app.laneFor(row)).toMatch(/^lane-/);
       expect(typeof app.stateTone(row)).toBe('string');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Steps 4 and 5 (#72)
+// ---------------------------------------------------------------------------
+
+// Six students on three columns, so the counts below are the fixture's own.
+const upToSessions = async (app, opts = {}) => {
+  await upToStepThree(app, opts);
+  app.toSessions();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return app;
+};
+
+const upToPreview = async (app, opts = {}) => {
+  await upToSessions(app, opts);
+  app.pickSeries('e1');
+  await app.toPreview();
+  return app;
+};
+
+describe('step 4 — the session picker', () => {
+  test('going forward opens a window and reads the timetable once', async () => {
+    const app = await upToSessions(component());
+    expect(app.stepIndex).toBe(3);
+    expect(app.eventsFrom).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(app.eventsTo > app.eventsFrom).toBe(true);
+
+    const reads = globalThis.fetch.mock.calls.map(([url]) => String(url));
+    expect(reads.filter((u) => u.includes('/api/clubworx/events'))).toHaveLength(1);
+    // The window is a request parameter, not a filter: Clubworx refuses
+    // `/events` with no window at all (#51), so the page always names one.
+    expect(reads.find((u) => u.includes('/events'))).toContain('from=');
+    expect(app.events).toHaveLength(3);
+  });
+
+  test('step 3’s gates still hold the door', async () => {
+    // A row nobody has sorted out must not reach a screen that books it.
+    const app = await upToStepThree(component(), { count: '99' });
+    expect(app.reviewed.ready).toBe(false);
+    app.toSessions();
+    expect(app.stepIndex).toBe(2);
+  });
+
+  test('picking the first session ticks its series and nothing else', async () => {
+    const app = await upToSessions(component());
+    app.pickSeries('e1');
+    expect(app.picked).toEqual(['e1', 'e2']); // Open Climb is a different series
+    expect(app.selection.ready).toBe(true);
+    expect(app.selection.bookings).toBe(12); // 2 sessions × 6 students
+    expect(app.sessionsLine()).toBe('2 sessions × 6 students = 12 bookings.');
+  });
+
+  test('a tick can be taken off again, and the numbers follow', async () => {
+    const app = await upToSessions(component());
+    app.pickSeries('e1');
+    app.togglePick('e2');
+    expect(app.picked).toEqual(['e1']);
+    expect(app.selection.bookings).toBe(6);
+  });
+
+  test('nothing picked keeps the forward button dark', async () => {
+    const app = await upToSessions(component());
+    expect(app.selection.ready).toBe(false);
+    expect(app.selection.blockers.map((b) => b.kind)).toContain('no-events');
+  });
+
+  test('a session inside the lead time blocks, and its removal clears it', async () => {
+    // D9: the fix is offered, never taken. The page removes the session when
+    // the operator says so and never on its own initiative.
+    const soon = {
+      ...EVENTS[0],
+      event_id: 'soon',
+      lead: { hoursAhead: 3, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+      bookable: false,
+    };
+    const app = await upToSessions(component({ eventList: [...EVENTS, soon] }));
+    app.togglePick('e1');
+    app.togglePick('soon');
+    const blocker = app.selection.blockers.find((b) => b.kind === 'lead-time');
+    expect(blocker).toBeTruthy();
+    expect(app.selection.ready).toBe(false);
+
+    app.answerSelection(blocker.actions[0]);
+    expect(app.picked).toEqual(['e1']);
+    expect(app.selection.ready).toBe(true);
+  });
+
+  test('an unbookable session is still shown, with its reason', async () => {
+    const past = {
+      ...EVENTS[0],
+      event_id: 'gone',
+      lead: { hoursAhead: -10, past: true, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+      bookable: false,
+    };
+    const app = await upToSessions(component({ eventList: [past] }));
+    expect(app.events).toHaveLength(1); // annotated, never filtered
+    expect(app.eventLane(past)).toBe('lane-bad');
+    expect(app.eventWarning(past)).toBe('Already started.');
+  });
+
+  test('too few spaces warns without blocking', async () => {
+    const app = await upToSessions(component());
+    app.togglePick('e3'); // Open Climb reports 4 spaces for 6 students
+    expect(app.selection.blockers.some((b) => b.kind === 'spaces' && b.severity === 'warn')).toBe(true);
+    expect(app.selection.ready).toBe(true);
+  });
+
+  test('searching by name re-reads and drops ticks the new window no longer holds', async () => {
+    const app = await upToSessions(component());
+    app.togglePick('e3');
+    app.eventsQuery = 'School Session';
+    await app.loadEvents();
+    expect(app.events.map((e) => e.event_id)).toEqual(['e1', 'e2']);
+    // e3 is gone from the window, so the tick goes with it — a count that
+    // disagrees with the table is how a group is booked into a session nobody
+    // can see.
+    expect(app.picked).toEqual([]);
+  });
+
+  test('a failed events read says so and leaves the picker empty rather than stale', async () => {
+    const app = await upToSessions(component({ eventsFail: true }));
+    expect(app.eventsState).toBe('error');
+    expect(app.eventsNote()).toContain('Could not read');
+    expect(app.events).toEqual([]);
+    expect(app.selection.ready).toBe(false);
+  });
+
+  test('a pasted id resolves against the loaded window and ticks its series', async () => {
+    const app = await upToSessions(component());
+    app.pastedEventId = ' e1 ';
+    app.usePastedId();
+    expect(app.pastedIdOk).toBe(true);
+    expect(app.picked).toEqual(['e1', 'e2']);
+    expect(app.pastedIdNote).toContain('School Session');
+  });
+
+  test('an id outside the window never claims the id is wrong', async () => {
+    // #97: `GET /events/:id` answers 404 for a real id and an invented one
+    // alike, so nothing can tell them apart — and "no such event" sends staff
+    // to re-check an id that is fine.
+    const app = await upToSessions(component());
+    app.pastedEventId = '999999';
+    app.usePastedId();
+    expect(app.pastedIdOk).toBe(false);
+    expect(app.pastedIdNote).toMatch(/window/i);
+    expect(app.pastedIdNote).not.toMatch(/not found|no such/i);
+    expect(app.picked).toEqual([]);
+    // And it costs no request: the answer is already on screen.
+    expect(globalThis.fetch.mock.calls.filter(([u]) => String(u).includes('event_id'))).toHaveLength(0);
+  });
+});
+
+describe('the Clubworx check between 4 and 5', () => {
+  test('it reads the plan once and each student once, and writes nothing', async () => {
+    const app = await upToPreview(component());
+    const reads = globalThis.fetch.mock.calls.map(([url]) => String(url));
+    expect(reads.filter((u) => u.includes('/api/clubworx/plan'))).toHaveLength(1);
+    expect(reads.filter((u) => u.includes('/api/clubworx/contacts'))).toHaveLength(6);
+
+    // Every call a GET. Apply is #73; a POST from this page would be a write
+    // nobody asked for, against records Clubworx cannot delete.
+    for (const [, options] of globalThis.fetch.mock.calls) {
+      expect(options?.method ?? 'GET').toBe('GET');
+    }
+  });
+
+  test('the search is asked with both halves of the identity key', async () => {
+    // A surname-less query walks ~60,000 contacts and concludes nothing; a
+    // query with no birthday cannot tell siblings apart (§5).
+    const app = await upToPreview(component());
+    const contacts = globalThis.fetch.mock.calls
+      .map(([url]) => String(url))
+      .filter((u) => u.includes('/api/clubworx/contacts'));
+    for (const url of contacts) {
+      const params = new URL(url, 'https://example.test').searchParams;
+      expect(params.get('last_name')).toBeTruthy();
+      expect(params.get('dob')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+    expect(app.preview.rows.every((r) => r.clubworx === 'new')).toBe(true);
+  });
+
+  test('an existing contact comes back matched and creates nothing', async () => {
+    const app = await upToPreview(component({
+      candidatesFor: (lastName, dob) => (lastName === 'Fernsby'
+        ? [{ contact_key: 'ck-1', first_name: 'Katie', last_name: 'Fernsby', dob, status_view: 'members' }]
+        : []),
+    }));
+    const matched = app.preview.rows.filter((r) => r.clubworx === 'matched');
+    expect(matched).toHaveLength(1);
+    expect(matched[0].contactKey).toBe('ck-1');
+    expect(app.preview.totals.contacts).toBe(5);
+    expect(app.preview.totals.returning).toBe(1);
+  });
+
+  test('a failed search blocks that student rather than reporting them new', async () => {
+    // `new` writes a contact Clubworx cannot delete. A request that failed must
+    // never come out the other side as one.
+    const app = await upToPreview(component({ contactsFail: true }));
+    expect(app.preview.rows.every((r) => r.clubworx === 'error')).toBe(true);
+    expect(app.preview.ready).toBe(false);
+    expect(app.preview.totals.contacts).toBe(0);
+  });
+
+  test('an unresolved plan blocks the whole run', async () => {
+    const app = await upToPreview(component({
+      plan: { ok: false, reason: 'plan-ambiguous', message: '2 membership plans are named "School Pass"' },
+    }));
+    const blocker = app.preview.blockers.find((b) => b.kind === 'plan');
+    expect(blocker.severity).toBe('block');
+    expect(blocker.detail).toContain('2 membership plans');
+    expect(app.preview.ready).toBe(false);
+  });
+});
+
+describe('step 5 — the preview', () => {
+  test('the permanence line counts the two permanent records apart from the bookings', async () => {
+    const app = await upToPreview(component());
+    expect(app.permanenceLine()).toBe(
+      'This will create 6 contacts (permanent) and 6 School Passes (permanent), '
+      + 'and make 12 bookings (cancellable).',
+    );
+    expect(app.preview.ready).toBe(true);
+  });
+
+  test('a re-run over students who all exist says it writes nothing permanent', async () => {
+    // D13: the preview is the guard for a deliberate re-paste, so it has to be
+    // readable as "this creates nothing" or the recovery path D5 prescribes
+    // looks identical to a mistake.
+    const app = await upToPreview(component({
+      candidatesFor: (lastName, dob) => [{ contact_key: `ck-${lastName}`, first_name: null, last_name: lastName, dob }],
+    }));
+    // No first name on the candidate, so these come back as variants, not
+    // matches — resolve them all the way a human would.
+    for (const line of app.preview.rows) app.useContact(line.key, line.candidates[0].contact_key);
+    expect(app.permanenceLine()).toContain('create no contacts and no new School Passes');
+    expect(app.preview.ready).toBe(true);
+  });
+
+  test('a name variant blocks Apply until it is decided, either way', async () => {
+    const app = await upToPreview(component({
+      candidatesFor: (lastName, dob) => (lastName === 'Fernsby'
+        ? [{ contact_key: 'ck-1', first_name: 'Katherine', last_name: 'Fernsby', dob, status_view: 'members' }]
+        : []),
+    }));
+    const variant = app.preview.rows.find((r) => r.clubworx === 'name-variant');
+    expect(variant.needsHuman).toBe(true);
+    expect(app.preview.ready).toBe(false);
+
+    app.useContact(variant.key, 'ck-1');
+    expect(app.preview.rows.find((r) => r.key === variant.key).clubworx).toBe('matched');
+    expect(app.preview.ready).toBe(true);
+
+    app.undoMatch(variant.key);
+    expect(app.preview.ready).toBe(false);
+
+    app.createAnyway(variant.key);
+    expect(app.preview.rows.find((r) => r.key === variant.key).clubworx).toBe('new');
+    expect(app.preview.ready).toBe(true);
+  });
+
+  test('the row helpers describe every preview row without throwing', async () => {
+    const app = await upToPreview(component({
+      candidatesFor: (lastName, dob) => (lastName === 'Fernsby'
+        ? [{ contact_key: 'ck-1', first_name: 'Katherine', last_name: 'Fernsby', dob, status_view: 'members' }]
+        : []),
+    }));
+    for (const line of app.preview.rows) {
+      expect(typeof app.consequenceLine(line)).toBe('string');
+      expect(typeof app.clubworxTone(line)).toBe('string');
+      app.togglePreviewRow(line.key);
+      expect(app.expandedPreview).toBe(line.key);
+      app.togglePreviewRow(line.key);
+      expect(app.expandedPreview).toBe(null);
+    }
+  });
+
+  test('going back to the sessions and forward again re-checks rather than trusting stale answers', async () => {
+    const app = await upToPreview(component());
+    const before = globalThis.fetch.mock.calls.length;
+    app.go(3);
+    app.togglePick('e2');
+    await app.toPreview();
+    expect(globalThis.fetch.mock.calls.length).toBeGreaterThan(before);
+    expect(app.preview.totals.bookings).toBe(6); // one session now
+  });
+});
+
+describe('the check does not leave stale answers on screen', () => {
+  test('a second run clears the first run’s preview before it moves', async () => {
+    // Step 5 is the screen an operator reads to approve permanent writes. A
+    // preview belonging to a different selection, on screen for even one
+    // render, is the wrong sentence at the one moment it is being trusted.
+    const app = await upToPreview(component());
+    expect(app.preview.totals.bookings).toBe(12);
+
+    app.go(3);
+    app.togglePick('e2');
+    const running = app.toPreview();
+    expect(app.preview).toBe(null);
+    expect(app.checkState).toBe('running');
+    await running;
+    expect(app.checkState).toBe('done');
+    expect(app.preview.totals.bookings).toBe(6);
   });
 });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -871,3 +871,28 @@ describe('the check does not leave stale answers on screen', () => {
     expect(app.preview.totals.bookings).toBe(6);
   });
 });
+
+describe('an unresolvable plan stops the run before it spends the allowance', () => {
+  test('no student is read when the School Pass plan did not resolve', async () => {
+    // §11 hard-stops the *run* on an unresolved plan, and the reads are not
+    // free: 6 students is 18 requests of an allowance the whole gym shares,
+    // and nothing caches them — so a run that cannot proceed would spend them
+    // again on the next attempt. The plan is a Clubworx configuration fix, so
+    // there is nothing the operator can do with the answers meanwhile.
+    const app = await upToSessions(component({
+      plan: { ok: false, reason: 'plan-not-found', message: 'no membership plan is named "School Pass"' },
+    }));
+    app.pickSeries('e1');
+    await app.toPreview();
+
+    const reads = globalThis.fetch.mock.calls.map(([url]) => String(url));
+    expect(reads.filter((u) => u.includes('/api/clubworx/contacts'))).toHaveLength(0);
+
+    // And it still lands on step 5 saying why, rather than refusing in place
+    // with no screen to read: the blocker is the answer.
+    expect(app.stepIndex).toBe(4);
+    expect(app.preview.blockers.some((b) => b.kind === 'plan' && b.severity === 'block')).toBe(true);
+    expect(app.preview.ready).toBe(false);
+    expect(app.checkState).toBe('done');
+  });
+});

--- a/school-booking/test/preview.test.js
+++ b/school-booking/test/preview.test.js
@@ -397,3 +397,55 @@ describe('the hard-stops before Apply lights up', () => {
     expect(preview.totals).toMatchObject({ students: 1, contacts: 1, passes: 1, bookings: 2, blocked: 1 });
   });
 });
+
+describe('step 3’s gates are hard-stops here too', () => {
+  // #72: "Any unresolved gate — **Hard-stop**." The preview is where Apply
+  // lights up, so every gate upstream of it has to be visible from here — not
+  // only the ones this step raised. Without this, a step 5 → 3 → 5 walk could
+  // leave a preview saying ready while the count gate was reopened behind it.
+  const blocked = {
+    ready: false,
+    blockers: [{
+      key: 'count-mismatch',
+      kind: 'count-mismatch',
+      severity: 'block',
+      title: 'You expected 7; we read 6',
+      detail: 'Fix the rows, or say the count has changed.',
+      lineNumbers: [],
+      actions: [],
+    }],
+  };
+
+  test('a blocking gate from step 3 keeps Apply dark', () => {
+    const preview = build({ review: blocked });
+    expect(preview.blockers.some((b) => b.kind === 'count-mismatch')).toBe(true);
+    expect(preview.ready).toBe(false);
+  });
+
+  test('step 3’s warnings are carried too, without blocking', () => {
+    const preview = build({
+      review: {
+        ready: true,
+        blockers: [{ key: 'count-unknown', kind: 'count-unknown', severity: 'warn', title: 'We read 6 students', detail: '…', actions: [] }],
+      },
+    });
+    expect(preview.blockers.some((b) => b.kind === 'count-unknown')).toBe(true);
+    expect(preview.ready).toBe(true);
+  });
+
+  test('step 3’s gates are not restated when it has none', () => {
+    expect(build().blockers.filter((b) => b.kind === 'count-mismatch')).toEqual([]);
+  });
+
+  test('a step-3 action is carried intact, so its control still works', () => {
+    const withAction = {
+      ready: false,
+      blockers: [{
+        key: 'count-mismatch', kind: 'count-mismatch', severity: 'block', title: 'x', detail: 'y',
+        actions: [{ key: 'redeclare', label: 'The count has changed', answers: 'redeclare', value: 6 }],
+      }],
+    };
+    const carried = build({ review: withAction }).blockers.find((b) => b.kind === 'count-mismatch');
+    expect(carried.actions[0].answers).toBe('redeclare');
+  });
+});

--- a/school-booking/test/preview.test.js
+++ b/school-booking/test/preview.test.js
@@ -1,0 +1,399 @@
+// Step 5 — the preview table, the permanence line, and what stops Apply.
+//
+// staff-site#72. Everything here is a pure function over what steps 3 and 4
+// already produced plus the Clubworx check between them, so the whole screen
+// can be walked without a network.
+
+import { describe, expect, test } from 'vitest';
+import {
+  buildPreview,
+  consequenceLine,
+  matchDecision,
+  permanenceLine,
+  resolveMatch,
+} from '../preview.js';
+
+// A step-3 row, in the shape `review()` emits.
+const row = (over = {}) => ({
+  key: 3,
+  lineNumbers: [3],
+  bucket: 'record',
+  state: 'clean',
+  firstName: 'Alice',
+  lastName: 'Smith',
+  dob: '2011-03-12',
+  raw: '',
+  flags: [],
+  needs: [],
+  note: '',
+  needsHuman: false,
+  resolution: null,
+  ...over,
+});
+
+// A `matchStudent()` result.
+const match = (over = {}) => ({
+  state: 'new',
+  reason: 'no-candidates',
+  contact: null,
+  candidates: [],
+  firstNameIsPreferred: false,
+  ...over,
+});
+
+const contact = (over = {}) => ({
+  contact_key: 'ck-1',
+  first_name: 'Alice',
+  last_name: 'Smith',
+  dob: '2011-03-12',
+  email: null,
+  status: 'Prospect',
+  status_view: 'prospects',
+  ...over,
+});
+
+const selection = (over = {}) => ({
+  events: [
+    { event_id: 'a', event_name: 'School Session', event_start_at: '2026-09-01T09:00:00+08:00' },
+    { event_id: 'b', event_name: 'School Session', event_start_at: '2026-09-08T09:00:00+08:00' },
+  ],
+  blockers: [],
+  ready: true,
+  sessions: 2,
+  students: 1,
+  bookings: 2,
+  firstSession: '2026-09-01',
+  lastSession: '2026-09-08',
+  ...over,
+});
+
+const plan = (over = {}) => ({
+  ok: true,
+  plan: {
+    membership_plan_id: 42,
+    name: 'School Pass',
+    membership_duration: '26 weeks',
+    duration: { ok: true, count: 26, unit: 'week', raw: '26 weeks' },
+    coverage_end: '2027-02-18',
+  },
+  ...over,
+});
+
+const build = (over = {}) =>
+  buildPreview({
+    rows: [row()],
+    matches: { 3: match() },
+    selection: selection(),
+    plan: plan(),
+    decisions: {},
+    ...over,
+  });
+
+describe('the three state columns', () => {
+  test('READ is the parse state and CLUBWORX the match state, kept apart', () => {
+    // P2b made structural: reading *down* a column is the scan this screen
+    // exists for, and folding the parse state into the student cell as a pill
+    // is what makes that scan impossible.
+    const preview = build();
+    expect(preview.rows[0]).toMatchObject({
+      name: 'Alice Smith',
+      dob: '2011-03-12',
+      read: 'clean',
+      clubworx: 'new',
+      outcome: 'will book ×2',
+    });
+  });
+
+  test('a matched student books and creates nothing', () => {
+    const preview = build({ matches: { 3: match({ state: 'matched', reason: 'first-name-matches', contact: contact() }) } });
+    expect(preview.rows[0].clubworx).toBe('matched');
+    expect(preview.rows[0].outcome).toBe('will book ×2');
+    expect(preview.rows[0].contactKey).toBe('ck-1');
+  });
+
+  test('a row that still needs a human has no Clubworx state at all', () => {
+    // It was never sent to the search — sending a row with a wrong or missing
+    // date of birth is how the surname + DOB key gets poisoned for every later
+    // term. So the cell is empty rather than guessing at `new`.
+    const preview = build({
+      rows: [row({ state: 'needs-confirmation', needsHuman: true, note: 'Check the birthday.' })],
+      matches: {},
+    });
+    expect(preview.rows[0]).toMatchObject({ read: 'needs-confirmation', clubworx: '', outcome: 'blocked' });
+  });
+
+  test('a student the search never reached is pending, not new', () => {
+    // `new` creates a permanent contact. An absent answer must never read as
+    // one — that is a duplicate written on the strength of a request that was
+    // never made.
+    const preview = build({ matches: {} });
+    expect(preview.rows[0].clubworx).toBe('pending');
+    expect(preview.rows[0].outcome).toBe('blocked');
+  });
+
+  test('a search that failed says so on the row', () => {
+    const preview = build({ matches: { 3: { error: 'Clubworx is busy' } } });
+    expect(preview.rows[0].clubworx).toBe('error');
+    expect(preview.rows[0].outcome).toBe('blocked');
+    expect(preview.rows[0].note).toBe('Clubworx is busy');
+  });
+
+  test('rows keep step 3’s order, so the two tables read the same way down', () => {
+    const preview = build({
+      rows: [row({ key: 9, firstName: 'Zoe' }), row({ key: 2, firstName: 'Ada' })],
+      matches: { 9: match(), 2: match() },
+    });
+    expect(preview.rows.map((r) => r.key)).toEqual([2, 9]);
+  });
+});
+
+describe('resolving a match', () => {
+  test('a name variant blocks until somebody decides', () => {
+    const preview = build({
+      matches: { 3: match({ state: 'name-variant', reason: 'first-name-differs', candidates: [contact({ first_name: 'Alexandra' })] }) },
+    });
+    expect(preview.rows[0].outcome).toBe('blocked');
+    expect(preview.rows[0].needsHuman).toBe(true);
+    expect(preview.rows[0].candidates).toHaveLength(1);
+    expect(preview.ready).toBe(false);
+  });
+
+  test('a nickname column is named on the row, because it changes what the mismatch means', () => {
+    const preview = build({
+      matches: {
+        3: match({
+          state: 'name-variant',
+          reason: 'first-name-differs',
+          candidates: [contact({ first_name: 'Alexandra' })],
+          firstNameIsPreferred: true,
+        }),
+      },
+    });
+    expect(preview.rows[0].note).toMatch(/preferred name/i);
+  });
+
+  test('choosing a candidate makes the row a match on that contact', () => {
+    const decisions = resolveMatch({}, 3, { kind: 'use', contactKey: 'ck-1' });
+    const preview = build({
+      matches: { 3: match({ state: 'name-variant', reason: 'first-name-differs', candidates: [contact()] }) },
+      decisions,
+    });
+    expect(preview.rows[0]).toMatchObject({ clubworx: 'matched', outcome: 'will book ×2', contactKey: 'ck-1' });
+    expect(preview.rows[0].resolution).toBe('use');
+    expect(preview.ready).toBe(true);
+  });
+
+  test('choosing to create anyway makes the row new, and says the record is permanent', () => {
+    const decisions = resolveMatch({}, 3, { kind: 'create' });
+    const preview = build({
+      matches: { 3: match({ state: 'ambiguous', reason: 'duplicate-contacts', candidates: [contact(), contact({ contact_key: 'ck-2' })] }) },
+      decisions,
+    });
+    expect(preview.rows[0].clubworx).toBe('new');
+    expect(preview.totals.contacts).toBe(1);
+    expect(consequenceLine(preview.rows[0])).toMatch(/permanent/);
+  });
+
+  test('a decision naming a contact the search did not offer is ignored', () => {
+    // The candidate list is re-read every time the check runs. A decision that
+    // outlived its candidates would otherwise attach a permanent pass to a
+    // contact key nothing on screen ever showed.
+    const decisions = resolveMatch({}, 3, { kind: 'use', contactKey: 'ck-gone' });
+    const preview = build({
+      matches: { 3: match({ state: 'name-variant', reason: 'first-name-differs', candidates: [contact()] }) },
+      decisions,
+    });
+    expect(preview.rows[0].outcome).toBe('blocked');
+  });
+
+  test('a decision is taken back by resolving to null', () => {
+    const log = resolveMatch({}, 3, { kind: 'use', contactKey: 'ck-1' });
+    expect(resolveMatch(log, 3, null)).toEqual({});
+  });
+
+  test('resolveMatch never mutates the log it was handed', () => {
+    const log = {};
+    resolveMatch(log, 3, { kind: 'create' });
+    expect(log).toEqual({});
+  });
+
+  test('matchDecision reads back what is in force on a row', () => {
+    expect(matchDecision({ 3: { kind: 'create' } }, 3)).toEqual({ kind: 'create' });
+    expect(matchDecision({}, 3)).toBe(null);
+  });
+
+  test('an unmatchable row cannot be resolved into existence', () => {
+    // `unmatchable` means the identity key itself is missing — no DOB, or no
+    // surname. Choosing a contact for it would be choosing on a birthday alone.
+    const decisions = resolveMatch({}, 3, { kind: 'create' });
+    const preview = build({ matches: { 3: match({ state: 'unmatchable', reason: 'no-dob' }) }, decisions });
+    expect(preview.rows[0].outcome).toBe('blocked');
+    expect(preview.rows[0].note).toMatch(/date of birth/i);
+  });
+});
+
+describe('the per-row consequence', () => {
+  test('a new student: two permanent records and the bookings', () => {
+    const preview = build();
+    expect(consequenceLine(preview.rows[0])).toBe(
+      'create a contact (permanent) · grant a School Pass (permanent) · 2 bookings (cancellable)',
+    );
+  });
+
+  test('a returning student creates nothing, and the pass is settled at Apply', () => {
+    // D4 and D14: the membership is read immediately before its own write, so
+    // the preview genuinely does not know. Saying "pass already active" here
+    // would be a claim nothing checked.
+    const preview = build({ matches: { 3: match({ state: 'matched', contact: contact() }) } });
+    expect(consequenceLine(preview.rows[0])).toBe(
+      'create nothing · pass checked at Apply · 2 bookings (cancellable)',
+    );
+  });
+
+  test('a blocked row says why instead of what it would do', () => {
+    const preview = build({ matches: { 3: match({ state: 'unmatchable', reason: 'no-surname' }) } });
+    expect(consequenceLine(preview.rows[0])).toMatch(/surname/i);
+    expect(consequenceLine(preview.rows[0])).not.toMatch(/bookings/);
+  });
+});
+
+describe('the permanence line', () => {
+  test('it counts the two permanent records apart from the cancellable one', () => {
+    const rows = [row({ key: 1 }), row({ key: 2 }), row({ key: 3 }), row({ key: 4 })];
+    const preview = build({
+      rows,
+      matches: Object.fromEntries(rows.map((r) => [r.key, match()])),
+      selection: selection({ students: 4, bookings: 8 }),
+    });
+    expect(permanenceLine(preview)).toBe(
+      'This will create 4 contacts (permanent) and 4 School Passes (permanent), '
+      + 'and make 8 bookings (cancellable).',
+    );
+  });
+
+  test('returning students are named as an unsettled pass rather than counted as one', () => {
+    const rows = [row({ key: 1 }), row({ key: 2 })];
+    const preview = build({
+      rows,
+      matches: { 1: match(), 2: match({ state: 'matched', contact: contact() }) },
+      selection: selection({ students: 2, bookings: 4 }),
+    });
+    expect(permanenceLine(preview)).toContain('create 1 contact (permanent) and 1 School Pass (permanent)');
+    expect(permanenceLine(preview)).toContain('1 returning student may also need a pass');
+  });
+
+  test('a re-run that creates nothing says exactly that', () => {
+    // D13: the preview is the guard for a deliberate re-paste. It has to be
+    // readable as "this writes nothing permanent", or the recovery path D5
+    // prescribes looks identical to a mistake.
+    const preview = build({ matches: { 3: match({ state: 'matched', contact: contact() }) } });
+    expect(permanenceLine(preview)).toContain('create no contacts and no new School Passes');
+  });
+
+  test('with nothing bookable there is no sentence to make', () => {
+    const preview = build({ matches: { 3: match({ state: 'unmatchable', reason: 'no-dob' }) } });
+    expect(permanenceLine(preview)).toBe('');
+  });
+});
+
+describe('the hard-stops before Apply lights up', () => {
+  test('a clean run is ready', () => {
+    const preview = build();
+    expect(preview.ready).toBe(true);
+    expect(preview.blockers.filter((b) => b.severity === 'block')).toEqual([]);
+  });
+
+  test('an unresolved plan is a hard-stop', () => {
+    const preview = build({ plan: { ok: false, reason: 'plan-not-found', message: 'no membership plan is named "School Pass"' } });
+    const blocker = preview.blockers.find((b) => b.kind === 'plan');
+    expect(blocker.severity).toBe('block');
+    expect(blocker.detail).toContain('no membership plan is named');
+    expect(preview.ready).toBe(false);
+  });
+
+  test('an ambiguous plan name is a hard-stop, not a first match', () => {
+    const preview = build({ plan: { ok: false, reason: 'plan-ambiguous', message: '2 membership plans are named "School Pass"' } });
+    expect(preview.blockers.some((b) => b.kind === 'plan' && b.severity === 'block')).toBe(true);
+  });
+
+  test('a plan not looked up yet is a hard-stop too', () => {
+    expect(build({ plan: null }).ready).toBe(false);
+  });
+
+  test('step 4’s blockers are carried, so Apply reads one list', () => {
+    const preview = build({
+      selection: selection({
+        ready: false,
+        blockers: [{ key: 'lead:b', kind: 'lead-time', severity: 'block', title: 'A session starts too soon to book', detail: '…', actions: [] }],
+      }),
+    });
+    expect(preview.blockers.some((b) => b.kind === 'lead-time')).toBe(true);
+    expect(preview.ready).toBe(false);
+  });
+
+  test('an unreadable plan duration warns and names the raw value, and never skips the check silently', () => {
+    const preview = build({
+      plan: plan({ plan: { ...plan().plan, membership_duration: 'a term', duration: { ok: false, raw: 'a term' }, coverage_end: null } }),
+    });
+    const warning = preview.blockers.find((b) => b.kind === 'plan-duration');
+    expect(warning.severity).toBe('warn');
+    expect(warning.detail).toContain('a term');
+    expect(preview.ready).toBe(true);
+  });
+
+  test('a last session past the pass’s coverage is a hard-stop', () => {
+    // ADR 0005: the test is *covers the last selected session*, not *active
+    // today*. Every booking is written on a day the pass is live; the shortfall
+    // surfaces weeks later at a session nobody is watching.
+    const preview = build({
+      selection: selection({ lastSession: '2027-06-01' }),
+      plan: plan(),
+    });
+    const blocker = preview.blockers.find((b) => b.kind === 'coverage');
+    expect(blocker.severity).toBe('block');
+    expect(blocker.detail).toContain('2027-02-18');
+    expect(blocker.detail).toContain('2027-06-01');
+    expect(preview.ready).toBe(false);
+  });
+
+  test('a coverage end the Worker did not send is a warning, not a silent pass', () => {
+    const preview = build({ plan: plan({ plan: { ...plan().plan, coverage_end: null } }) });
+    expect(preview.blockers.some((b) => b.kind === 'coverage-unknown' && b.severity === 'warn')).toBe(true);
+    expect(preview.ready).toBe(true);
+  });
+
+  test('a session exactly on the last covered day is allowed', () => {
+    const preview = build({ selection: selection({ lastSession: '2027-02-18' }) });
+    expect(preview.blockers.some((b) => b.kind === 'coverage')).toBe(false);
+  });
+
+  test('unresolved rows are one blocker naming them, not one blocker each', () => {
+    const rows = [row({ key: 1, firstName: 'Ada' }), row({ key: 2, firstName: 'Zoe' })];
+    const preview = build({
+      rows,
+      matches: {
+        1: match({ state: 'ambiguous', reason: 'duplicate-contacts', candidates: [contact()] }),
+        2: match({ state: 'ambiguous', reason: 'duplicate-contacts', candidates: [contact()] }),
+      },
+    });
+    const blocker = preview.blockers.find((b) => b.kind === 'unresolved-matches');
+    expect(blocker.severity).toBe('block');
+    expect(blocker.detail).toContain('Ada');
+    expect(blocker.detail).toContain('Zoe');
+  });
+
+  test('every student blocked is a hard-stop, even with sessions picked', () => {
+    const preview = build({ matches: { 3: match({ state: 'unmatchable', reason: 'no-dob' }) } });
+    expect(preview.blockers.some((b) => b.kind === 'nobody-to-book')).toBe(true);
+  });
+
+  test('the totals only count rows that would actually run', () => {
+    const rows = [row({ key: 1 }), row({ key: 2 })];
+    const preview = build({
+      rows,
+      matches: { 1: match(), 2: match({ state: 'ambiguous', reason: 'duplicate-contacts', candidates: [contact()] }) },
+      selection: selection({ students: 2, bookings: 4 }),
+    });
+    expect(preview.totals).toMatchObject({ students: 1, contacts: 1, passes: 1, bookings: 2, blocked: 1 });
+  });
+});


### PR DESCRIPTION
Closes #72. Part of #46. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md` §8, §9, §11.

Steps 4 and 5 of the gated stepper. **Still not in `tools.json`** (§17), and every route this page calls is a GET — Apply is rendered disabled, because the run engine is #73. A component test asserts both.

## What landed

Two pure modules, tested before the page could reach them:

- **`school-booking/events.js`** — what a *selection* is. §8's same-name/same-location pre-tick, D9's per-session removal, and `sessionRefusal()`: the one place deciding what is wrong with a session and how serious.
- **`school-booking/preview.js`** — the READ/CLUBWORX/OUTCOME table, the match-resolution log (name variants, ambiguous matches), the per-row consequence, the aggregate permanence line, and every hard-stop that keeps Apply dark.

All five rows of #72's hard-stop table are implemented at the stated severity.

## Three decisions worth reviewing

**The pasted event id resolves page-side.** #67 built it on `GET /events/:id`; #97 measured that route answering 404 for *every* id, real or invented — so the Worker's honest 502 carries Clubworx's `"Not Found"`, which tells a staff member their correct id is wrong. The page resolves against the window it already holds, says *not in this window*, never *not found*, and spends no request. It resolves, shows name, date and `spaces_available`, names how many existing ticks confirming will replace, and waits. `resolveEvent` is left in place unreached: #97 handed that choice to #54, and deleting it would decide the question by removing an option.

**The preview says less than §9's sketch.** That sketch reads `pass already active · 4 bookings (2 already booked)`. D4/D14 read the membership *at Apply*, and there is no bookings read on the Worker at all — so a matched row says `pass checked at Apply`, and returning students are named beside the permanence line rather than counted into it. Inventing the other two thirds would be #50's exact failure: a truthful-sounding line pointed at the wrong mechanism.

**A Worker change rode along, and it needs a deploy.** `/plan` now returns `coverage_end`, so §11's *"the last selected session falls outside today + membership_duration"* hard-stop can be checked without a second copy of the calendar arithmetic in the browser. That row is in §11 but **not** in #72's own five-row table, so flagging it as a deliberate addition rather than smuggling it. It degrades safely if deployed out of order — a missing `coverage_end` is a named warning, never a check silently skipped.

## Deploy order

`main` is production here, so **merging is deploying**. Per §17 ("the Worker before the page"):

```bash
cd cloudflare-clubworx && npx wrangler deploy   # ships coverage_end
# then merge this PR
```

Merging first is safe — the page warns rather than failing — but the coverage hard-stop stays inert until the Worker is out.

## Also fixed, from review

- The lead-time cascade existed twice and the copies disagreed: a session Clubworx reported full was painted the same red as a lead-time hard-stop, and a *null* space count got that red with no reason beside it. Root cause is the Worker's `bookable` folding "no room" in with "too close to the start". `sessionRefusal()` is now the single decision point.
- Step 3's gates now reach the preview, so a 5 → 3 → 5 walk cannot land on a stale `ready`. Any step 3 edit discards the preview outright — the match states came from reads keyed on the old rows.
- An unresolved School Pass plan stops the run *before* spending ~3 requests a student of a gym-wide allowance on answers nothing caches.
- The `?v=` guard now walks the import chain instead of naming two files. #72 put three modules into it and one, `identity.js`, arrived carrying an unversioned `./parse.js` — the exact fault the guard's own comment describes. Mutation-tested against four breaks.

## Verification

1,265 tests pass across the repo (293 in `school-booking/`, 665 in `cloudflare-clubworx/`, 217 in `vouchers/`, 81 + 9 in the two Workers). `school-booking.html` parses with no unclosed tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn