### PR TITLE
School booking date picker: minimum today, no fortnight cap, and a Today button

### DIFF
--- a/school-booking.html
+++ b/school-booking.html
@@ -308,6 +308,33 @@
 
   .dp-empty { pointer-events: none; }
 
+  /* A Today shortcut inside the panel. roster.html has none — its Today is a
+     button in the page's own day nav — but this page has no day nav, and a
+     school booking is nearly always being set up for the term starting now. */
+  .dp-footer {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(31, 41, 55, 0.08);
+    display: flex;
+    justify-content: center;
+  }
+
+  .dp-today-btn {
+    border: 1px solid rgba(139, 28, 35, 0.25);
+    border-radius: 8px;
+    background: transparent;
+    color: #8b1c23;
+    font: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 5px 16px;
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+
+  .dp-today-btn:hover:not(:disabled) { background: rgba(139, 28, 35, 0.08); }
+  .dp-today-btn:disabled { opacity: 0.35; cursor: default; }
+
   /* The trigger, shaped like the other fields on this step rather than like
      roster.html's header button — same control, different background. */
   .dp-field {
@@ -862,6 +889,12 @@
                             x-text="cell.day"></button>
                   </template>
                 </div>
+                <div class="dp-footer">
+                  <button type="button" class="dp-today-btn"
+                          :disabled="!todayPickable()"
+                          :title="todayPickable() ? '' : 'Today is before the first session'"
+                          @click="goToday()">Today</button>
+                </div>
               </div>
             </div>
           </div>
@@ -902,6 +935,12 @@
                             @click="cell.empty || pickDay(cell.iso)"
                             x-text="cell.day"></button>
                   </template>
+                </div>
+                <div class="dp-footer">
+                  <button type="button" class="dp-today-btn"
+                          :disabled="!todayPickable()"
+                          :title="todayPickable() ? '' : 'Today is before the first session'"
+                          @click="goToday()">Today</button>
                 </div>
               </div>
             </div>
@@ -1769,26 +1808,64 @@ function schoolBooking() {
       return window.schoolBookingCalendar.monthLabel(this.dpYear, this.dpMonth);
     },
 
-    // The two pickers bound each other: `from` cannot be set past `to`, and
-    // `to` cannot be set before `from`. That is what keeps a backwards window
-    // from being reachable by clicking, rather than only refused afterwards by
-    // canSearch() with nothing saying which end to move.
+    // What each picker may offer.
+    //
+    // `from` starts at **today**: nothing is bookable behind you — a past
+    // session is a hard-stop on the selection anyway — so offering an earlier
+    // date is offering a dead end. It has **no upper bound**. It briefly did,
+    // capped at `to`, which meant the seeded fortnight showed as a fortnight of
+    // selectable days and nothing on screen explained the cage. A term starts
+    // when it starts; the second date follows the first, not the reverse.
+    //
+    // `to` starts at `from`, which is the one bound that reads as a fact rather
+    // than a restriction — a last session before the first is not a window.
+    // It has no upper bound either.
     monthCells() {
       const which = this.datePicker;
       if (!which) return [];
       return window.schoolBookingCalendar.monthGrid(this.dpYear, this.dpMonth, {
         selected: this.dayFor(which),
         today: this.todayDay(),
-        min: which === 'to' ? this.eventsFrom : '',
-        max: which === 'from' ? this.eventsTo : '',
+        min: which === 'to' ? this.firstAllowedTo() : this.todayDay(),
+        max: '',
       });
+    },
+
+    // The earliest a last session may be: the first session, or today when no
+    // usable first session has been set.
+    firstAllowedTo() {
+      return window.schoolBookingCalendar.isRealDay(this.eventsFrom)
+        ? this.eventsFrom
+        : this.todayDay();
     },
 
     pickDay(day) {
       if (!day) return;
-      if (this.datePicker === 'from') this.eventsFrom = day;
-      else if (this.datePicker === 'to') this.eventsTo = day;
+      if (this.datePicker === 'from') {
+        this.eventsFrom = day;
+        // Carry the last session along rather than leaving a backwards window
+        // with Search dark and nothing saying which end to move. Not a silent
+        // adjustment — the second field shows the new date, and the operator
+        // is on their way to setting it properly anyway.
+        if (this.eventsTo < day) this.eventsTo = day;
+      } else if (this.datePicker === 'to') {
+        this.eventsTo = day;
+      }
       this.closeDatePicker();
+    },
+
+    // Today, when this picker is allowed to take it. On the `to` picker with a
+    // first session in the future it is behind the minimum, and a button that
+    // cannot work is one somebody presses at the moment they need it to.
+    todayPickable() {
+      const today = this.todayDay();
+      if (!today || !this.datePicker) return false;
+      return this.datePicker === 'to' ? today >= this.firstAllowedTo() : true;
+    },
+
+    goToday() {
+      if (!this.todayPickable()) return;
+      this.pickDay(this.todayDay());
     },
 
     // `Fri 21 Aug 2026` — a written date, because a picker that shows an ISO

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -1183,9 +1183,11 @@ describe('the house date picker', () => {
     expect(app.monthLabel()).toBe('December 2026');
   });
 
-  test('the two pickers bound each other, so a backwards window cannot be clicked', async () => {
-    // canSearch() would refuse it afterwards, but with nothing saying which end
-    // to move. Disabling the cells is the version an operator can act on.
+  test('the last session may not precede the first, and the first is not capped by it', async () => {
+    // One bound reads as a fact — a last session before the first is not a
+    // window — and the other read as a cage: `from` capped at `to` meant the
+    // seeded fortnight was all the picker offered, with nothing explaining it
+    // (#108). So only the first of these holds.
     const app = await upToSessions(component());
     app.eventsFrom = '2026-09-10';
     app.eventsTo = '2026-09-20';
@@ -1198,8 +1200,8 @@ describe('the house date picker', () => {
 
     app.toggleDatePicker('from');
     const from = (iso) => app.monthCells().find((c) => c.iso === iso).disabled;
-    expect(from('2026-09-21')).toBe(true); // after `to`
-    expect(from('2026-09-20')).toBe(false);
+    expect(from('2026-09-21')).toBe(false); // past `to`, and allowed
+    expect(from('2026-09-30')).toBe(false);
   });
 
   test('the trigger shows a written date, not an ISO string', async () => {
@@ -1244,5 +1246,100 @@ describe('step 4 says each thing once', () => {
     app.pickSeries('e1');
     expect(app.selection.sessions).toBe(2);
     expect(app.sessionsLine()).toBe('2 sessions × 6 students = 12 bookings.');
+  });
+});
+
+describe('the date picker bounds (#108)', () => {
+  test('the first session cannot be in the past', async () => {
+    // Nothing is bookable behind you — a past session is a hard-stop on the
+    // selection anyway, so offering the date is offering a dead end.
+    const app = await upToSessions(component());
+    const today = app.todayDay();
+    app.toggleDatePicker('from');
+
+    const cells = app.monthCells().filter((c) => !c.empty);
+    const past = cells.filter((c) => c.iso < today);
+    const future = cells.filter((c) => c.iso >= today);
+    expect(past.every((c) => c.disabled)).toBe(true);
+    expect(future.every((c) => !c.disabled)).toBe(true);
+  });
+
+  test('the first session is not capped by the seeded fortnight', async () => {
+    // The bug reported on #106: `from` was bounded above by `to`, and `to` is
+    // seeded to today + 14 — so the picker offered a fortnight and nothing
+    // explained why. A term starts when it starts; the second date follows the
+    // first, not the other way round.
+    const app = await upToSessions(component());
+    app.toggleDatePicker('from');
+    app.stepMonth(1);
+    app.stepMonth(1);
+    app.stepMonth(1); // three months past the seeded window
+    expect(app.monthCells().filter((c) => !c.empty).every((c) => !c.disabled)).toBe(true);
+  });
+
+  test('moving the first session past the last carries the last with it', async () => {
+    // Rather than leaving a backwards window with Search dark and nothing
+    // saying which end to move. The field shows the new date, so nothing is
+    // hidden by it.
+    const app = await upToSessions(component());
+    app.toggleDatePicker('from');
+    app.pickDay('2027-03-01');
+    expect(app.eventsFrom).toBe('2027-03-01');
+    expect(app.eventsTo).toBe('2027-03-01');
+    expect(app.canSearch()).toBe(true);
+  });
+
+  test('a first session inside the window leaves the last alone', async () => {
+    const app = await upToSessions(component());
+    const to = app.eventsTo;
+    app.toggleDatePicker('from');
+    app.pickDay(app.eventsFrom); // today, well before `to`
+    expect(app.eventsTo).toBe(to);
+  });
+
+  test('the last session still cannot precede the first', async () => {
+    const app = await upToSessions(component());
+    app.eventsFrom = '2026-09-10';
+    app.toggleDatePicker('to');
+    const at = (iso) => app.monthCells().find((c) => c.iso === iso).disabled;
+    expect(at('2026-09-09')).toBe(true);
+    expect(at('2026-09-10')).toBe(false);
+
+    // And no upper bound: three months on, everything is still selectable.
+    app.stepMonth(3);
+    expect(app.monthCells().filter((c) => !c.empty).every((c) => !c.disabled)).toBe(true);
+  });
+});
+
+describe('the picker’s Today button (#108)', () => {
+  test('it jumps the view to today and picks it', async () => {
+    const app = await upToSessions(component());
+    app.toggleDatePicker('from');
+    app.stepMonth(6);
+    app.goToday();
+    expect(app.eventsFrom).toBe(app.todayDay());
+    expect(app.datePicker).toBe(null);
+  });
+
+  test('it is offered only when today is a date this picker may take', async () => {
+    // On the `to` picker with a first session in the future, today is behind
+    // the minimum — so the button would be a control that cannot work.
+    const app = await upToSessions(component());
+    app.toggleDatePicker('from');
+    expect(app.todayPickable()).toBe(true);
+
+    app.eventsFrom = '2027-01-01';
+    app.toggleDatePicker('to');
+    expect(app.todayPickable()).toBe(false);
+  });
+
+  test('an unpickable Today does nothing rather than setting a refused date', async () => {
+    const app = await upToSessions(component());
+    app.eventsFrom = '2027-01-01';
+    app.eventsTo = '2027-02-01';
+    app.toggleDatePicker('to');
+    app.goToday();
+    expect(app.eventsTo).toBe('2027-02-01');
+    expect(app.datePicker).toBe('to');
   });
 });


### PR DESCRIPTION
Three things from using the picker on the live page.

## The first session cannot be in the past

Nothing is bookable behind you — a past session is already a hard-stop on the selection — so offering an earlier date was offering a dead end.

## The first session is no longer capped by the last

This was the reported *"only 2 weeks available"*. `from` was bounded above by `to`, and `to` is seeded to today + 14 — so the picker offered exactly a fortnight of selectable days, with nothing on screen explaining the cage.

The bound was reasoning backwards. A term starts when it starts; the second date follows the first, not the reverse. `to` keeps its **lower** bound on `from`, which is the one that reads as a fact rather than a restriction: a last session before the first is not a window.

Moving the first session past the last now **carries the last with it**, rather than leaving a backwards window with Search dark and nothing naming which end to move. Not a silent adjustment — the second field shows the new date, and the operator is on their way to setting it properly anyway.

## A Today button in the panel

`roster.html` has none, because its Today is a button in the page's own day nav. This page has no day nav, and a school booking is nearly always being set up for the term starting now.

It is **disabled on the `to` picker when the first session is in the future**, where today sits behind the minimum and the button could only fail.

## Verification

Clicked in a real browser, not driven by calling the methods — which is exactly what #107 was about:

```
From, this month  : selectable days = 11   (today is 21 Aug — past days greyed)
From, next month  : selectable days = 30   (no fortnight cap)
From, +3 months   : selectable days = 30
picking a far From -> from 2026-11-10, to 2026-11-10   (the last followed)
To picker Today    : disabled = true       (today is before the first session)
clicking it anyway -> unchanged
From picker Today  : disabled = false -> from = today, to left alone
```

347 tests in `school-booking/` (up from 339), 1,319 across the repo. Page-only — no Worker deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn