### PR TITLE
School booking step 4: the operator names the window, and the calendar is ours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,10 +100,18 @@ cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, an
                           what they found. Start with probes/README.md — it carries
                           the rules (no production data recorded, pace under
                           75 req/min) that any new probe has to follow.
-school-booking.html     - the school booking page, steps 1-5 (#71, #72): school,
-                          paste + declare the count, the parse result with
-                          inline row resolution, the session picker, and the
-                          preview. Variant A of §9, decided on #54. NOT in
+school-booking.html     - the school booking page, steps 1-5 (#71, #72, #106):
+                          school, paste + declare the count, the parse result
+                          with inline row resolution, the session picker, and
+                          the preview. Step 4 reads NOTHING until the operator
+                          names a date window and presses Search: a term-wide
+                          window is ~900 events at this gym — five requests of a
+                          gym-wide allowance and a table nobody can scan.
+                          Narrowing the dates is the only lever on that cost;
+                          the name filter is applied in the Worker's memory
+                          AFTER the walk, so it shortens the table and never the
+                          request count. The date fields are the house picker
+                          (calendar.js), not the browser's. Variant A of §9, decided on #54. NOT in
                           tools.json and unreachable from the hub until #46's
                           last step — §17's order, because `main` is production.
                           Step 6 (Apply, the run engine, the result table) is
@@ -125,6 +133,24 @@ school-booking/events.js - what a SELECTION of sessions is: the same-name,
                           window already on screen — GET /events/:id answers 404
                           for every id, real or invented (#97), so a message
                           built on it would tell staff a correct id is wrong.
+                          seriesReach() answers the cost of letting staff set
+                          the window (#106): preTicked can only tick what the
+                          window holds, so a `to` that stops mid-term books a
+                          partial series. It projects the next session from the
+                          MEDIAN gap — the lower one on a tie, so a cancelled
+                          week cannot suppress the warning — and says so when
+                          that date falls past what was actually loaded.
+school-booking/calendar.js - the month grid behind the house date picker, plus
+                          isRealDay(). roster.html draws the same calendar
+                          imperatively against live Date objects; this is the
+                          same thing as data, so Alpine can render it and the
+                          arithmetic can be tested rather than eyeballed in a
+                          dropdown. Keep the two looking identical — the .dp-*
+                          CSS is ported from roster.html, so a change belongs in
+                          both files or neither. `2026-02-30` is why isRealDay
+                          exists: it does not throw, it rolls to 2 March, and a
+                          window shifted by two days is a session missing from
+                          the picker with nothing on screen explaining it.
 school-booking/preview.js - step 5: the STUDENT/DOB/READ/CLUBWORX/OUTCOME table,
                           the match resolution log, the per-row consequence and
                           the aggregate permanence line, plus every hard-stop

--- a/school-booking.html
+++ b/school-booking.html
@@ -66,11 +66,13 @@
   import * as identity from './school-booking/identity.js?v=2';
   import * as events from './school-booking/events.js?v=2';
   import * as preview from './school-booking/preview.js?v=2';
+  import * as calendar from './school-booking/calendar.js?v=2';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
   window.schoolBookingIdentity = identity;
   window.schoolBookingEvents = events;
   window.schoolBookingPreview = preview;
+  window.schoolBookingCalendar = calendar;
 </script>
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 
@@ -172,6 +174,169 @@
 
   .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; }
   .strike { text-decoration: line-through; }
+
+  /* ── Custom calendar dropdown ──────────────────────────────────────────
+     Ported from roster.html, which draws the same calendar imperatively. The
+     look is deliberately identical — one house calendar, two pages — so the
+     values below are its values and should be changed in both or neither.
+
+     One difference: roster.html positions with `position: fixed` and
+     JS-measured coordinates, because its picker lives in a scrolling header.
+     These two sit in normal flow, so they are absolutely positioned under
+     their own trigger. That needs no measuring, and it cannot leave the panel
+     stranded away from its button when the page scrolls. */
+  .dp-dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    z-index: 40;
+    background: #fff;
+    border: 1px solid rgba(139, 28, 35, 0.14);
+    border-radius: 18px;
+    box-shadow: 0 20px 48px -16px rgba(15, 23, 42, 0.4), 0 4px 12px -4px rgba(139, 28, 35, 0.15);
+    padding: 18px;
+    width: 272px;
+    animation: dp-in 160ms ease;
+  }
+
+  @keyframes dp-in {
+    from { opacity: 0; transform: translateY(-6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .dp-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 14px;
+  }
+
+  .dp-month-label {
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: #1f2937;
+    letter-spacing: -0.01em;
+  }
+
+  .dp-nav {
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
+    border: 1px solid rgba(31, 41, 55, 0.1);
+    background: transparent;
+    color: #4b5563;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 120ms ease, color 120ms ease;
+    padding: 0;
+  }
+
+  .dp-nav:hover:not(:disabled) { background: rgba(139, 28, 35, 0.08); color: #8b1c23; }
+  .dp-nav:disabled { opacity: 0.3; cursor: default; }
+
+  .dp-weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    margin-bottom: 4px;
+  }
+
+  .dp-weekdays span {
+    text-align: center;
+    font-size: 0.68rem;
+    font-weight: 700;
+    color: #4b5563;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 0 6px;
+  }
+
+  .dp-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 2px;
+  }
+
+  .dp-day {
+    aspect-ratio: 1;
+    border-radius: 8px;
+    border: none;
+    background: transparent;
+    color: #1f2937;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    width: 100%;
+    transition: background 120ms ease, color 120ms ease;
+    line-height: 1;
+  }
+
+  .dp-day:hover:not(:disabled):not(.dp-selected) {
+    background: rgba(139, 28, 35, 0.1);
+    color: #8b1c23;
+  }
+
+  .dp-day.dp-today {
+    background: rgba(139, 28, 35, 0.1);
+    color: #8b1c23;
+    font-weight: 700;
+  }
+
+  .dp-day.dp-selected {
+    background: #8b1c23;
+    color: #fff;
+    font-weight: 700;
+  }
+
+  .dp-day.dp-today.dp-selected {
+    background: #8b1c23;
+    color: #fff;
+  }
+
+  .dp-day:disabled {
+    opacity: 0.28;
+    cursor: default;
+  }
+
+  .dp-empty { pointer-events: none; }
+
+  /* The trigger, shaped like the other fields on this step rather than like
+     roster.html's header button — same control, different background. */
+  .dp-field {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid rgba(31, 41, 55, 0.15);
+    border-radius: 12px;
+    background: #fff;
+    padding: 8px 12px;
+    font: inherit;
+    font-size: 0.875rem;
+    color: #1f2937;
+    cursor: pointer;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
+  }
+
+  .dp-field:hover { border-color: rgba(139, 28, 35, 0.35); }
+
+  .dp-field[aria-expanded="true"] {
+    border-color: #8b1c23;
+    box-shadow: 0 0 0 3px rgba(139, 28, 35, 0.12);
+  }
+
+  .dp-field svg { width: 15px; height: 15px; opacity: 0.55; flex-shrink: 0; }
+  .dp-field .dp-value { font-variant-numeric: tabular-nums; }
+  .dp-field .dp-unset { color: #9ca3af; }
+
+  .dp-anchor { position: relative; display: inline-block; }
 
   .row-hit { cursor: pointer; }
   .row-hit:hover { background: rgba(139, 28, 35, 0.025); }
@@ -659,16 +824,84 @@
              "everything"), and the name filter runs Worker-side over the walked
              rows because no name parameter on /events has ever been measured. -->
         <div class="flex items-end gap-3 flex-wrap mb-4">
-          <label class="block">
-            <span class="field-label">From</span>
-            <input type="date" x-model="eventsFrom"
-                   class="rounded-xl border border-neutral-200 px-3 py-2 text-sm mono">
-          </label>
-          <label class="block">
-            <span class="field-label">To</span>
-            <input type="date" x-model="eventsTo"
-                   class="rounded-xl border border-neutral-200 px-3 py-2 text-sm mono">
-          </label>
+          <div class="block">
+            <span class="field-label">First session on or after</span>
+            <div class="dp-anchor" @click.outside="closeDatePicker()">
+              <button type="button" class="dp-field"
+                      :aria-expanded="datePicker === 'from' ? 'true' : 'false'"
+                      aria-haspopup="dialog"
+                      aria-label="Choose the first date to search from"
+                      @click="toggleDatePicker('from')">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                <span class="dp-value" :class="dayFor('from') ? '' : 'dp-unset'"
+                      x-text="dayLabel(dayFor('from'))"></span>
+              </button>
+
+              <div class="dp-dropdown" x-show="datePicker === 'from'" x-cloak
+                   role="dialog" aria-label="Choose the first date to search from">
+                <div class="dp-header">
+                  <button type="button" class="dp-nav" aria-label="Previous month"
+                          @click="stepMonth(-1)">&#8592;</button>
+                  <span class="dp-month-label" x-text="monthLabel()"></span>
+                  <button type="button" class="dp-nav" aria-label="Next month"
+                          @click="stepMonth(1)">&#8594;</button>
+                </div>
+                <div class="dp-weekdays">
+                  <span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span>
+                </div>
+                <div class="dp-grid">
+                  <template x-for="cell in monthCells()" :key="cell.key">
+                    <button type="button"
+                            :class="cell.empty ? 'dp-day dp-empty' : 'dp-day' + (cell.selected ? ' dp-selected' : cell.today ? ' dp-today' : '')"
+                            :disabled="cell.disabled"
+                            :aria-label="cell.label"
+                            :aria-current="cell.selected ? 'date' : false"
+                            @click="cell.empty || pickDay(cell.iso)"
+                            x-text="cell.day"></button>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="block">
+            <span class="field-label">Last session on or before</span>
+            <div class="dp-anchor" @click.outside="closeDatePicker()">
+              <button type="button" class="dp-field"
+                      :aria-expanded="datePicker === 'to' ? 'true' : 'false'"
+                      aria-haspopup="dialog"
+                      aria-label="Choose the last date to search to"
+                      @click="toggleDatePicker('to')">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                <span class="dp-value" :class="dayFor('to') ? '' : 'dp-unset'"
+                      x-text="dayLabel(dayFor('to'))"></span>
+              </button>
+
+              <div class="dp-dropdown" x-show="datePicker === 'to'" x-cloak
+                   role="dialog" aria-label="Choose the last date to search to">
+                <div class="dp-header">
+                  <button type="button" class="dp-nav" aria-label="Previous month"
+                          @click="stepMonth(-1)">&#8592;</button>
+                  <span class="dp-month-label" x-text="monthLabel()"></span>
+                  <button type="button" class="dp-nav" aria-label="Next month"
+                          @click="stepMonth(1)">&#8594;</button>
+                </div>
+                <div class="dp-weekdays">
+                  <span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span>
+                </div>
+                <div class="dp-grid">
+                  <template x-for="cell in monthCells()" :key="cell.key">
+                    <button type="button"
+                            :class="cell.empty ? 'dp-day dp-empty' : 'dp-day' + (cell.selected ? ' dp-selected' : cell.today ? ' dp-today' : '')"
+                            :disabled="cell.disabled"
+                            :aria-label="cell.label"
+                            :aria-current="cell.selected ? 'date' : false"
+                            @click="cell.empty || pickDay(cell.iso)"
+                            x-text="cell.day"></button>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </div>
           <label class="block flex-1 min-w-[200px]">
             <span class="field-label">Session name contains</span>
             <input type="text" x-model="eventsQuery" placeholder="e.g. the school's name"
@@ -687,7 +920,12 @@
              already loaded, NOT against Clubworx: GET /events/:id answers 404
              for every id, real or invented (#97), so the Worker cannot tell a
              good id from a bad one and neither can a message built on it. -->
-        <div class="rounded-xl bg-neutral-50 border border-neutral-200 px-3.5 py-2.5 mb-4">
+        <!-- Shown only once there is a window to resolve against. The id is
+             matched page-side (see events.js), so before the first search this
+             control cannot succeed — and an affordance that can only fail is
+             one somebody tries at the moment they most need it to work. -->
+        <div class="rounded-xl bg-neutral-50 border border-neutral-200 px-3.5 py-2.5 mb-4"
+             x-show="events.length > 0" x-cloak>
           <div class="flex items-end gap-2 flex-wrap">
             <label class="block flex-1 min-w-[200px]">
               <span class="field-label">Or paste a Clubworx event id</span>
@@ -762,7 +1000,13 @@
           </div>
         </div>
 
+        <!-- The multiplication, once there is one to state. With nothing picked
+             this said "No sessions picked yet." directly above a blocker saying
+             "No sessions picked" — the same two-banners-one-message fault #71
+             fixed on the count. The blocker owns that sentence; this owns the
+             arithmetic. -->
         <div class="rounded-xl px-3.5 py-2.5 text-sm mt-4"
+             x-show="selection.sessions > 0" x-cloak
              :class="selection.ready ? 'bg-emerald-50 border border-emerald-200 text-emerald-800' : 'bg-neutral-50 border border-neutral-200 text-neutral-600'">
           <span x-text="sessionsLine()"></span>
         </div>
@@ -1003,6 +1247,14 @@ function schoolBooking() {
     eventsFrom: '',
     eventsTo: '',
     eventsQuery: '',
+    // The window the events on screen actually came from. Distinct from the two
+    // boxes above, which staff may have edited since.
+    loadedFrom: '',
+    loadedTo: '',
+    // Which date picker is open: 'from', 'to', or nothing.
+    datePicker: null,
+    dpYear: new Date().getFullYear(),
+    dpMonth: new Date().getMonth(),
     pastedEventId: '',
     pastedIdNote: '',
     pastedIdOk: false,
@@ -1040,6 +1292,7 @@ function schoolBooking() {
       if (!window.schoolBookingIdentity?.matchStudent) missing.push('the matching rule');
       if (!window.schoolBookingEvents?.selectionReport) missing.push('the session rules');
       if (!window.schoolBookingPreview?.buildPreview) missing.push('the preview rules');
+      if (!window.schoolBookingCalendar?.monthGrid) missing.push('the calendar');
       if (missing.length) {
         this.bootstrapError = `Could not load ${missing.join(' and ')}.`;
         return;
@@ -1460,10 +1713,103 @@ function schoolBooking() {
     // The picker's window is a request parameter, not a filter: Clubworx
     // refuses `/events` with no date window (422, empty body — #51), so there
     // is no "everything" to fall back to and the page always has to name one.
+    // --- the house date picker -------------------------------------------
+    // roster.html draws this calendar imperatively against live Date objects,
+    // which suits a page with one picker and no framework. This page has two
+    // and Alpine, so the grid is a value from calendar.js and the markup is an
+    // x-for over it. `datePicker` holds which one is open — a string, never a
+    // function, so nothing here can be invoked by being rendered (§16).
+    toggleDatePicker(which) {
+      if (this.datePicker === which) {
+        this.closeDatePicker();
+        return;
+      }
+      this.datePicker = which;
+      // Open on the month already chosen, so a picker reopened does not throw
+      // away where the last visit left it. Falling back to today rather than to
+      // an empty month, which would open on January 1970.
+      const on = window.schoolBookingCalendar.monthOf(this.dayFor(which))
+        ?? window.schoolBookingCalendar.monthOf(this.todayDay());
+      this.dpYear = on?.year ?? new Date().getFullYear();
+      this.dpMonth = on?.month ?? new Date().getMonth();
+    },
+
+    closeDatePicker() {
+      this.datePicker = null;
+    },
+
+    dayFor(which) {
+      return which === 'from' ? this.eventsFrom : this.eventsTo;
+    },
+
+    todayDay() {
+      return window.schoolBookingCalendar.todayInPerth() ?? '';
+    },
+
+    stepMonth(delta) {
+      const next = window.schoolBookingCalendar.shiftMonth(this.dpYear, this.dpMonth, delta);
+      this.dpYear = next.year;
+      this.dpMonth = next.month;
+    },
+
+    monthLabel() {
+      return window.schoolBookingCalendar.monthLabel(this.dpYear, this.dpMonth);
+    },
+
+    // The two pickers bound each other: `from` cannot be set past `to`, and
+    // `to` cannot be set before `from`. That is what keeps a backwards window
+    // from being reachable by clicking, rather than only refused afterwards by
+    // canSearch() with nothing saying which end to move.
+    monthCells() {
+      const which = this.datePicker;
+      if (!which) return [];
+      return window.schoolBookingCalendar.monthGrid(this.dpYear, this.dpMonth, {
+        selected: this.dayFor(which),
+        today: this.todayDay(),
+        min: which === 'to' ? this.eventsFrom : '',
+        max: which === 'from' ? this.eventsTo : '',
+      });
+    },
+
+    pickDay(day) {
+      if (!day) return;
+      if (this.datePicker === 'from') this.eventsFrom = day;
+      else if (this.datePicker === 'to') this.eventsTo = day;
+      this.closeDatePicker();
+    },
+
+    // `Fri 21 Aug 2026` — a written date, because a picker that shows an ISO
+    // string is a text box wearing a calendar. The ISO form is what travels to
+    // the Worker; it is not what a human confirms a term against.
+    dayLabel(day) {
+      if (!window.schoolBookingCalendar.isRealDay(day)) return 'Choose a date';
+      return new Date(`${day}T00:00:00Z`).toLocaleDateString('en-AU', {
+        weekday: 'short', day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC',
+      });
+    },
+
+    // Two real days, in order. Checked here rather than met as the Worker's own
+    // refusal: `/events` answers 422 for a bad window (#51), and "from and to
+    // are required, each as a real YYYY-MM-DD day" is a sentence about a field
+    // an operator cannot see. `2026-02-30` is the one worth naming — it does
+    // not error anywhere, it rolls forward, so a window silently shifted by a
+    // day is a session missing from the picker with nothing to explain it.
+    canSearch() {
+      return window.schoolBookingCalendar.isRealDay(this.eventsFrom)
+        && window.schoolBookingCalendar.isRealDay(this.eventsTo)
+        && this.eventsFrom <= this.eventsTo;
+    },
+
     async loadEvents() {
+      if (!this.canSearch()) return;
       this.eventsState = 'loading';
       this.pastedIdNote = '';
-      const params = new URLSearchParams({ from: this.eventsFrom, to: this.eventsTo });
+      // Pinned before the await: the boxes are editable while this is in
+      // flight, so reading them afterwards would record a window that was
+      // never requested.
+      const from = this.eventsFrom;
+      const to = this.eventsTo;
+      const params = new URLSearchParams({ from, to });
       if (this.eventsQuery.trim()) params.set('q', this.eventsQuery.trim());
       try {
         const res = await fetch(`/api/clubworx/events?${params}`, { headers: { accept: 'application/json' } });
@@ -1473,6 +1819,8 @@ function schoolBooking() {
         this.eventsTotal = body.total ?? this.events.length;
         this.eventsTruncated = body.truncated === true;
         this.eventsState = 'ready';
+        this.loadedFrom = from;
+        this.loadedTo = to;
         // A tick pointing at a session this window no longer holds is a tick
         // nobody can see. Dropped rather than carried: `selectionReport` would
         // drop it anyway, and a count that disagrees with the table is how a
@@ -1485,6 +1833,8 @@ function schoolBooking() {
         this.eventsTruncated = false;
         this.eventsState = 'error';
         this.eventsError = String(error.message || error);
+        this.loadedFrom = '';
+        this.loadedTo = '';
       }
       this.refreshSelection();
     },
@@ -1610,6 +1960,10 @@ function schoolBooking() {
         selected: this.picked,
         studentCount: this.reviewed?.counts.records ?? 0,
         truncated: this.eventsTruncated,
+        // The window that was actually *read*, not the one in the boxes. Staff
+        // edit the dates without pressing Search, and a series checked against
+        // dates nobody loaded would clear the warning by typing.
+        windowTo: this.loadedTo,
       });
     },
 
@@ -1625,13 +1979,22 @@ function schoolBooking() {
       if (action.answers === 'remove') this.togglePick(action.value);
     },
 
+    // The dates are seeded and the read waits. A term-wide window is ~900
+    // events at this gym: five requests of an allowance the whole gym shares,
+    // spent on arrival before anybody has said what they want, and a table far
+    // too long to scan. Narrowing the dates is also the *only* lever that
+    // reduces that cost — the name filter is applied in the Worker's memory
+    // after the walk (see listEvents), so it shortens the table and not the
+    // request count.
+    //
+    // Seeded rather than blank: two empty date boxes on every visit is a toll
+    // paid by everyone to save a click for nobody.
     toSessions() {
       if (!this.reviewed?.ready) return;
-      if (this.eventsState === 'idle') {
-        const window_ = window.schoolBookingEvents.defaultWindow();
-        this.eventsFrom = window_.from;
-        this.eventsTo = window_.to;
-        this.loadEvents();
+      if (this.eventsState === 'idle' && !this.eventsFrom) {
+        const opening = window.schoolBookingEvents.defaultWindow();
+        this.eventsFrom = opening.from;
+        this.eventsTo = opening.to;
       }
       this.refreshSelection();
       this.go(3);

--- a/school-booking/calendar.js
+++ b/school-booking/calendar.js
@@ -1,0 +1,152 @@
+// school-booking/calendar.js
+//
+// The month grid behind the house date picker, as data. The page imports this
+// and publishes it as `window.schoolBookingCalendar`.
+//
+// staff-site#106.
+//
+// ---------------------------------------------------------------------------
+// Why the page does not use `<input type="date">`
+// ---------------------------------------------------------------------------
+// The browser's own picker is a different control in every browser and on every
+// platform, and none of them look like this site. `roster.html` already draws a
+// house calendar — the `.dp-*` block in its stylesheet — so the school booking
+// page draws the same one, and this module is the half of it that can be tested.
+//
+// roster.html builds its grid imperatively against live `Date` objects. That
+// suits a page with one picker and no framework; this page has two pickers and
+// Alpine, so the grid is a value here and the markup is an `x-for` over it.
+// Nothing this module returns is ever a function — the same rule steps.js keeps,
+// for the same reason (§16).
+//
+// ---------------------------------------------------------------------------
+// Everything is a `YYYY-MM-DD` day, and the arithmetic is UTC
+// ---------------------------------------------------------------------------
+// A day is what the Worker wants (`/events` refuses a window that is not two
+// real days) and a day is what the picker shows, so a day is the only type that
+// travels. Building the grid in UTC keeps a cell from shifting under a machine
+// in a different timezone; only `todayInPerth` looks at a clock, and it looks at
+// Perth's because that is where the gym is.
+
+// Same constant and the same reasoning as events.js. Neither file can import
+// the Worker's `duration.js` — that module ships with the Worker.
+const AWST_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+const DAY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Is this a real calendar day, written `YYYY-MM-DD`?
+ *
+ * The rollover is the whole point. `new Date('2026-02-30')` does not throw — it
+ * quietly becomes 2 March — so a date that cannot exist reaches the Worker as a
+ * window shifted by two days, and the sessions that go missing from the picker
+ * have nothing on screen to explain them. Parsing and then checking the parts
+ * came back unchanged is what catches it.
+ */
+export function isRealDay(value) {
+  const match = DAY.exec(String(value ?? ''));
+  if (!match) return false;
+
+  const [, year, month, day] = match.map(Number);
+  const at = new Date(Date.UTC(year, month - 1, day));
+
+  return at.getUTCFullYear() === year
+    && at.getUTCMonth() === month - 1
+    && at.getUTCDate() === day;
+}
+
+/**
+ * The month a day falls in, or null when the day is not one.
+ *
+ * `month` counts from **zero**, matching `Date.prototype.getMonth` and the grid
+ * roster.html builds. One calendar on this site counting from 0 and another
+ * from 1 is an off-by-one waiting for whoever copies between them.
+ */
+export function monthOf(day) {
+  if (!isRealDay(day)) return null;
+  const [, year, month] = DAY.exec(day).map(Number);
+  return { year, month: month - 1 };
+}
+
+/** Walk `delta` months, rolling the year at both ends. */
+export function shiftMonth(year, month, delta) {
+  const at = new Date(Date.UTC(year, month + delta, 1));
+  return { year: at.getUTCFullYear(), month: at.getUTCMonth() };
+}
+
+/** `August 2026`, in Australian English. */
+export function monthLabel(year, month) {
+  return new Date(Date.UTC(year, month, 1))
+    .toLocaleDateString('en-AU', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+}
+
+/** The calendar day an instant falls on **in Perth**, or null if it cannot be read. */
+export function todayInPerth(now = new Date()) {
+  const at = now instanceof Date ? now : new Date(now);
+  if (Number.isNaN(at.getTime())) return null;
+  return new Date(at.getTime() + AWST_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+const iso = (year, month, day) =>
+  `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+/**
+ * One month, as a Monday-first grid of cells.
+ *
+ * Leading blanks come first so the columns line up under Mo–Su, matching the
+ * house calendar. A blank carries nothing to click or read: it is `disabled`
+ * and its `iso` is null, so markup that forgets to check `empty` still cannot
+ * select one.
+ *
+ * `min`/`max` are **inclusive** at both ends — they are days, not a half-open
+ * range, and a picker that quietly excludes its own last day is the kind of
+ * fault nobody reports because it looks like the date simply was not there.
+ *
+ * @param {number} year
+ * @param {number} month Counting from zero — see monthOf.
+ * @param {{selected?: string, today?: string, min?: string, max?: string}} [opts]
+ * @returns {Array<{key: string, day: number|null, iso: string|null, empty: boolean,
+ *                  selected: boolean, today: boolean, disabled: boolean, label: string}>}
+ */
+export function monthGrid(year, month, { selected, today, min, max } = {}) {
+  // Monday = 0. `getUTCDay` puts Sunday at 0, so the shift is +6 mod 7.
+  const firstDayOfWeek = (new Date(Date.UTC(year, month, 1)).getUTCDay() + 6) % 7;
+  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+
+  const cells = [];
+
+  for (let i = 0; i < firstDayOfWeek; i += 1) {
+    cells.push({
+      // Keyed, because Alpine needs one per cell and two blanks are otherwise
+      // indistinguishable — a duplicate key silently drops a cell from an x-for.
+      key: `blank-${i}`,
+      day: null,
+      iso: null,
+      empty: true,
+      selected: false,
+      today: false,
+      disabled: true,
+      label: '',
+    });
+  }
+
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const value = iso(year, month, day);
+    cells.push({
+      key: value,
+      day,
+      iso: value,
+      empty: false,
+      selected: value === selected,
+      today: value === today,
+      disabled: (isRealDay(min) && value < min) || (isRealDay(max) && value > max),
+      // A bare number is not a label. Screen readers read the button, and "21"
+      // on its own says nothing about which month is open.
+      label: new Date(`${value}T00:00:00Z`).toLocaleDateString('en-AU', {
+        weekday: 'long', day: 'numeric', month: 'long', timeZone: 'UTC',
+      }),
+    });
+  }
+
+  return cells;
+}

--- a/school-booking/events.js
+++ b/school-booking/events.js
@@ -43,10 +43,20 @@
 // are different problems with different fixes — widen the window, or check the
 // id — and the second sends staff to correct something that is already correct.
 
-// The picker's opening window. A term, near enough: the tool is used to book a
-// school's term of sessions, and a window this wide holds one comfortably while
-// staying far short of `MAX_PAGES` in the Worker.
-const WINDOW_DAYS = 90;
+// The picker's opening window — a fortnight, and deliberately not a term.
+//
+// Nothing loads until the operator presses Search, so this is a *starting
+// point* they widen to the last session, not a guess at the run. It is short
+// because the cheap thing has to be the default one: a term-wide window is
+// ~900 events at this gym, five requests of a gym-wide allowance and a table
+// nobody can scan, and a default that expensive is one an operator pays for
+// every time they arrive at this step without meaning to.
+//
+// Narrowing the dates is also the *only* lever on that cost. The name filter
+// runs in the Worker's memory after the window has been walked (listEvents, and
+// the paragraph there explains why it is not sent upstream), so it shortens the
+// table and never the request count.
+const WINDOW_DAYS = 14;
 
 // Everything this system does is in Perth, so the run day is the Perth day.
 // Same constant and the same reasoning as `cloudflare-clubworx/src/duration.js`;
@@ -290,8 +300,9 @@ const removal = (event) => ({
  * @param {Array<string>} opts.selected Ticked event ids.
  * @param {number} opts.studentCount Students the run would book.
  * @param {boolean} [opts.truncated] Whether the Worker said it could not read the window to the end.
+ * @param {string} [opts.windowTo] The last day loaded, so a series running past it can be named.
  */
-export function selectionReport({ events, selected, studentCount = 0, truncated = false } = {}) {
+export function selectionReport({ events, selected, studentCount = 0, truncated = false, windowTo = '' } = {}) {
   const picked = selectedEvents(events, selected);
   const blockers = [];
 
@@ -351,6 +362,18 @@ export function selectionReport({ events, selected, studentCount = 0, truncated 
     }
   }
 
+  const reach = seriesReach({ events, selected, windowTo });
+  if (!reach.complete) {
+    blockers.push({
+      key: 'series-reach',
+      kind: 'series-reach',
+      severity: 'warn',
+      title: 'This series may run past the dates loaded',
+      detail: reach.message,
+      actions: [],
+    });
+  }
+
   if (truncated) {
     blockers.push({
       key: 'truncated',
@@ -376,6 +399,67 @@ export function selectionReport({ events, selected, studentCount = 0, truncated 
     // What the pass has to cover (§10 D4, ADR 0005) — the **last** selected
     // session, not today.
     lastSession: days[days.length - 1] ?? null,
+  };
+}
+
+/**
+ * Could the ticked series continue past the dates that were loaded?
+ *
+ * Nothing loads until the operator names a window, so the window is theirs to
+ * get wrong — and `preTicked` can only tick what the window holds. A `to` that
+ * stops mid-term therefore books a partial series, silently, which is the one
+ * thing deferring the load makes *worse* rather than better.
+ *
+ * The projection is the honest form of the question. Two ticked sessions give
+ * an interval, so the next one in the series is predictable; if that date falls
+ * **inside** the loaded window then the walk would have found it, and its
+ * absence is evidence the series has ended. If it falls **past** the window, the
+ * walk never looked there and nothing on this page knows either way.
+ *
+ * The **median** gap, not the last one: a cancelled week leaves a 14-day hole,
+ * and projecting from that alone pushes the expectation a fortnight out and
+ * hides a real edge.
+ *
+ * One session is not a series. With no interval there is nothing to project,
+ * and inventing one would warn about a session nobody has evidence for.
+ *
+ * @returns {{complete: boolean, nextExpected: string|null, message: string}}
+ */
+export function seriesReach({ events, selected, windowTo } = {}) {
+  const settled = { complete: true, nextExpected: null, message: '' };
+
+  const picked = selectedEvents(events, selected);
+  if (picked.length < 2 || !windowTo) return settled;
+
+  const days = picked.map((e) => perthDay(e.event_start_at)).filter(Boolean);
+  if (days.length < 2) return settled;
+
+  const gaps = [];
+  for (let i = 1; i < days.length; i += 1) {
+    gaps.push(Math.round((Date.parse(`${days[i]}T00:00:00Z`) - Date.parse(`${days[i - 1]}T00:00:00Z`)) / 86_400_000));
+  }
+  gaps.sort((a, b) => a - b);
+  // The **lower** middle on an even count, which is the safe direction: a
+  // shorter gap projects the next session sooner, so the doubt is raised rather
+  // than suppressed. Taking the upper middle lets one cancelled week — a single
+  // 14-day hole among sevens — push the expectation past the window edge and
+  // silence the warning at exactly the moment it is right.
+  const gap = gaps[Math.floor((gaps.length - 1) / 2)];
+  if (!Number.isFinite(gap) || gap <= 0) return settled;
+
+  const last = days[days.length - 1];
+  const next = new Date(`${last}T00:00:00Z`);
+  next.setUTCDate(next.getUTCDate() + gap);
+  const nextExpected = next.toISOString().slice(0, 10);
+
+  if (nextExpected <= windowTo) return settled;
+
+  return {
+    complete: false,
+    nextExpected,
+    message: `If this series runs on, the next session would be about ${nextExpected} — past `
+      + `${windowTo}, the last date loaded. Widen the dates and search again to be sure the whole `
+      + 'term is ticked.',
   };
 }
 

--- a/school-booking/test/calendar.test.js
+++ b/school-booking/test/calendar.test.js
@@ -1,0 +1,144 @@
+// The month grid behind the house date picker, without a DOM.
+//
+// staff-site#106. roster.html draws the same calendar imperatively; this is the
+// same shape as data, so the school booking page can render it with Alpine and
+// the arithmetic can be tested rather than eyeballed in a dropdown.
+
+import { describe, expect, test } from 'vitest';
+import { isRealDay, monthGrid, monthLabel, monthOf, shiftMonth, todayInPerth } from '../calendar.js';
+
+const days = (grid) => grid.filter((cell) => !cell.empty);
+
+describe('isRealDay', () => {
+  test('a real day passes', () => {
+    expect(isRealDay('2026-08-21')).toBe(true);
+    expect(isRealDay('2024-02-29')).toBe(true); // a leap year
+  });
+
+  test('a day that does not exist is refused rather than rolled forward', () => {
+    // The one worth naming: `new Date('2026-02-30')` does not throw, it rolls
+    // to 2 March. A window silently shifted by two days is a session missing
+    // from the picker with nothing on screen to explain it.
+    expect(isRealDay('2026-02-30')).toBe(false);
+    expect(isRealDay('2026-13-01')).toBe(false);
+    expect(isRealDay('2025-02-29')).toBe(false); // not a leap year
+  });
+
+  test('anything that is not a YYYY-MM-DD day is refused', () => {
+    expect(isRealDay('')).toBe(false);
+    expect(isRealDay(null)).toBe(false);
+    expect(isRealDay('21/08/2026')).toBe(false);
+    expect(isRealDay('2026-8-21')).toBe(false);
+    expect(isRealDay('2026-08-21T09:00:00Z')).toBe(false);
+  });
+});
+
+describe('monthOf', () => {
+  test('it reads the month a day belongs to, counting months from zero', () => {
+    // Zero-based to match `Date.prototype.getMonth`, which is what roster.html
+    // uses — one calendar counting from 0 and another from 1 on the same site
+    // is an off-by-one waiting for whoever copies between them.
+    expect(monthOf('2026-08-21')).toEqual({ year: 2026, month: 7 });
+  });
+
+  test('a day it cannot read gets null, not a guess', () => {
+    expect(monthOf('nonsense')).toBe(null);
+    expect(monthOf('2026-02-30')).toBe(null);
+  });
+});
+
+describe('shiftMonth', () => {
+  test('it walks forward and back', () => {
+    expect(shiftMonth(2026, 7, 1)).toEqual({ year: 2026, month: 8 });
+    expect(shiftMonth(2026, 7, -1)).toEqual({ year: 2026, month: 6 });
+  });
+
+  test('it rolls the year at both ends', () => {
+    expect(shiftMonth(2026, 11, 1)).toEqual({ year: 2027, month: 0 });
+    expect(shiftMonth(2026, 0, -1)).toEqual({ year: 2025, month: 11 });
+  });
+});
+
+describe('monthLabel', () => {
+  test('it names the month and year', () => {
+    expect(monthLabel(2026, 7)).toBe('August 2026');
+    expect(monthLabel(2027, 0)).toBe('January 2027');
+  });
+});
+
+describe('monthGrid', () => {
+  test('it starts on Monday, so the leading blanks match the house calendar', () => {
+    // 1 August 2026 is a Saturday, so Mon–Fri lead in as blanks.
+    const grid = monthGrid(2026, 7, {});
+    expect(grid.slice(0, 5).every((cell) => cell.empty)).toBe(true);
+    expect(grid[5]).toMatchObject({ day: 1, iso: '2026-08-01' });
+  });
+
+  test('a month starting on a Monday has no leading blanks', () => {
+    // 1 June 2026 is a Monday.
+    expect(monthGrid(2026, 5, {})[0]).toMatchObject({ day: 1, iso: '2026-06-01' });
+  });
+
+  test('it holds every day of the month, and no more', () => {
+    expect(days(monthGrid(2026, 7, {}))).toHaveLength(31); // August
+    expect(days(monthGrid(2026, 8, {}))).toHaveLength(30); // September
+    expect(days(monthGrid(2026, 1, {}))).toHaveLength(28); // February 2026
+    expect(days(monthGrid(2024, 1, {}))).toHaveLength(29); // February 2024, leap
+  });
+
+  test('the selected day and today are marked apart', () => {
+    const grid = monthGrid(2026, 7, { selected: '2026-08-21', today: '2026-08-14' });
+    const find = (iso) => grid.find((cell) => cell.iso === iso);
+    expect(find('2026-08-21')).toMatchObject({ selected: true, today: false });
+    expect(find('2026-08-14')).toMatchObject({ selected: false, today: true });
+    expect(find('2026-08-01')).toMatchObject({ selected: false, today: false });
+  });
+
+  test('a day can be both today and selected', () => {
+    const grid = monthGrid(2026, 7, { selected: '2026-08-21', today: '2026-08-21' });
+    expect(grid.find((c) => c.iso === '2026-08-21')).toMatchObject({ selected: true, today: true });
+  });
+
+  test('days outside min and max are disabled, inclusive at both ends', () => {
+    const grid = monthGrid(2026, 7, { min: '2026-08-10', max: '2026-08-20' });
+    const at = (iso) => grid.find((cell) => cell.iso === iso).disabled;
+    expect(at('2026-08-09')).toBe(true);
+    expect(at('2026-08-10')).toBe(false);
+    expect(at('2026-08-20')).toBe(false);
+    expect(at('2026-08-21')).toBe(true);
+  });
+
+  test('no bounds means no day is disabled', () => {
+    // The blanks stay disabled either way — see the cell shape. This is about
+    // the days.
+    expect(days(monthGrid(2026, 7, {})).some((cell) => cell.disabled)).toBe(false);
+  });
+
+  test('every day carries a spoken label, because a bare number is not one', () => {
+    const grid = monthGrid(2026, 7, {});
+    expect(grid.find((cell) => cell.iso === '2026-08-21').label).toBe('Friday 21 August');
+  });
+
+  test('the blanks carry nothing to click or read', () => {
+    const blank = monthGrid(2026, 7, {})[0];
+    expect(blank).toMatchObject({ empty: true, iso: null, day: null, disabled: true });
+  });
+
+  test('grid cells are unique by key, so a re-render cannot duplicate a day', () => {
+    const grid = monthGrid(2026, 7, {});
+    expect(new Set(grid.map((cell) => cell.key)).size).toBe(grid.length);
+  });
+});
+
+describe('todayInPerth', () => {
+  test('it reads the Perth day, not the UTC one', () => {
+    // 23:30 UTC on the 21st is 07:30 on the 22nd in Perth. A picker opening on
+    // the UTC day marks the wrong cell "today" for eight hours of every day.
+    expect(todayInPerth('2026-08-21T23:30:00Z')).toBe('2026-08-22');
+    expect(todayInPerth('2026-08-21T14:00:00+08:00')).toBe('2026-08-21');
+  });
+
+  test('an unreadable instant gets null rather than a wrong day', () => {
+    expect(todayInPerth('not a date')).toBe(null);
+  });
+});

--- a/school-booking/test/events.test.js
+++ b/school-booking/test/events.test.js
@@ -14,6 +14,7 @@ import {
   resolvePastedId,
   selectedEvents,
   selectionReport,
+  seriesReach,
   sessionsLine,
 } from '../events.js';
 
@@ -34,10 +35,12 @@ const event = (over = {}) => ({
 });
 
 describe('defaultWindow', () => {
-  test('it opens on the run day and runs a term ahead', () => {
+  test('it opens on the run day and offers a fortnight to widen from', () => {
+    // A starting point, not a guess at the run: nothing loads until Search is
+    // pressed, so the default's job is to be cheap if it is left alone.
     expect(defaultWindow('2026-08-21T14:00:00+08:00')).toEqual({
       from: '2026-08-21',
-      to: '2026-11-19',
+      to: '2026-09-04',
     });
   });
 
@@ -368,5 +371,71 @@ describe('the picker and the report agree about severity', () => {
     const report = selectionReport({ events: [soon], selected: ['s'], studentCount: 6 });
     expect(report.ready).toBe(false);
     expect(sessionRefusal(soon).severity).toBe('block');
+  });
+});
+
+describe('seriesReach — a hand-set window can cut a series in half', () => {
+  // Nothing loads until the operator names the dates, so the window is now
+  // theirs to get wrong. `preTicked` can only tick what the window holds, so a
+  // `to` that stops mid-term books a partial series with nothing on screen
+  // saying so. This is the something.
+  const weekly = (id, day) => event({
+    event_id: id,
+    event_start_at: `2026-09-${day}T09:00:00+08:00`,
+  });
+
+  test('a series whose next session would be inside the window is complete', () => {
+    // Ticked 1st and 8th, window runs to the 30th. If a 15th existed the walk
+    // would have found it, so its absence is evidence rather than a blind spot.
+    const events = [weekly('a', '01'), weekly('b', '08')];
+    expect(seriesReach({ events, selected: ['a', 'b'], windowTo: '2026-09-30' }))
+      .toMatchObject({ complete: true });
+  });
+
+  test('a series running up to the window edge warns, and names the date it cannot see', () => {
+    const events = [weekly('a', '15'), weekly('b', '22'), weekly('c', '29')];
+    const reach = seriesReach({ events, selected: ['a', 'b', 'c'], windowTo: '2026-09-30' });
+    expect(reach.complete).toBe(false);
+    expect(reach.nextExpected).toBe('2026-10-06');
+    expect(reach.message).toContain('2026-10-06');
+    expect(reach.message).toMatch(/widen/i);
+  });
+
+  test('it is a warning, never a block', () => {
+    const events = [weekly('a', '22'), weekly('b', '29')];
+    const report = selectionReport({
+      events, selected: ['a', 'b'], studentCount: 6, windowTo: '2026-09-30',
+    });
+    const warning = report.blockers.find((b) => b.kind === 'series-reach');
+    expect(warning.severity).toBe('warn');
+    expect(report.ready).toBe(true);
+  });
+
+  test('one session is not a series, so nothing is projected from it', () => {
+    // With a single tick there is no interval to project, and inventing one
+    // would warn about a session nobody has evidence for.
+    const events = [weekly('a', '29')];
+    expect(seriesReach({ events, selected: ['a'], windowTo: '2026-09-30' }))
+      .toMatchObject({ complete: true, nextExpected: null });
+  });
+
+  test('nothing ticked says nothing', () => {
+    expect(seriesReach({ events: [weekly('a', '01')], selected: [], windowTo: '2026-09-30' }))
+      .toMatchObject({ complete: true });
+  });
+
+  test('an uneven spacing uses the median gap rather than the last one', () => {
+    // A cancelled week leaves a 14-day hole. Projecting from the last gap
+    // alone would push the expectation a fortnight out and hide a real edge.
+    const events = [weekly('a', '01'), weekly('b', '08'), weekly('c', '22')];
+    const reach = seriesReach({ events, selected: ['a', 'b', 'c'], windowTo: '2026-09-25' });
+    expect(reach.nextExpected).toBe('2026-09-29'); // 22nd + 7, not + 14
+    expect(reach.complete).toBe(false);
+  });
+
+  test('no window end means nothing to be past', () => {
+    const events = [weekly('a', '22'), weekly('b', '29')];
+    expect(seriesReach({ events, selected: ['a', 'b'], windowTo: '' }))
+      .toMatchObject({ complete: true });
   });
 });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -17,6 +17,7 @@ import * as steps from '../steps.js';
 import * as identity from '../identity.js';
 import * as events from '../events.js';
 import * as preview from '../preview.js';
+import * as calendar from '../calendar.js';
 
 const html = readFileSync(new URL('../../school-booking.html', import.meta.url), 'utf8');
 const fixture = (name) =>
@@ -96,6 +97,7 @@ function component({
     schoolBookingIdentity: identity,
     schoolBookingEvents: events,
     schoolBookingPreview: preview,
+    schoolBookingCalendar: calendar,
   };
   globalThis.fetch = vi.fn(async (url) => {
     const target = String(url);
@@ -184,6 +186,7 @@ describe('bootstrap', () => {
       schoolBookingIdentity: identity,
       schoolBookingEvents: events,
       schoolBookingPreview: preview,
+      schoolBookingCalendar: calendar,
     };
     globalThis.fetch = vi.fn();
     const app = await settled(makeComponent());
@@ -572,6 +575,7 @@ describe('step 3 — resolving a row', () => {
 // ---------------------------------------------------------------------------
 
 // Six students on three columns, so the counts below are the fixture's own.
+// As far as step 4, with the dates seeded and nothing read yet.
 const upToSessions = async (app, opts = {}) => {
   await upToStepThree(app, opts);
   app.toSessions();
@@ -579,25 +583,93 @@ const upToSessions = async (app, opts = {}) => {
   return app;
 };
 
-const upToPreview = async (app, opts = {}) => {
+// …and with the timetable actually read, which is now an explicit act. The
+// window is widened past the fortnight the page seeds, because the fixture
+// sessions are in September and the point of the seed is that it is short.
+const withEvents = async (app, opts = {}) => {
   await upToSessions(app, opts);
+  app.eventsFrom = '2026-08-21';
+  app.eventsTo = '2026-12-31';
+  await app.loadEvents();
+  return app;
+};
+
+const upToPreview = async (app, opts = {}) => {
+  await withEvents(app, opts);
   app.pickSeries('e1');
   await app.toPreview();
   return app;
 };
 
 describe('step 4 — the session picker', () => {
-  test('going forward opens a window and reads the timetable once', async () => {
+  test('going forward reads nothing until the operator says which dates', async () => {
+    // A term-wide window is ~900 events at this gym — five requests of an
+    // allowance the whole gym shares, spent on arrival before anybody has said
+    // what they want, and a table too long to scan. So the dates are seeded
+    // and the read waits.
     const app = await upToSessions(component());
     expect(app.stepIndex).toBe(3);
-    expect(app.eventsFrom).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    expect(app.eventsTo > app.eventsFrom).toBe(true);
+    expect(app.eventsState).toBe('idle');
+    expect(app.events).toEqual([]);
 
     const reads = globalThis.fetch.mock.calls.map(([url]) => String(url));
-    expect(reads.filter((u) => u.includes('/api/clubworx/events'))).toHaveLength(1);
+    expect(reads.filter((u) => u.includes('/api/clubworx/events'))).toHaveLength(0);
+
+    // Seeded, not blank: a starting point beats two empty boxes every time.
+    expect(app.eventsFrom).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(app.eventsTo).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(app.eventsTo > app.eventsFrom).toBe(true);
+  });
+
+  test('searching reads the window that is on screen', async () => {
+    const app = await upToSessions(component());
+    app.eventsFrom = '2026-09-01';
+    app.eventsTo = '2026-09-30';
+    await app.loadEvents();
+
+    const read = globalThis.fetch.mock.calls.map(([url]) => String(url))
+      .find((u) => u.includes('/api/clubworx/events'));
     // The window is a request parameter, not a filter: Clubworx refuses
     // `/events` with no window at all (#51), so the page always names one.
-    expect(reads.find((u) => u.includes('/events'))).toContain('from=');
+    expect(read).toContain('from=2026-09-01');
+    expect(read).toContain('to=2026-09-30');
+    expect(app.events).toHaveLength(3);
+  });
+
+  test('Search stays dark until both dates are real days', async () => {
+    // A blank or impossible date is a Worker 422 the operator cannot act on —
+    // "from and to are required, each as a real YYYY-MM-DD day" is a sentence
+    // about a field they cannot see. Caught here instead.
+    const app = await upToSessions(component());
+    expect(app.canSearch()).toBe(true);
+
+    app.eventsTo = '';
+    expect(app.canSearch()).toBe(false);
+    app.eventsTo = '2026-02-30'; // rolls forward rather than erroring
+    expect(app.canSearch()).toBe(false);
+    app.eventsTo = '2026-09-30';
+    expect(app.canSearch()).toBe(true);
+
+    // Backwards is not a window either.
+    app.eventsFrom = '2026-10-30';
+    expect(app.canSearch()).toBe(false);
+  });
+
+  test('a search that cannot run does not reach the network', async () => {
+    const app = await upToSessions(component());
+    app.eventsTo = '';
+    await app.loadEvents();
+    expect(globalThis.fetch.mock.calls.filter(([u]) => String(u).includes('/events'))).toHaveLength(0);
+    expect(app.eventsState).toBe('idle');
+  });
+
+  test('the name filter is optional — a blank one still searches', async () => {
+    const app = await upToSessions(component());
+    expect(app.eventsQuery).toBe('');
+    await app.loadEvents();
+    const read = globalThis.fetch.mock.calls.map(([url]) => String(url))
+      .find((u) => u.includes('/api/clubworx/events'));
+    expect(read).not.toContain('q=');
     expect(app.events).toHaveLength(3);
   });
 
@@ -610,7 +682,7 @@ describe('step 4 — the session picker', () => {
   });
 
   test('picking the first session ticks its series and nothing else', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.pickSeries('e1');
     expect(app.picked).toEqual(['e1', 'e2']); // Open Climb is a different series
     expect(app.selection.ready).toBe(true);
@@ -619,7 +691,7 @@ describe('step 4 — the session picker', () => {
   });
 
   test('a tick can be taken off again, and the numbers follow', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.pickSeries('e1');
     app.togglePick('e2');
     expect(app.picked).toEqual(['e1']);
@@ -627,7 +699,7 @@ describe('step 4 — the session picker', () => {
   });
 
   test('nothing picked keeps the forward button dark', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     expect(app.selection.ready).toBe(false);
     expect(app.selection.blockers.map((b) => b.kind)).toContain('no-events');
   });
@@ -641,7 +713,7 @@ describe('step 4 — the session picker', () => {
       lead: { hoursAhead: 3, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
       bookable: false,
     };
-    const app = await upToSessions(component({ eventList: [...EVENTS, soon] }));
+    const app = await withEvents(component({ eventList: [...EVENTS, soon] }));
     app.togglePick('e1');
     app.togglePick('soon');
     const blocker = app.selection.blockers.find((b) => b.kind === 'lead-time');
@@ -660,7 +732,7 @@ describe('step 4 — the session picker', () => {
       lead: { hoursAhead: -10, past: true, withinLeadTime: false, minLeadHours: 24, unreadable: false },
       bookable: false,
     };
-    const app = await upToSessions(component({ eventList: [past] }));
+    const app = await withEvents(component({ eventList: [past] }));
     expect(app.events).toHaveLength(1); // annotated, never filtered
     expect(app.eventLane(past)).toBe('lane-bad');
     expect(app.eventWarning(past)).toBe('Already started.');
@@ -668,14 +740,14 @@ describe('step 4 — the session picker', () => {
   });
 
   test('too few spaces warns without blocking', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.togglePick('e3'); // Open Climb reports 4 spaces for 6 students
     expect(app.selection.blockers.some((b) => b.kind === 'spaces' && b.severity === 'warn')).toBe(true);
     expect(app.selection.ready).toBe(true);
   });
 
   test('searching by name re-reads and drops ticks the new window no longer holds', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.togglePick('e3');
     app.eventsQuery = 'School Session';
     await app.loadEvents();
@@ -687,7 +759,7 @@ describe('step 4 — the session picker', () => {
   });
 
   test('a failed events read says so and leaves the picker empty rather than stale', async () => {
-    const app = await upToSessions(component({ eventsFail: true }));
+    const app = await withEvents(component({ eventsFail: true }));
     expect(app.eventsState).toBe('error');
     expect(app.eventsNote()).toContain('Could not read');
     expect(app.events).toEqual([]);
@@ -695,7 +767,7 @@ describe('step 4 — the session picker', () => {
   });
 
   test('a pasted id resolves against the loaded window, then waits to be confirmed', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.pastedEventId = ' e1 ';
     app.usePastedId();
     expect(app.pastedIdOk).toBe(true);
@@ -710,7 +782,7 @@ describe('step 4 — the session picker', () => {
     // #97: `GET /events/:id` answers 404 for a real id and an invented one
     // alike, so nothing can tell them apart — and "no such event" sends staff
     // to re-check an id that is fine.
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.pastedEventId = '999999';
     app.usePastedId();
     expect(app.pastedIdOk).toBe(false);
@@ -883,7 +955,7 @@ describe('an unresolvable plan stops the run before it spends the allowance', ()
     // and nothing caches them — so a run that cannot proceed would spend them
     // again on the next attempt. The plan is a Clubworx configuration fix, so
     // there is nothing the operator can do with the answers meanwhile.
-    const app = await upToSessions(component({
+    const app = await withEvents(component({
       plan: { ok: false, reason: 'plan-not-found', message: 'no membership plan is named "School Pass"' },
     }));
     app.pickSeries('e1');
@@ -905,7 +977,7 @@ describe('the pasted id is a shortcut past the search, never past the confirmati
   test('resolving offers the session for confirmation and ticks nothing yet', async () => {
     // §8: "The id is resolved and shown with its name, date and
     // `spaces_available` for confirmation before it can be selected."
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.pastedEventId = 'e1';
     app.usePastedId();
 
@@ -917,7 +989,7 @@ describe('the pasted id is a shortcut past the search, never past the confirmati
   });
 
   test('confirming ticks the series from that session', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.pastedEventId = 'e1';
     app.usePastedId();
     app.confirmPastedId();
@@ -929,7 +1001,7 @@ describe('the pasted id is a shortcut past the search, never past the confirmati
     // It replaces because pasting an id is the same statement as "pick this
     // first". Silently discarding six ticked sessions is what makes that
     // surprising, so the sentence names the count before the click.
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.togglePick('e3');
     app.pastedEventId = 'e1';
     app.usePastedId();
@@ -938,7 +1010,7 @@ describe('the pasted id is a shortcut past the search, never past the confirmati
   });
 
   test('an unresolvable id offers nothing to confirm', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.togglePick('e1');
     app.pastedEventId = '999999';
     app.usePastedId();
@@ -948,7 +1020,7 @@ describe('the pasted id is a shortcut past the search, never past the confirmati
   });
 
   test('a resolved session can be dismissed without being taken', async () => {
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.pastedEventId = 'e1';
     app.usePastedId();
     app.cancelPastedId();
@@ -991,7 +1063,7 @@ describe('a preview cannot outlive the list it describes', () => {
   test('a step 3 gate still open is a hard-stop on the preview itself', async () => {
     // Belt as well as braces: even a preview that was somehow built while a
     // gate was open reports that gate, because buildPreview carries them.
-    const app = await upToSessions(component());
+    const app = await withEvents(component());
     app.pickSeries('e1');
     await app.toPreview();
     expect(app.preview.ready).toBe(true);
@@ -1003,5 +1075,151 @@ describe('a preview cannot outlive the list it describes', () => {
     app.refreshPreview();
     expect(app.preview.blockers.some((b) => b.kind === 'count-mismatch')).toBe(true);
     expect(app.preview.ready).toBe(false);
+  });
+});
+
+describe('a hand-set window can cut a series in half', () => {
+  test('a series running up to the loaded edge warns without blocking', async () => {
+    const app = await upToSessions(component());
+    app.eventsFrom = '2026-08-21';
+    app.eventsTo = '2026-09-09'; // stops a day after the second session
+    await app.loadEvents();
+    app.pickSeries('e1');
+
+    const warning = app.selection.blockers.find((b) => b.kind === 'series-reach');
+    expect(warning.severity).toBe('warn');
+    expect(warning.detail).toContain('2026-09-15'); // the session it cannot see
+    expect(app.selection.ready).toBe(true);
+  });
+
+  test('a window that reaches past the series says nothing', async () => {
+    const app = await withEvents(component());
+    app.pickSeries('e1');
+    expect(app.selection.blockers.some((b) => b.kind === 'series-reach')).toBe(false);
+  });
+
+  test('editing the dates without searching does not clear the warning', async () => {
+    // The warning is about the window that was *read*. Typing a wider date into
+    // the box changes nothing until Search is pressed, and a warning that
+    // cleared on the keystroke would be answered by the one action that does
+    // not answer it.
+    const app = await upToSessions(component());
+    app.eventsFrom = '2026-08-21';
+    app.eventsTo = '2026-09-09';
+    await app.loadEvents();
+    app.pickSeries('e1');
+    expect(app.selection.blockers.some((b) => b.kind === 'series-reach')).toBe(true);
+
+    app.eventsTo = '2026-12-31';
+    app.refreshSelection();
+    expect(app.selection.blockers.some((b) => b.kind === 'series-reach')).toBe(true);
+
+    await app.loadEvents();
+    app.pickSeries('e1');
+    expect(app.selection.blockers.some((b) => b.kind === 'series-reach')).toBe(false);
+  });
+});
+
+describe('the house date picker', () => {
+  test('it opens on the month already chosen, and closes on a pick', async () => {
+    const app = await upToSessions(component());
+    app.eventsFrom = '2026-09-15';
+
+    app.toggleDatePicker('from');
+    expect(app.datePicker).toBe('from');
+    expect(app.monthLabel()).toBe('September 2026');
+    expect(app.monthCells().find((c) => c.iso === '2026-09-15').selected).toBe(true);
+
+    app.pickDay('2026-09-01');
+    expect(app.eventsFrom).toBe('2026-09-01');
+    expect(app.datePicker).toBe(null);
+  });
+
+  test('clicking the same trigger again closes it', async () => {
+    const app = await upToSessions(component());
+    app.toggleDatePicker('to');
+    expect(app.datePicker).toBe('to');
+    app.toggleDatePicker('to');
+    expect(app.datePicker).toBe(null);
+  });
+
+  test('opening one picker replaces the other, never both at once', async () => {
+    const app = await upToSessions(component());
+    app.toggleDatePicker('from');
+    app.toggleDatePicker('to');
+    expect(app.datePicker).toBe('to');
+  });
+
+  test('the months walk, and roll the year', async () => {
+    const app = await upToSessions(component());
+    app.eventsFrom = '2026-12-01';
+    app.toggleDatePicker('from');
+    app.stepMonth(1);
+    expect(app.monthLabel()).toBe('January 2027');
+    app.stepMonth(-1);
+    expect(app.monthLabel()).toBe('December 2026');
+  });
+
+  test('the two pickers bound each other, so a backwards window cannot be clicked', async () => {
+    // canSearch() would refuse it afterwards, but with nothing saying which end
+    // to move. Disabling the cells is the version an operator can act on.
+    const app = await upToSessions(component());
+    app.eventsFrom = '2026-09-10';
+    app.eventsTo = '2026-09-20';
+
+    app.toggleDatePicker('to');
+    const to = (iso) => app.monthCells().find((c) => c.iso === iso).disabled;
+    expect(to('2026-09-09')).toBe(true);  // before `from`
+    expect(to('2026-09-10')).toBe(false); // `from` itself is fair game
+    expect(to('2026-09-30')).toBe(false);
+
+    app.toggleDatePicker('from');
+    const from = (iso) => app.monthCells().find((c) => c.iso === iso).disabled;
+    expect(from('2026-09-21')).toBe(true); // after `to`
+    expect(from('2026-09-20')).toBe(false);
+  });
+
+  test('the trigger shows a written date, not an ISO string', async () => {
+    const app = await upToSessions(component());
+    // en-AU's own short form, whatever that is on the runtime — spelled out
+    // here so a change to it is a failing test rather than a surprise.
+    expect(app.dayLabel('2026-09-15')).toBe('Tue, 15 Sept 2026');
+    expect(app.dayLabel('')).toBe('Choose a date');
+    expect(app.dayLabel('2026-02-30')).toBe('Choose a date');
+  });
+
+  test('a closed picker builds no grid', async () => {
+    const app = await upToSessions(component());
+    expect(app.monthCells()).toEqual([]);
+  });
+
+  test('picking through the picker leaves Search able to run', async () => {
+    const app = await upToSessions(component());
+    app.toggleDatePicker('from');
+    app.pickDay('2026-09-01');
+    app.toggleDatePicker('to');
+    app.pickDay('2026-09-30');
+    expect(app.canSearch()).toBe(true);
+
+    await app.loadEvents();
+    const read = globalThis.fetch.mock.calls.map(([url]) => String(url))
+      .find((u) => u.includes('/api/clubworx/events'));
+    expect(read).toContain('from=2026-09-01');
+    expect(read).toContain('to=2026-09-30');
+  });
+});
+
+describe('step 4 says each thing once', () => {
+  test('the multiplication line stays away until there is a selection to multiply', async () => {
+    // #71's lesson, re-learned: "No sessions picked yet." above a blocker
+    // saying "No sessions picked" is two banners for one message, and the
+    // repetition is what trains people to stop reading the region.
+    const app = await withEvents(component());
+    expect(app.selection.sessions).toBe(0);
+    expect(app.selection.blockers.some((b) => b.kind === 'no-events')).toBe(true);
+
+    app.pickSeries('e1');
+    expect(app.selection.sessions).toBe(2);
+    expect(app.sessionsLine()).toBe('2 sessions × 6 students = 12 bookings.');
   });
 });


### PR DESCRIPTION
Follow-up to #72, from testing the built page. Three changes to step 4, plus two things testing turned up.

## Nothing loads until Search is pressed

Arriving at step 4 walked a 90-day window automatically. At ~70 events/week that is **~900 events ≈ 5 requests**, spent before anybody had said what they wanted, out of an allowance the roster Worker and n8n also draw from — and a table far too long to scan.

The dates are now seeded to a fortnight and the read waits. **Search stays dark until both are real days in order**, so a blank or impossible date is caught here rather than met as the Worker's 422 — which is a sentence about a field the operator cannot see. `2026-02-30` is the one worth naming: it does not throw, it rolls to 2 March.

The seed is short on purpose. With the load deferred, the default's only job is to be cheap if left alone.

**Worth knowing:** narrowing the dates is the *only* lever on that cost. The name filter is applied in the Worker's memory **after** the window has been walked (deliberately — no name parameter on `/events` has ever been measured, and one Clubworx quietly honoured differently would return less than the window holds and look exactly like a thin timetable). So it shortens the table, never the request count. It stays **optional**: a school whose sessions are not named for it would otherwise be locked out of its own picker.

## A hand-set window can cut a series in half

This is the one thing deferring the load makes *worse*. `preTicked` can only tick what the window holds, so a `to` that stops mid-term books a partial series in silence.

`seriesReach()` projects the next session from the **median** gap between ticked sessions and warns when that date falls past what was loaded. The lower median on a tie, so one cancelled week's 14-day hole cannot push the expectation out and suppress the warning at exactly the moment it is right. It checks the window that was **read**, not the one in the boxes — otherwise the warning would be cleared by the keystroke that does not answer it. Warn, never block.

> This series may run past the dates loaded
> If this series runs on, the next session would be about 2026-09-15 — past 2026-09-09, the last date loaded. Widen the dates and search again to be sure the whole term is ticked.

## The date fields are the house calendar

Ported from `roster.html` — same `.dp-*` styling, Monday-first, UJ red, and a written date on the trigger (`Fri, 21 Aug 2026`) rather than an ISO string. A picker that shows an ISO string is a text box wearing a calendar.

The grid is `school-booking/calendar.js`, a tested value: roster.html's imperative version suits one picker and no framework, and this page has two and Alpine. One deliberate difference — roster.html positions with `position: fixed` and JS-measured coordinates because its picker lives in a scrolling header; these sit in normal flow and are absolutely positioned under their own trigger, which needs no measuring and cannot strand the panel away from its button on scroll.

The two pickers **bound each other**, so a backwards window cannot be clicked rather than only refused afterwards with nothing saying which end to move.

## Two things testing turned up

- Step 4 said *"No sessions picked yet."* directly above a blocker saying *"No sessions picked"* — the same two-banners-one-message fault #71 fixed on the count banners. The blocker owns the sentence; the multiplication line owns the arithmetic and stays away until there is one.
- The paste-an-id box now appears only once there is a window to resolve against. It matches page-side, so before the first search it was a control that could only fail — the kind somebody tries at the moment they most need it to work.

## Verification

Driven in a real browser as well as in tests: the picker opens on the right month, the series pre-tick works, a too-soon session greys out with its actual reason, and the series warning renders without blocking the forward button.

336 tests in `school-booking/` (up from 293), 1,308 across the repo. No Worker change, so **no `wrangler deploy` needed** — merging is the whole deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn