### PR TITLE
Fix: the school booking date picker opened and closed on the same click

### DIFF
--- a/school-booking.html
+++ b/school-booking.html
@@ -826,7 +826,7 @@
         <div class="flex items-end gap-3 flex-wrap mb-4">
           <div class="block">
             <span class="field-label">First session on or after</span>
-            <div class="dp-anchor" @click.outside="closeDatePicker()">
+            <div class="dp-anchor">
               <button type="button" class="dp-field"
                       :aria-expanded="datePicker === 'from' ? 'true' : 'false'"
                       aria-haspopup="dialog"
@@ -838,7 +838,9 @@
               </button>
 
               <div class="dp-dropdown" x-show="datePicker === 'from'" x-cloak
-                   role="dialog" aria-label="Choose the first date to search from">
+                   role="dialog" aria-label="Choose the first date to search from"
+                   @click.outside="closeDatePicker('from')"
+                   @keydown.escape.window="closeDatePicker('from')">
                 <div class="dp-header">
                   <button type="button" class="dp-nav" aria-label="Previous month"
                           @click="stepMonth(-1)">&#8592;</button>
@@ -865,7 +867,7 @@
           </div>
           <div class="block">
             <span class="field-label">Last session on or before</span>
-            <div class="dp-anchor" @click.outside="closeDatePicker()">
+            <div class="dp-anchor">
               <button type="button" class="dp-field"
                       :aria-expanded="datePicker === 'to' ? 'true' : 'false'"
                       aria-haspopup="dialog"
@@ -877,7 +879,9 @@
               </button>
 
               <div class="dp-dropdown" x-show="datePicker === 'to'" x-cloak
-                   role="dialog" aria-label="Choose the last date to search to">
+                   role="dialog" aria-label="Choose the last date to search to"
+                   @click.outside="closeDatePicker('to')"
+                   @keydown.escape.window="closeDatePicker('to')">
                 <div class="dp-header">
                   <button type="button" class="dp-nav" aria-label="Previous month"
                           @click="stepMonth(-1)">&#8592;</button>
@@ -1734,7 +1738,16 @@ function schoolBooking() {
       this.dpMonth = on?.month ?? new Date().getMonth();
     },
 
-    closeDatePicker() {
+    // `which` is not decoration. There are two pickers, so "outside" is a
+    // different region for each — and a handler that closed *whichever* was
+    // open would shut the one just opened by a click on the other's trigger.
+    // That is exactly the bug this replaced: clicking From ran To's
+    // outside-handler, and the picker opened and closed on the same click.
+    //
+    // Called with no argument it closes whatever is open, which is what
+    // picking a day and toggling want.
+    closeDatePicker(which) {
+      if (which && this.datePicker !== which) return;
       this.datePicker = null;
     },
 

--- a/school-booking/test/alpine-bindings.test.js
+++ b/school-booking/test/alpine-bindings.test.js
@@ -221,6 +221,43 @@ describe('school-booking.html', () => {
     }
   });
 
+  test('no two always-present outside-handlers close the same thing', () => {
+    // The fault this catches, found in use on #106: the two date pickers each
+    // had `@click.outside="closeDatePicker()"` on their own always-present
+    // wrapper. Clicking the From trigger is *outside* the To wrapper, so To's
+    // handler fired and shut the picker From had just opened — the picker
+    // opened and closed on the same click, and nothing threw.
+    //
+    // Like the `x-show="b.fix"` bug above, this is invisible to a component
+    // test: `toggleDatePicker` and `closeDatePicker` are both correct on their
+    // own, and only their wiring is wrong. So it is checked as text.
+    //
+    // The rule: an outside-handler must sit on the element it hides — `x-show`
+    // gives it no size when shut, and Alpine skips an outside-handler on a
+    // zero-size element, so a closed control has no live handler to fire on a
+    // click meant for another. The column chips already do this. A handler on
+    // an always-present wrapper is only safe when it is alone in what it
+    // closes.
+    const handlers = [...html.matchAll(/<(\w+)((?:[^>]|\n)*?@click\.outside="([^"]*)"(?:[^>]|\n)*?)>/g)]
+      .map(([, tag, attrs, expr]) => ({
+        tag,
+        expr,
+        conditional: attrs.includes('x-show') || attrs.includes('x-if'),
+      }));
+    expect(handlers.length, 'the page has outside-handlers to check').toBeGreaterThan(0);
+
+    const unconditional = handlers.filter((h) => !h.conditional);
+    for (const handler of unconditional) {
+      const sharing = handlers.filter((h) => h.expr === handler.expr).length;
+      expect(
+        sharing,
+        `\`@click.outside="${handler.expr}"\` sits on an element with no x-show/x-if and is `
+        + 'not alone — each copy fires on a click inside the other, so they close each other. '
+        + 'Move it onto the element the control hides, as the column chips do.',
+      ).toBe(1);
+    }
+  });
+
   test('the page is not reachable from the hub yet', () => {
     // §17: the hub entry is the last step of #46, and it is what makes every
     // earlier step visible to staff. Landing it early ships a half-built tool

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -1150,6 +1150,29 @@ describe('the house date picker', () => {
     expect(app.datePicker).toBe('to');
   });
 
+  test('a close meant for the other picker leaves this one alone', async () => {
+    // The runtime half of #106's fix. Both pickers have an outside-handler, so
+    // a click on one trigger fires the other's — and a close that did not
+    // check which picker it spoke for would shut the one just opened. That is
+    // the bug that shipped: the picker opened and closed on the same click,
+    // and nothing threw.
+    const app = await upToSessions(component());
+    app.toggleDatePicker('from');
+    app.closeDatePicker('to');
+    expect(app.datePicker).toBe('from');
+
+    app.closeDatePicker('from');
+    expect(app.datePicker).toBe(null);
+  });
+
+  test('a close with no picker named shuts whatever is open', async () => {
+    // Which is what picking a day and re-clicking a trigger both want.
+    const app = await upToSessions(component());
+    app.toggleDatePicker('to');
+    app.closeDatePicker();
+    expect(app.datePicker).toBe(null);
+  });
+
   test('the months walk, and roll the year', async () => {
     const app = await upToSessions(component());
     app.eventsFrom = '2026-12-01';


### PR DESCRIPTION
Reported after #106 merged: clicking a date field did nothing.

## What was wrong

Both pickers carried `@click.outside="closeDatePicker()"` on their own always-present `.dp-anchor` wrapper. Clicking the **From** trigger is *outside* the **To** wrapper — so To's handler fired on the same click and shut the picker From had just opened.

Traced in the browser:

```
toggle:from  ->  after-toggle:from  ->  close
```

Nothing threw. Both `toggleDatePicker` and `closeDatePicker` were correct on their own; only the wiring between them was wrong.

## The fix, in two parts

**The handler moves onto the element it hides** — the pattern the column chips in this same file already use. `x-show` leaves a shut dropdown with no size, and Alpine skips an outside-handler on a zero-size element, so a closed picker has no live handler to fire on a click meant for the other one. Escape closes them too now, matching the other two dropdowns on the page.

**`closeDatePicker(which)` names the picker it speaks for** and returns early otherwise, so even a handler that does fire cannot shut a different one.

Both, deliberately: the first stops the handlers colliding, the second makes a collision harmless if one is ever reintroduced.

## Why it got through, and what stops it next time

Every test drove `toggleDatePicker()` **as a method**, and it works perfectly as a method. Nothing ever clicked the button — so the whole class of wiring fault was untested. My screenshots were taken the same way, which is why they looked right.

The regression test is two-part to match:

- A **static guard** in `alpine-bindings.test.js`, in the family of the existing `x-show="b.fix"` check, refusing two always-present outside-handlers that close the same thing. Mutation-tested against the exact markup that shipped — it fails on it.
- **Component tests** for the `which` guard.

## Verification

Clicked through all seven paths in a real browser: open, switch pickers, pick a day, click away, Escape, and re-clicking the same trigger. All correct.

339 tests in `school-booking/` (up from 336), 1,311 across the repo. Page-only — no Worker deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn