### PR TITLE
School booking step 6: Apply, the run engine, the result table and the cancel (#73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ cloudflare-clubworx/probes/ - read-only probes against the live Clubworx API, an
                           what they found. Start with probes/README.md — it carries
                           the rules (no production data recorded, pace under
                           75 req/min) that any new probe has to follow.
-school-booking.html     - the school booking page, steps 1-5 (#71, #72, #106):
+school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #106):
                           school, paste + declare the count, the parse result
                           with inline row resolution, the session picker, and
                           the preview. Step 4 reads NOTHING until the operator
@@ -114,9 +114,11 @@ school-booking.html     - the school booking page, steps 1-5 (#71, #72, #106):
                           (calendar.js), not the browser's. Variant A of §9, decided on #54. NOT in
                           tools.json and unreachable from the hub until #46's
                           last step — §17's order, because `main` is production.
-                          Step 6 (Apply, the run engine, the result table) is
-                          #73; every route this page calls is a GET, and a
-                          component test asserts that.
+                          Steps 1-5 READ; step 6 WRITES (#73). The page holds
+                          only the confirm gate, the single-flight lock, the
+                          storage and the rendering — the run itself is run.js
+                          (#78's seam), and a component test asserts that steps
+                          1-5 issue no POST.
 school-booking/events.js - what a SELECTION of sessions is: the same-name,
                           same-location pre-tick (no recurrence field exists,
                           so any automatic rule is a guess), the lead-time and
@@ -160,6 +162,26 @@ school-booking/preview.js - step 5: the STUDENT/DOB/READ/CLUBWORX/OUTCOME table,
                           Apply" rather than "pass already active". An absent
                           answer is `pending`, never `new` — `new` writes a
                           contact Clubworx cannot delete.
+school-booking/run.js   - step 6's engine: Apply's per-student loop, D8's retry
+                          policy, D7's circuit breaker, the throttle halt, the
+                          cancel loop, and D10's browser-only store. Takes an
+                          INJECTED caller (#78) — everything in it runs when
+                          things are already going wrong, and inside an Alpine
+                          component none of it would have cover. A throttle
+                          pauses the WHOLE run, detected on the `reason` field
+                          and not the status: once a call has written something
+                          the Worker answers 200 carrying `reason: "throttled"`,
+                          because the body is then the only record of the write.
+school-booking/outcome.js - what one `POST /student` answer means, and what a
+                          run of them adds up to. Two exports are safety rules
+                          rather than presentation: isFailure() feeds the
+                          circuit breaker (a `needs-confirmation` is data about
+                          one student, not a systemic condition), and
+                          cancellable() is D12's interlock — an `already booked`
+                          row was NOT made by this run, so cancelling it may
+                          delete a booking a real member made themselves. The
+                          three permanence classes are counted apart, never
+                          collapsed into a success total.
 school-booking/parse.js - turns a pasted school student list into rows plus the
                           list-level inferences (layout, column mapping, date
                           orientation). Pure and unit tested; §7 of the design

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,8 +180,15 @@ school-booking/outcome.js - what one `POST /student` answer means, and what a
                           cancellable() is D12's interlock — an `already booked`
                           row was NOT made by this run, so cancelling it may
                           delete a booking a real member made themselves. The
-                          three permanence classes are counted apart, never
-                          collapsed into a success total.
+                          interlock has TWO sources of already-gone ids, and
+                          missing the second re-cancels: the human control's
+                          `cancel.cancelledIds`, and D3's automatic rollback,
+                          which cancels an abandoned student's bookings and
+                          reports them in `rollback.cancelledIds` while handing
+                          the rows back UNMUTATED — still reading `booked`, ids
+                          intact. bookingRows() is what stops a dead id being
+                          rendered as live. The three permanence classes are
+                          counted apart, never collapsed into a success total.
 school-booking/parse.js - turns a pasted school student list into rows plus the
                           list-level inferences (layout, column mapping, date
                           orientation). Pure and unit tested; §7 of the design

--- a/school-booking.html
+++ b/school-booking.html
@@ -1294,6 +1294,9 @@
              x-show="runState === 'halted'" x-cloak>
           <div class="font-semibold">The run stopped early</div>
           <div class="text-xs mt-1 opacity-90" x-text="runMessage"></div>
+          <div class="text-xs mt-1 opacity-90" x-show="runRemaining > 0" x-cloak
+               x-text="`${runRemaining} student(s) were never reached. They are in the table below as `
+                 + 'not run, and nothing was written for them.'"></div>
           <div class="text-xs mt-1 opacity-90">
             Re-running the same list is safe and is how this is finished: students already done come
             back as <span class="mono">already booked</span>.
@@ -1342,13 +1345,28 @@
                   <td colspan="5" class="px-4 py-3">
                     <div class="text-[0.78rem] text-neutral-600 mb-2">└ <span x-text="record.detail"></span></div>
 
+                    <!-- The write chain's own warnings about this student. It
+                         raises them precisely where it went ahead anyway, so
+                         dropping them loses the only notice that it did. -->
+                    <div class="text-[0.78rem] text-amber-800 mb-2" x-show="record.warnings.length > 0" x-cloak>
+                      <template x-for="warning in record.warnings" :key="warning">
+                        <div x-text="warning"></div>
+                      </template>
+                    </div>
+
                     <!-- The booking ids, because a stranded or half-cancelled
                          student is finished by hand in Clubworx and this is
                          what a human needs to find them. -->
                     <div x-show="record.bookings.length > 0" x-cloak>
                       <span class="field-label">Bookings</span>
                       <div class="space-y-1">
-                        <template x-for="b in record.bookings" :key="b.event_id">
+                        <!-- bookingRows(), not record.bookings: the Worker's row
+                             records what the BOOKING call did and is not
+                             rewritten when D3's rollback cancels it, so a raw
+                             row shows `booked` beside an id that no longer
+                             exists — and that id is the one a human would then
+                             go hunting for in Clubworx. -->
+                        <template x-for="b in bookingRows(record)" :key="b.event_id">
                           <div class="flex items-center gap-2 flex-wrap text-[0.78rem]">
                             <span class="mono text-[0.7rem] text-neutral-500" x-text="b.event_id"></span>
                             <span x-text="b.state"></span>
@@ -1569,6 +1587,7 @@ function schoolBooking() {
     runReason: null,
     runMessage: '',
     runProgress: '',
+    runRemaining: 0,
     runAt: null,
     runSessionStarts: [],
     expandedResult: null,
@@ -2517,7 +2536,11 @@ function schoolBooking() {
       const students = this.preview?.totals?.students ?? 0;
       const sessions = this.preview?.sessions?.length ?? 0;
       if (students === 0) return '';
-      const requests = students * (4 + sessions);
+      // §6's arithmetic, not an estimate of its own: 3 dedup reads + 1
+      // membership read + a contact write + a membership write + one booking
+      // per event. It is what makes 25 students x 6 sessions the ~300 requests
+      // and ~4 minutes the design tells staff about.
+      const requests = students * (6 + sessions);
       const minutes = Math.max(1, Math.ceil(requests / 75));
       return `About ${requests} Clubworx requests — roughly ${minutes} minute${minutes === 1 ? '' : 's'} `
         + 'at the 75-a-minute allowance, which is shared with the whole gym. The roster and the '
@@ -2561,6 +2584,7 @@ function schoolBooking() {
       this.runAt = new Date().toISOString();
       this.runSessionStarts = (this.preview.sessions ?? []).map((e) => e.event_start_at);
       this.expandedResult = null;
+      this.runRemaining = 0;
       this.runProgress = `Starting ${students.length} student${students.length === 1 ? '' : 's'}…`;
       this.guardUnload(true);
       this.go(5);
@@ -2581,6 +2605,7 @@ function schoolBooking() {
       this.runState = result.state;
       this.runReason = result.reason;
       this.runMessage = result.message;
+      this.runRemaining = result.remaining;
       this.runProgress = '';
       this.running = false;
       this.guardUnload(false);
@@ -2707,6 +2732,10 @@ function schoolBooking() {
       this.running = false;
       this.guardUnload(false);
       this.saveRun();
+    },
+
+    bookingRows(record) {
+      return window.schoolBookingOutcome.bookingRows(record);
     },
 
     cancelReport(record) {

--- a/school-booking.html
+++ b/school-booking.html
@@ -1,15 +1,22 @@
 <!--
-  School group booking — steps 1 to 5.
+  School group booking — steps 1 to 6.
 
-  staff-site#71 and #72, map #46. Design:
-  docs/superpowers/specs/2026-08-19-school-group-booking-design.md §7, §8 and §9.
+  staff-site#71, #72 and #73, map #46. Design:
+  docs/superpowers/specs/2026-08-19-school-group-booking-design.md §7 to §12.
   Variant A, the gated stepper, decided on #54 against three built prototypes.
 
   NOT LINKED FROM tools.json. That is deliberate and is the last step of #46
   (§17): `main` is production here, so every step before the hub entry lands is
-  deployed but invisible to staff. Step 6 — Apply, the run engine and the result
-  table — is #73, and nothing on this page can write anything: every route it
-  calls is a GET.
+  deployed but invisible to staff.
+
+  STEPS 1-5 READ. STEP 6 WRITES, and two of the three records it writes cannot
+  be deleted through the Clubworx API at all — a contact and a School Pass are
+  permanent, and only a booking can be taken back (§12). The run engine itself
+  is `school-booking/run.js`, deliberately outside this file and taking an
+  injected caller (#78): the retry policy, the circuit breaker, the throttle
+  halt and the cancel interlock all run when things are already going wrong,
+  which is exactly the code that gets no cover if it lives in an Alpine
+  component in a repo with no DOM test infrastructure.
 
   Steps 4 and 5 read Clubworx and nothing more. The Clubworx check between them
   is strictly serial, one student at a time, because the 75-requests-a-minute
@@ -67,12 +74,16 @@
   import * as events from './school-booking/events.js?v=2';
   import * as preview from './school-booking/preview.js?v=2';
   import * as calendar from './school-booking/calendar.js?v=2';
+  import * as outcome from './school-booking/outcome.js?v=2';
+  import * as run from './school-booking/run.js?v=2';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
   window.schoolBookingIdentity = identity;
   window.schoolBookingEvents = events;
   window.schoolBookingPreview = preview;
   window.schoolBookingCalendar = calendar;
+  window.schoolBookingOutcome = outcome;
+  window.schoolBookingRun = run;
 </script>
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 
@@ -412,6 +423,24 @@
         <b>This page is not safe to use.</b>
         <span x-text="bootstrapError"></span>
         Reload with a hard refresh; if that does not fix it, the page has shipped against a stale module.
+      </div>
+
+      <!-- D10 — the run this browser is still holding. Offered, never opened
+           for you: a saved run may be from yesterday, and a result table that
+           appears unbidden is one an operator can mistake for the run they
+           just did. The specific failure being defended against is a reload
+           destroying the only record of creations that cannot be undone. -->
+      <div x-show="restored" x-cloak
+           class="rounded-xl bg-sky-50 border border-sky-200 text-sky-900 px-4 py-3 text-sm mb-5">
+        <div class="font-semibold" x-text="restoredLine()"></div>
+        <div class="text-xs mt-1 opacity-90">
+          Contacts and School Passes cannot be deleted, so this is the only record of what that run
+          created. Keep a copy before discarding it.
+        </div>
+        <div class="flex gap-2 mt-2">
+          <button type="button" class="chip" @click="openRestored()">Open it</button>
+          <button type="button" class="chip" @click="discardRestored()">Discard it</button>
+        </div>
       </div>
 
       <!-- ── Step strip ──────────────────────────────────────────────────── -->
@@ -1204,18 +1233,193 @@
               </div>
             </div>
 
+            <!-- The confirm step. What is being confirmed is not "are you
+                 sure" — the permanence line above already says what will be
+                 written — but the COST, which nothing else on the page can
+                 tell them: several minutes of an allowance the whole gym
+                 shares (§6). Staff who know that pick a quiet moment. -->
+            <div x-show="confirming" x-cloak
+                 class="rounded-xl bg-amber-50 border border-amber-300 text-amber-900 px-3.5 py-3 text-sm mt-6">
+              <div class="font-semibold">Before this starts</div>
+              <div class="mt-1" x-text="runCost()"></div>
+              <div class="mt-1" x-text="permanenceLine()"></div>
+              <div class="text-xs mt-1 opacity-90">
+                Leave this tab open. Every student is written one at a time, and closing the page
+                mid-run loses the record of what was created.
+              </div>
+              <div class="flex gap-2 mt-3">
+                <button type="button"
+                        class="bg-uj hover:bg-uj-dark text-white rounded-xl px-4 py-2 text-sm font-semibold"
+                        @click="apply()">Start the run</button>
+                <button type="button" class="chip" @click="standDown()">Not now</button>
+              </div>
+            </div>
+
             <div class="flex justify-between mt-6">
               <button type="button" class="text-sm text-neutral-500 hover:text-neutral-800" @click="go(3)">← Back</button>
-              <!-- Apply is staff-site#73. Gated here anyway: the gates are the
-                   deliverable of this step, and a button wired to nothing is
-                   safer than a button wired to half a write chain. -->
-              <button type="button" disabled
-                      :title="preview.ready ? 'Every gate is clear. The run engine is staff-site#73' : 'Something above is still blocking'"
-                      class="rounded-xl px-5 py-2.5 text-sm font-semibold bg-neutral-100 text-neutral-400 cursor-not-allowed"
-                      x-text="preview.ready ? 'Apply (not built yet)' : 'Apply — blocked'"></button>
+              <button type="button" :disabled="!preview.ready || running || confirming"
+                      :title="preview.ready ? 'Nothing above is blocking' : 'Something above is still blocking'"
+                      :class="preview.ready && !running && !confirming
+                        ? 'bg-uj hover:bg-uj-dark text-white'
+                        : 'bg-neutral-100 text-neutral-400 cursor-not-allowed'"
+                      class="rounded-xl px-5 py-2.5 text-sm font-semibold"
+                      @click="askApply()"
+                      x-text="preview.ready ? 'Apply' : 'Apply — blocked'"></button>
             </div>
           </div>
         </template>
+      </section>
+
+      <!-- ── 6 · Result ──────────────────────────────────────────────────── -->
+      <!-- D11 — the same rows in the same order, in past tense. Not a new
+           screen with a new mental model: the sentence above the preview table
+           and the sentence above this one are the same sentence, before and
+           after, which is the only way to check that what happened is what was
+           agreed to. -->
+      <section x-show="stepIndex === 5">
+        <h2 class="text-lg font-bold mb-1">What happened</h2>
+        <p class="text-sm text-neutral-500 mb-5 max-w-2xl">
+          Contacts and School Passes are permanent — the Clubworx API has no delete for either.
+          Bookings are the one thing that can be taken back.
+        </p>
+
+        <div class="rounded-xl bg-sky-50 border border-sky-200 text-sky-900 px-3.5 py-2.5 text-sm mb-3"
+             x-show="runState === 'running'" x-cloak>
+          <span x-text="runProgress"></span>
+          One student at a time — the Clubworx allowance is shared with the whole gym. Leave this tab open.
+        </div>
+
+        <!-- A halt says why, and says that what is above it is untouched. -->
+        <div class="rounded-xl bg-rose-50 border border-rose-200 text-rose-800 px-3.5 py-2.5 text-sm mb-3"
+             x-show="runState === 'halted'" x-cloak>
+          <div class="font-semibold">The run stopped early</div>
+          <div class="text-xs mt-1 opacity-90" x-text="runMessage"></div>
+          <div class="text-xs mt-1 opacity-90">
+            Re-running the same list is safe and is how this is finished: students already done come
+            back as <span class="mono">already booked</span>.
+          </div>
+        </div>
+
+        <div class="rounded-xl px-3.5 py-3 text-sm mb-3 bg-amber-50 border border-amber-300 text-amber-900"
+             x-show="resultLine()" x-cloak>
+          <div class="font-semibold" x-text="resultLine()"></div>
+          <div class="mt-1.5" x-show="strandedWarning()" x-cloak x-text="strandedWarning()"></div>
+        </div>
+
+        <div class="rounded-card border border-neutral-200 overflow-hidden bg-white"
+             x-show="runRecords.length > 0" x-cloak>
+          <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-neutral-50 border-b border-neutral-200">
+              <tr class="text-left text-[0.68rem] uppercase tracking-wider text-neutral-500">
+                <th scope="col" class="px-4 py-2">#</th>
+                <th scope="col" class="px-4 py-2">Student</th>
+                <th scope="col" class="px-4 py-2">DOB</th>
+                <th scope="col" class="px-4 py-2">Result</th>
+                <th scope="col" class="px-4 py-2">What happened</th>
+              </tr>
+            </thead>
+            <template x-for="(record, index) in runRecords" :key="record.key">
+              <tbody>
+                <tr class="border-b border-neutral-100 row-hit lane"
+                    :class="record.state === 'booked' || record.state === 'already booked' ? 'lane-ok' : 'lane-need'"
+                    @click="toggleResultRow(record.key)">
+                  <td class="px-4 py-2 mono text-[0.7rem] text-neutral-400" x-text="index + 1"></td>
+                  <td class="px-4 py-2">
+                    <span class="mono text-[0.66rem] text-neutral-400 mr-1"
+                          x-text="expandedResult === record.key ? '▾' : '▸'"></span>
+                    <span x-text="record.name"></span>
+                  </td>
+                  <td class="px-4 py-2 mono text-[0.75rem]" x-text="record.dob || '—'"></td>
+                  <td class="px-4 py-2">
+                    <span class="px-1.5 py-0.5 rounded text-[0.68rem] font-medium"
+                          :class="resultTone(record)" x-text="record.state"></span>
+                  </td>
+                  <td class="px-4 py-2 text-[0.8rem] text-neutral-600" x-text="record.label"></td>
+                </tr>
+
+                <tr x-show="expandedResult === record.key" x-cloak class="border-b border-neutral-100 bg-neutral-50/60">
+                  <td colspan="5" class="px-4 py-3">
+                    <div class="text-[0.78rem] text-neutral-600 mb-2">└ <span x-text="record.detail"></span></div>
+
+                    <!-- The booking ids, because a stranded or half-cancelled
+                         student is finished by hand in Clubworx and this is
+                         what a human needs to find them. -->
+                    <div x-show="record.bookings.length > 0" x-cloak>
+                      <span class="field-label">Bookings</span>
+                      <div class="space-y-1">
+                        <template x-for="b in record.bookings" :key="b.event_id">
+                          <div class="flex items-center gap-2 flex-wrap text-[0.78rem]">
+                            <span class="mono text-[0.7rem] text-neutral-500" x-text="b.event_id"></span>
+                            <span x-text="b.state"></span>
+                            <span class="mono text-[0.7rem] text-neutral-400" x-text="b.booking_id || ''"></span>
+                            <span class="text-amber-800" x-show="b.shown" x-cloak x-text="b.shown"></span>
+                          </div>
+                        </template>
+                      </div>
+                    </div>
+
+                    <div class="text-[0.78rem] text-neutral-600 mt-2" x-show="record.cancel" x-cloak>
+                      <span class="field-label">Cancel</span>
+                      <span x-text="cancelLine(record)"></span>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </template>
+          </table>
+          </div>
+        </div>
+
+        <!-- D12 — there is no button called "Undo". The permanence of the two
+             records this cannot touch is stated BESIDE the control, not in a
+             footnote, and the count is what the interlock allows: rows this
+             run booked, never a row that was already there. -->
+        <div class="rounded-xl border border-neutral-200 bg-white px-3.5 py-3 text-sm mt-4"
+             x-show="runRecords.length > 0 && runState !== 'running'" x-cloak>
+          <div class="font-semibold">Taking it back</div>
+          <div class="text-xs text-neutral-500 mt-1">
+            Only bookings can be cancelled. The contacts and School Passes this run created stay in
+            Clubworx — the API has no delete for either, and cancelling does not restore what was
+            there before.
+          </div>
+          <div class="text-xs text-neutral-500 mt-1" x-show="cancellableCount() === 0" x-cloak>
+            Nothing here was booked by this run, so there is nothing to cancel. Bookings that were
+            already there are never touched.
+          </div>
+
+          <div class="flex gap-2 mt-3 items-center flex-wrap" x-show="!cancelConfirming" x-cloak>
+            <button type="button" :disabled="cancellableCount() === 0 || running"
+                    class="rounded-xl px-4 py-2 text-sm font-semibold border border-rose-300 text-rose-700 disabled:opacity-40"
+                    @click="askCancel()"
+                    x-text="`Cancel ${cancellableCount()} booking${cancellableCount() === 1 ? '' : 's'} from this run`"></button>
+            <button type="button" class="chip" @click="copyRecord()"
+                    x-text="copied ? 'Copied' : 'Copy the record'"></button>
+            <button type="button" class="chip" @click="downloadRecord()">Download the record</button>
+          </div>
+
+          <div class="mt-3" x-show="cancelConfirming" x-cloak>
+            <div class="text-[0.82rem] text-rose-800 font-semibold"
+                 x-text="`Cancel ${cancellableCount()} booking${cancellableCount() === 1 ? '' : 's'}?`"></div>
+            <div class="text-xs text-neutral-500 mt-1">
+              The contacts and passes stay. Bookings that were already in Clubworx before this run
+              are not touched.
+            </div>
+            <div class="flex gap-2 mt-2">
+              <button type="button" class="rounded-xl px-4 py-2 text-sm font-semibold bg-rose-600 text-white"
+                      @click="cancelRun()">Yes, cancel them</button>
+              <button type="button" class="chip" @click="standDownCancel()">Keep them</button>
+            </div>
+          </div>
+
+          <div class="text-xs mt-2" x-show="cancelState === 'running'" x-cloak>Cancelling, one student at a time…</div>
+          <div class="text-xs mt-2 text-rose-700" x-show="cancelState === 'halted'" x-cloak x-text="cancelMessage"></div>
+        </div>
+
+        <div class="flex justify-between mt-6">
+          <button type="button" class="text-sm text-neutral-500 hover:text-neutral-800"
+                  :disabled="running" @click="go(4)">← Back to the preview</button>
+        </div>
       </section>
 
     </div>
@@ -1223,7 +1427,10 @@
 
   <footer class="max-w-[1100px] mx-auto w-full px-4 pb-8 text-xs text-neutral-500">
     <div class="border-t border-neutral-200 pt-4 flex flex-wrap items-center justify-between gap-x-5 gap-y-1">
-      <span>Nothing on this page writes anything. Apply and the result table are staff-site#73.</span>
+      <span>
+        Steps 1–5 read only. <b>Apply writes</b>: contacts and School Passes are permanent, bookings
+        can be cancelled. The record of a run is kept in this browser only.
+      </span>
     </div>
   </footer>
 
@@ -1234,16 +1441,15 @@ const COLUMN_ROLES = ['dob', 'firstName', 'lastName', 'combined'];
 
 function schoolBooking() {
   return {
-    // Six steps, because six is the shape of the run (§9). The last three are
-    // not built; `built` is what the strip and the forward button read, so
-    // there is one place to change when #72 and #73 land.
+    // Six steps, because six is the shape of the run (§9). `built` is what the
+    // strip and the forward button read; all six are built as of #73.
     STEPS: [
       { key: 'school',   label: 'School',   built: true },
       { key: 'paste',    label: 'Paste',    built: true },
       { key: 'rows',     label: 'Rows',     built: true },
       { key: 'sessions', label: 'Sessions', built: true },
       { key: 'preview',  label: 'Preview',  built: true },
-      { key: 'result',   label: 'Result',   built: false },
+      { key: 'result',   label: 'Result',   built: true },
     ],
     stepIndex: 0,
     maxStepReached: 0,
@@ -1325,6 +1531,31 @@ function schoolBooking() {
     decisions: {},
     expandedPreview: null,
 
+    // Step 6 — the run
+    // The confirm panel between Apply and the first write. §6 sizes a run at
+    // ~4 minutes of a gym-wide allowance, and staff are told that before it
+    // starts rather than discovering it as a slow afternoon.
+    confirming: false,
+    // The single-flight lock (D13). A double-click on Apply, or a resubmit
+    // mid-run, is the one re-run case that does need special handling.
+    running: false,
+    runRecords: [],
+    runState: 'idle',
+    runReason: null,
+    runMessage: '',
+    runProgress: '',
+    runAt: null,
+    runSessionLabels: [],
+    expandedResult: null,
+    cancelState: 'idle',
+    cancelMessage: '',
+    cancelConfirming: false,
+    // A run found in this browser's storage at load — D10's whole purpose. It
+    // is offered, never auto-opened: it may be yesterday's, and the operator
+    // has to know which run they are looking at.
+    restored: null,
+    copied: false,
+
     init() {
       // Both modules or neither. Every gate on this page is one of their
       // exports, so a partial load is a page that looks like it is checking
@@ -1336,10 +1567,15 @@ function schoolBooking() {
       if (!window.schoolBookingEvents?.selectionReport) missing.push('the session rules');
       if (!window.schoolBookingPreview?.buildPreview) missing.push('the preview rules');
       if (!window.schoolBookingCalendar?.monthGrid) missing.push('the calendar');
+      if (!window.schoolBookingOutcome?.studentRecord) missing.push('the outcome rules');
+      if (!window.schoolBookingRun?.runStudents) missing.push('the run engine');
       if (missing.length) {
         this.bootstrapError = `Could not load ${missing.join(' and ')}.`;
         return;
       }
+      // D10 — before anything else. A reload mid-run is the failure this
+      // defends against, so the record has to be found on the way back in.
+      this.restored = this.store().load();
       this.loadSchools();
     },
 
@@ -2228,6 +2464,285 @@ function schoolBooking() {
       if (line.clubworx === 'new') return 'text-sky-700 bg-sky-50';
       if (line.clubworx === '') return 'text-neutral-500 bg-neutral-100';
       return 'text-amber-700 bg-amber-50';
+    },
+
+    // --- step 6, the run --------------------------------------------------
+    // The engine itself is `school-booking/run.js`, taking an injected caller
+    // (#78). Everything below is the page's half: the gate, the lock, the
+    // storage and the rendering. Nothing here decides a retry, a halt or the
+    // cancel interlock — those have tests, and this does not.
+
+    /** D10's store. A private window has no `localStorage`; `runStore` copes. */
+    store() {
+      return window.schoolBookingRun.runStore(
+        (typeof window !== 'undefined' && window.localStorage) || null,
+        'uj-school-booking-run',
+      );
+    },
+
+    /**
+     * What the run costs, said before it starts.
+     *
+     * §6: the Clubworx allowance is 75 a minute and **gym-wide** — the roster
+     * Worker and the automations spend it unseen. A school import is therefore
+     * a several-minute gym-wide slowdown, and staff who are told that can pick
+     * a quiet moment. Staff who are not told it report a broken roster.
+     */
+    runCost() {
+      const students = this.preview?.totals?.students ?? 0;
+      const sessions = this.preview?.sessions?.length ?? 0;
+      if (students === 0) return '';
+      const requests = students * (4 + sessions);
+      const minutes = Math.max(1, Math.ceil(requests / 75));
+      return `About ${requests} Clubworx requests — roughly ${minutes} minute${minutes === 1 ? '' : 's'} `
+        + 'at the 75-a-minute allowance, which is shared with the whole gym. The roster and the '
+        + 'automations will be slow while this runs.';
+    },
+
+    askApply() {
+      if (!this.preview?.ready || this.running) return;
+      this.confirming = true;
+    },
+
+    standDown() {
+      this.confirming = false;
+    },
+
+    /**
+     * Apply.
+     *
+     * The lock is D13's: a re-paste needs no warning — it is the recovery path —
+     * but a double-click or a mid-run resubmit does, because it would run the
+     * same student twice concurrently and spend the allowance racing itself.
+     */
+    async apply() {
+      if (!this.preview?.ready || this.running) return;
+
+      const students = window.schoolBookingRun.runList({
+        preview: this.preview,
+        rows: this.reviewed?.rows ?? [],
+        email: this.marker(),
+      });
+      if (students.length === 0) return;
+
+      this.confirming = false;
+      this.running = true;
+      this.runState = 'running';
+      this.runReason = null;
+      this.runMessage = '';
+      this.runRecords = [];
+      this.cancelState = 'idle';
+      this.cancelMessage = '';
+      this.runAt = new Date().toISOString();
+      this.runSessionLabels = (this.preview.sessions ?? []).map((e) => e.event_start_at);
+      this.expandedResult = null;
+      this.runProgress = `Starting ${students.length} student${students.length === 1 ? '' : 's'}…`;
+      this.guardUnload(true);
+      this.go(5);
+
+      const result = await window.schoolBookingRun.runStudents({
+        students,
+        call: (payload) => this.callWorker('/api/clubworx/student', payload),
+        onRow: (record, records) => {
+          // Published and stored per student. An end-of-run write is the one
+          // that is missing when the tab is closed on student 19.
+          this.runRecords = [...records];
+          this.runProgress = `${records.length} of ${students.length} done…`;
+          this.saveRun();
+        },
+      });
+
+      this.runRecords = [...result.records];
+      this.runState = result.state;
+      this.runReason = result.reason;
+      this.runMessage = result.message;
+      this.runProgress = '';
+      this.running = false;
+      this.guardUnload(false);
+      this.saveRun();
+    },
+
+    /**
+     * One Worker call, as the engine wants it: a status and a parsed body, and
+     * a throw only when the request itself failed.
+     *
+     * A non-200 is **not** thrown. On these two routes the body IS the record
+     * of what was written (§12), and throwing is how a client ends up
+     * discarding it.
+     */
+    async callWorker(path, payload) {
+      const res = await fetch(path, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      let body = null;
+      try {
+        body = await res.json();
+      } catch {
+        body = null;
+      }
+      return { status: res.status, body };
+    },
+
+    saveRun() {
+      this.store().save({
+        at: this.runAt,
+        school: this.tag,
+        sessions: this.runSessionLabels,
+        state: this.runState,
+        records: this.runRecords,
+      });
+    },
+
+    /**
+     * The `beforeunload` warning — D13's other half.
+     *
+     * Only while a run is in flight. A permanent contact that has been created
+     * and not yet recorded on this page is the one thing a reload can destroy
+     * for good.
+     */
+    guardUnload(on) {
+      if (typeof window?.addEventListener !== 'function') return;
+      if (on) {
+        this.unloadGuard = (event) => { event.preventDefault(); event.returnValue = ''; };
+        window.addEventListener('beforeunload', this.unloadGuard);
+      } else if (this.unloadGuard) {
+        window.removeEventListener('beforeunload', this.unloadGuard);
+        this.unloadGuard = null;
+      }
+    },
+    unloadGuard: null,
+
+    resultLine() {
+      return window.schoolBookingOutcome.resultLine(this.runRecords);
+    },
+
+    strandedWarning() {
+      return window.schoolBookingOutcome.strandedWarning(this.runRecords);
+    },
+
+    resultTone(record) {
+      if (record.state === 'booked') return 'text-emerald-700 bg-emerald-50';
+      if (record.state === 'already booked') return 'text-sky-700 bg-sky-50';
+      if (record.state === 'stranded' || record.state === 'failed') return 'text-rose-700 bg-rose-50';
+      if (record.state === 'not run') return 'text-neutral-500 bg-neutral-100';
+      return 'text-amber-700 bg-amber-50';
+    },
+
+    toggleResultRow(key) {
+      this.expandedResult = this.expandedResult === key ? null : key;
+    },
+
+    /** How many bookings the cancel control would act on — D12's interlock. */
+    cancellableCount() {
+      return this.runRecords.reduce(
+        (total, record) => total + window.schoolBookingOutcome.cancellable(record).length,
+        0,
+      );
+    },
+
+    askCancel() {
+      if (this.cancellableCount() === 0 || this.running) return;
+      this.cancelConfirming = true;
+    },
+
+    standDownCancel() {
+      this.cancelConfirming = false;
+    },
+
+    /**
+     * "Cancel bookings from this run" — never "Undo".
+     *
+     * It reaches bookings and nothing else. The contacts and the School Passes
+     * this run created stay, because the API has no delete for either, and the
+     * button's own label plus the sentence beside it are where staff read that
+     * — not a footnote after the fact.
+     */
+    async cancelRun() {
+      if (this.running) return;
+      this.cancelConfirming = false;
+      this.running = true;
+      this.cancelState = 'running';
+      this.cancelMessage = '';
+      this.guardUnload(true);
+
+      const result = await window.schoolBookingRun.cancelStudents({
+        records: this.runRecords,
+        call: (payload) => this.callWorker('/api/clubworx/unbook', payload),
+        onRow: (record, records) => {
+          this.runRecords = [...records];
+          this.saveRun();
+        },
+      });
+
+      this.runRecords = [...result.records];
+      this.cancelState = result.state === 'halted' ? 'halted' : 'done';
+      this.cancelMessage = result.message;
+      this.running = false;
+      this.guardUnload(false);
+      this.saveRun();
+    },
+
+    /** The line a cancelled row shows, in the Worker's own words. */
+    cancelLine(record) {
+      if (!record.cancel) return '';
+      const c = record.cancel;
+      const head = `${c.cancelled ?? 0} cancelled`;
+      return c.message ? `${head} — ${c.message}` : head;
+    },
+
+    recordText() {
+      return window.schoolBookingOutcome.runRecordText(this.runRecords, {
+        school: this.tag,
+        at: this.runAt,
+        sessions: this.runSessionLabels,
+      });
+    },
+
+    async copyRecord() {
+      try {
+        await navigator.clipboard.writeText(this.recordText());
+        this.copied = true;
+        setTimeout(() => { this.copied = false; }, 2000);
+      } catch {
+        this.copied = false;
+      }
+    },
+
+    downloadRecord() {
+      const blob = new Blob([this.recordText()], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `school-booking-${this.tag || 'run'}-${(this.runAt || '').slice(0, 10)}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+    },
+
+    // --- the run this browser was already holding -------------------------
+    openRestored() {
+      if (!this.restored) return;
+      this.runRecords = this.restored.records ?? [];
+      this.runAt = this.restored.at ?? null;
+      this.runSessionLabels = this.restored.sessions ?? [];
+      this.runState = this.restored.state ?? 'complete';
+      this.restored = null;
+      this.maxStepReached = 5;
+      this.go(5);
+    },
+
+    discardRestored() {
+      this.store().clear();
+      this.restored = null;
+    },
+
+    restoredLine() {
+      if (!this.restored) return '';
+      const count = (this.restored.records ?? []).length;
+      const when = (this.restored.at ?? '').slice(0, 16).replace('T', ' ');
+      return `A run of ${count} student${count === 1 ? '' : 's'}${this.restored.school ? ` for ${this.restored.school}` : ''}`
+        + `${when ? `, started ${when}` : ''}, is saved in this browser.`;
     },
 
     go(index) {

--- a/school-booking.html
+++ b/school-booking.html
@@ -1570,7 +1570,7 @@ function schoolBooking() {
     runMessage: '',
     runProgress: '',
     runAt: null,
-    runSessionLabels: [],
+    runSessionStarts: [],
     expandedResult: null,
     cancelState: 'idle',
     cancelMessage: '',
@@ -2559,7 +2559,7 @@ function schoolBooking() {
       this.cancelState = 'idle';
       this.cancelMessage = '';
       this.runAt = new Date().toISOString();
-      this.runSessionLabels = (this.preview.sessions ?? []).map((e) => e.event_start_at);
+      this.runSessionStarts = (this.preview.sessions ?? []).map((e) => e.event_start_at);
       this.expandedResult = null;
       this.runProgress = `Starting ${students.length} student${students.length === 1 ? '' : 's'}…`;
       this.guardUnload(true);
@@ -2614,7 +2614,7 @@ function schoolBooking() {
       this.store().save({
         at: this.runAt,
         school: this.tag,
-        sessions: this.runSessionLabels,
+        sessions: this.runSessionStarts,
         state: this.runState,
         records: this.runRecords,
       });
@@ -2713,19 +2713,15 @@ function schoolBooking() {
       return window.schoolBookingOutcome.cancelReport(record);
     },
 
-    /** The line a cancelled row shows, in the Worker's own words. */
     cancelLine(record) {
-      if (!record.cancel) return '';
-      const c = record.cancel;
-      const head = `${c.cancelled ?? 0} cancelled`;
-      return c.message ? `${head} — ${c.message}` : head;
+      return window.schoolBookingOutcome.cancelLine(record);
     },
 
     recordText() {
       return window.schoolBookingOutcome.runRecordText(this.runRecords, {
         school: this.tag,
         at: this.runAt,
-        sessions: this.runSessionLabels,
+        sessions: this.runSessionStarts,
       });
     },
 
@@ -2754,7 +2750,7 @@ function schoolBooking() {
       if (!this.restored) return;
       this.runRecords = this.restored.records ?? [];
       this.runAt = this.restored.at ?? null;
-      this.runSessionLabels = this.restored.sessions ?? [];
+      this.runSessionStarts = this.restored.sessions ?? [];
       this.runState = this.restored.state ?? 'complete';
       this.restored = null;
       this.maxStepReached = 5;

--- a/school-booking.html
+++ b/school-booking.html
@@ -1359,10 +1359,35 @@
                       </div>
                     </div>
 
-                    <div class="text-[0.78rem] text-neutral-600 mt-2" x-show="record.cancel" x-cloak>
-                      <span class="field-label">Cancel</span>
-                      <span x-text="cancelLine(record)"></span>
-                    </div>
+                    <!-- The cancel's own record. `failed[]` and `stillBooked[]`
+                         arrive on a 200 because they are the list of what a
+                         human still has to remove by hand — so they are shown,
+                         not folded into a count. Rows the Worker did not try
+                         after a throttle are kept apart: those are still there
+                         and still cancellable from this page. -->
+                    <template x-if="cancelReport(record)">
+                      <div class="text-[0.78rem] text-neutral-600 mt-2">
+                        <span class="field-label">Cancel</span>
+                        <div x-text="cancelLine(record)"></div>
+                        <div class="text-amber-800 mt-1" x-show="!cancelReport(record).verified && cancelReport(record).cancelled > 0" x-cloak>
+                          Accepted, but not confirmed by a re-read — check this student in Clubworx
+                          before assuming these are gone.
+                        </div>
+                        <template x-if="cancelReport(record).byHand.length > 0">
+                          <div class="text-rose-700 mt-1">
+                            <div>Still in Clubworx — remove these by hand:</div>
+                            <template x-for="left in cancelReport(record).byHand" :key="left.booking_id || left.event_id">
+                              <div class="mono text-[0.7rem]">
+                                <span x-text="left.booking_id || left.event_id"></span>
+                                <span class="font-sans" x-text="' — ' + left.reason"></span>
+                              </div>
+                            </template>
+                          </div>
+                        </template>
+                        <div class="text-amber-800 mt-1" x-show="cancelReport(record).notAttempted.length > 0" x-cloak
+                             x-text="`${cancelReport(record).notAttempted.length} booking(s) were not tried — Clubworx began throttling. They are still there and can be cancelled again shortly.`"></div>
+                      </div>
+                    </template>
                   </td>
                 </tr>
               </tbody>
@@ -2682,6 +2707,10 @@ function schoolBooking() {
       this.running = false;
       this.guardUnload(false);
       this.saveRun();
+    },
+
+    cancelReport(record) {
+      return window.schoolBookingOutcome.cancelReport(record);
     },
 
     /** The line a cancelled row shows, in the Worker's own words. */

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -81,6 +81,7 @@ export function studentRecord({ student, status = null, body = null, error = nul
     strandedDetail: null,
     rollback: null,
     warnings: [],
+    rolledBack: 0,
     throttled: false,
     // Filled by the cancel pass, and only then — an absent cancel and a cancel
     // that did nothing are different facts.
@@ -104,7 +105,13 @@ export function studentRecord({ student, status = null, body = null, error = nul
   const reply = body ?? {};
   const outcome = reply.outcome ?? 'failed';
   const bookings = Array.isArray(reply.bookings) ? reply.bookings : [];
-  const booked = bookings.filter((b) => b?.state === 'booked').length;
+  // D3's rollback has already cancelled these, and the Worker hands the rows
+  // back unmutated — so counting every `booked` row would report bookings that
+  // no longer exist as ones staff could still cancel.
+  const rolledBack = new Set((reply.rollback?.cancelledIds ?? []).map(String));
+  const booked = bookings.filter(
+    (b) => b?.state === 'booked' && !rolledBack.has(String(b?.booking_id)),
+  ).length;
   const alreadyBooked = bookings.filter((b) => b?.state === 'already booked').length;
   const throttled = reply.reason === 'throttled';
 
@@ -122,6 +129,7 @@ export function studentRecord({ student, status = null, body = null, error = nul
     stranded: reply.stranded === true,
     strandedDetail: reply.strandedDetail ?? null,
     rollback: reply.rollback ?? null,
+    rolledBack: rolledBack.size,
     warnings: Array.isArray(reply.warnings) ? reply.warnings : [],
     throttled,
     detail: reply.message ?? '',
@@ -204,14 +212,46 @@ function doneLine(row) {
  *     ids that are gone and read the refusals as a new failure.
  */
 export function cancellable(record) {
-  const gone = cancelledIds(record);
+  const gone = goneIds(record);
   return (record?.bookings ?? []).filter(
     (b) => b?.state === 'booked' && b?.booking_id && !gone.has(String(b.booking_id)),
   );
 }
 
-/** The booking ids a previous cancel already removed. One rule, one home. */
-const cancelledIds = (record) => new Set((record?.cancel?.cancelledIds ?? []).map(String));
+/**
+ * Every booking id that is already gone. One rule, one home.
+ *
+ * **Two sources, and missing the second is a bug that re-cancels.** The obvious
+ * one is a previous run of the human control (`record.cancel`). The other is
+ * **D3's automatic rollback**: when a student is abandoned the Worker cancels
+ * that student's bookings itself and reports them in `rollback.cancelledIds` —
+ * but it hands back the booking rows **unmutated**, so they still read
+ * `state: 'booked'` and still carry live-looking ids. Reading only `cancel`
+ * therefore offers to cancel bookings the Worker already cancelled, on exactly
+ * the rows whose own `strandedDetail` says the student has *no bookings from
+ * this run*.
+ */
+const goneIds = (record) => new Set([
+  ...(record?.cancel?.cancelledIds ?? []),
+  ...(record?.rollback?.cancelledIds ?? []),
+].map(String));
+
+/**
+ * The bookings as they now stand, with the rows that are gone saying so.
+ *
+ * The Worker's row is a record of what the *booking call* did, and it is not
+ * rewritten when a later cancel removes it. Rendering it raw shows `booked`
+ * beside an id that no longer exists — and that id is the one a human would
+ * then go looking for in Clubworx.
+ */
+export function bookingRows(record) {
+  const gone = goneIds(record);
+  const rolled = new Set((record?.rollback?.cancelledIds ?? []).map(String));
+  return (record?.bookings ?? []).map((b) => {
+    if (b?.state !== 'booked' || !gone.has(String(b?.booking_id))) return b;
+    return { ...b, state: rolled.has(String(b.booking_id)) ? 'rolled back' : 'cancelled' };
+  });
+}
 
 /**
  * The rows to send to `POST /unbook` for one student.
@@ -228,7 +268,7 @@ const cancelledIds = (record) => new Set((record?.cancel?.cancelledIds ?? []).ma
  * screenful of new failures.
  */
 export function cancelRows(record) {
-  const gone = cancelledIds(record);
+  const gone = goneIds(record);
   return (record?.bookings ?? []).filter((b) => !gone.has(String(b?.booking_id ?? '')));
 }
 
@@ -305,6 +345,7 @@ export function resultTotals(records) {
     failed: 0,
     stranded: 0,
     cancelled: 0,
+    rolledBack: 0,
     notRun: 0,
   };
 
@@ -314,6 +355,7 @@ export function resultTotals(records) {
     totals.bookings += row.booked;
     totals.alreadyBooked += row.alreadyBooked;
     totals.cancelled += row.cancel?.cancelled ?? 0;
+    totals.rolledBack += row.rolledBack ?? 0;
     if (row.stranded) totals.stranded += 1;
     if (row.state === 'refused') totals.refused += 1;
     if (row.state === 'not run') totals.notRun += 1;
@@ -321,6 +363,44 @@ export function resultTotals(records) {
   }
 
   return totals;
+}
+
+/**
+ * A student the run never reached.
+ *
+ * D11 is *"the same rows, same order"*, and a halt that quietly shortens the
+ * table breaks the half of that which matters most: staff need to see **where
+ * it got to**, and a table of 5 rows after a halt at student 5 of 25 reads as a
+ * list of 5 students rather than a run that stopped. Nothing was written for
+ * these, so re-running the list is how they are finished (D5).
+ */
+export function notRunRecord(student, detail) {
+  return {
+    key: student?.key ?? null,
+    name: student?.name ?? '',
+    dob: student?.dob ?? null,
+    sessions: student?.sessions ?? 0,
+    contactKey: student?.contactKey ?? null,
+    status: null,
+    outcome: 'not-run',
+    reason: 'not-run',
+    state: 'not run',
+    label: 'not run',
+    detail,
+    bookings: [],
+    booked: 0,
+    alreadyBooked: 0,
+    contactCreated: false,
+    passGranted: false,
+    written: false,
+    stranded: false,
+    strandedDetail: null,
+    rollback: null,
+    rolledBack: 0,
+    warnings: [],
+    throttled: false,
+    cancel: null,
+  };
 }
 
 /** Row numbers, 1-based, for the states staff have to go and look at. */
@@ -351,6 +431,10 @@ export function resultLine(records) {
       ? `${plural(t.bookings, 'booking')} made, ${t.cancelled} cancelled since`
       : `${plural(t.bookings, 'booking')} made (can be cancelled)`,
   ];
+  // Without this the bookings total simply reads lower than the run made, with
+  // nothing on screen accounting for the difference. D3's rollback is a routine
+  // outcome, not an edge case, so it gets a clause.
+  if (t.rolledBack > 0) parts.push(`${plural(t.rolledBack, 'booking')} rolled back`);
   if (t.alreadyBooked > 0) parts.push(`${t.alreadyBooked} already booked`);
 
   const refused = rowsWhere(rows, (r) => r.state === 'refused');

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -210,6 +210,46 @@ export function cancellable(record) {
   );
 }
 
+/**
+ * What a cancel left behind, split by what a human actually has to do.
+ *
+ * `POST /unbook` returns `failed[]` and `stillBooked[]` on a **200** on purpose:
+ * a non-200 invites the page to throw the body away, and that body is the only
+ * record of which bookings a human still has to remove. So they are rendered,
+ * not summarised into a count.
+ *
+ * The split matters more than the total. `failed[].attempted === false` marks
+ * rows the Worker deliberately did **not** try after a throttle — those
+ * bookings are still there and still cancellable by clicking again, and listing
+ * them as needing manual removal would send staff into Clubworx to do by hand
+ * what one more click does. Everything else — a refused cancel, a row with no
+ * booking id, and an id that came back present on the verifying re-read — is
+ * genuinely a hand job.
+ *
+ * `verified: false` is **not** a synonym for failed. It means the cancel was
+ * accepted and could not be confirmed: go and look, rather than try again.
+ */
+export function cancelReport(record) {
+  const c = record?.cancel;
+  if (!c) return null;
+  const failed = Array.isArray(c.failed) ? c.failed : [];
+  return {
+    outcome: c.outcome ?? 'failed',
+    cancelled: c.cancelled ?? 0,
+    verified: c.verified === true,
+    message: c.message ?? '',
+    notAttempted: failed.filter((f) => f?.attempted === false),
+    byHand: [
+      ...failed.filter((f) => f?.attempted !== false),
+      ...(c.stillBooked ?? []).map((id) => ({
+        booking_id: id,
+        event_id: null,
+        reason: 'Clubworx accepted the cancellation and the booking was still there on a re-read',
+      })),
+    ],
+  };
+}
+
 /** Whether anything in the run can still be cancelled. */
 export function anyCancellable(records) {
   return (records ?? []).some((r) => cancellable(r).length > 0);

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -204,10 +204,32 @@ function doneLine(row) {
  *     ids that are gone and read the refusals as a new failure.
  */
 export function cancellable(record) {
-  const gone = new Set((record?.cancel?.cancelledIds ?? []).map(String));
+  const gone = cancelledIds(record);
   return (record?.bookings ?? []).filter(
     (b) => b?.state === 'booked' && b?.booking_id && !gone.has(String(b.booking_id)),
   );
+}
+
+/** The booking ids a previous cancel already removed. One rule, one home. */
+const cancelledIds = (record) => new Set((record?.cancel?.cancelledIds ?? []).map(String));
+
+/**
+ * The rows to send to `POST /unbook` for one student.
+ *
+ * The whole array `POST /student` handed back, less anything a previous cancel
+ * already removed — **not** pre-filtered down to `booked`. The Worker's
+ * `cancelRunBookings` owns the interlock and takes each row's own
+ * `contact_key`, so handing it the rows as they came keeps one authority for
+ * the rule rather than two that can drift. `cancellable` above is what decides
+ * whether a student is sent at all; this is what is in the envelope.
+ *
+ * Dropping ids a previous pass already cancelled is a different thing: those
+ * bookings are gone, and re-sending them turns a clean partial cancel into a
+ * screenful of new failures.
+ */
+export function cancelRows(record) {
+  const gone = cancelledIds(record);
+  return (record?.bookings ?? []).filter((b) => !gone.has(String(b?.booking_id ?? '')));
 }
 
 /**
@@ -248,6 +270,21 @@ export function cancelReport(record) {
       })),
     ],
   };
+}
+
+/**
+ * The cancel's headline, in the Worker's own words.
+ *
+ * `message` travels verbatim — it is the Worker's sentence about a set of
+ * bookings, and it already distinguishes "cancelled and confirmed gone" from
+ * "accepted and could not be confirmed", which is the distinction a re-wording
+ * would lose (D6).
+ */
+export function cancelLine(record) {
+  const c = record?.cancel;
+  if (!c) return '';
+  const head = `${c.cancelled ?? 0} cancelled`;
+  return c.message ? `${head} — ${c.message}` : head;
 }
 
 /** Whether anything in the run can still be cancelled. */

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -1,0 +1,343 @@
+// school-booking/outcome.js
+//
+// What one `POST /student` answer means, and what a whole run of them adds up
+// to. Pure over the Worker's reply; the page publishes it as
+// `window.schoolBookingOutcome`.
+//
+// staff-site#73. Design: `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+// §11 (the error vocabulary), §12 (irreversibility, D10, D11, D12).
+//
+// ---------------------------------------------------------------------------
+// Why the counting is done here and not in the table
+// ---------------------------------------------------------------------------
+// D11 keeps the three permanence classes apart rather than collapsing them into
+// a success count, because they are three different kinds of irreversible: a
+// contact and a pass cannot be taken back at all, and a booking can. A single
+// "58 succeeded" would be true and would hide the only distinction that matters
+// when something has gone wrong.
+//
+// Two of the functions below are safety-critical rather than presentational:
+//
+//   - **`isFailure`** feeds D7's circuit breaker. A `needs-confirmation` is a
+//     considered answer about one student's pass, not a systemic condition, so
+//     counting it would halt a run on three ordinary rows.
+//   - **`cancellable`** is D12's interlock. A row marked `already booked` was
+//     not made by this run; cancelling it would delete a booking a real member
+//     may have made themselves — #50's worst outcome. The Worker enforces the
+//     same rule (`cancelRunBookings`), and this page does not lean on that: a
+//     row it should never send is a row it does not send.
+
+const plural = (n, noun) => `${n} ${noun}${n === 1 ? '' : 's'}`;
+const passes = (n) => `${n} School ${n === 1 ? 'Pass' : 'Passes'}`;
+
+/** A pass state that means one was newly written, and therefore is permanent. */
+const GRANTED_PASS = new Set(['created-with-contact', 'granted']);
+
+/**
+ * Outcomes that are a considered answer rather than a fault.
+ *
+ * Everything else feeds the circuit breaker. `refused` is in the failing set on
+ * purpose: the refusals `POST /student` gives — a lead-time session, a pass that
+ * will not cover the term — are conditions of the *run*, so three in a row is
+ * exactly the systemic case D7 exists to stop.
+ */
+const SETTLED = new Set(['complete', 'needs-confirmation']);
+
+/** Whether this row counts toward D7's three-consecutive-failures halt. */
+export function isFailure(record) {
+  return !SETTLED.has(record?.outcome);
+}
+
+/**
+ * One student's answer, as the result table and `localStorage` both hold it.
+ *
+ * Takes the reply as `fetch` leaves it — a status and a parsed body — or an
+ * `error` string when the request never arrived. A transport failure is named
+ * `network` rather than borrowed from the outcome vocabulary: "the Worker said
+ * this student failed" and "nothing reached the Worker" send an operator to two
+ * different places, and only one of them may have written something.
+ *
+ * @param {object} opts
+ * @param {object} opts.student the row being run — key, name, dob, sessions
+ * @param {number|null} [opts.status] the HTTP status the Worker answered with
+ * @param {object|null} [opts.body] the parsed reply
+ * @param {string|null} [opts.error] set when the request itself failed
+ */
+export function studentRecord({ student, status = null, body = null, error = null }) {
+  const base = {
+    key: student?.key ?? null,
+    name: student?.name ?? '',
+    dob: student?.dob ?? null,
+    sessions: student?.sessions ?? 0,
+    contactKey: student?.contactKey ?? null,
+    status,
+    bookings: [],
+    booked: 0,
+    alreadyBooked: 0,
+    contactCreated: false,
+    passGranted: false,
+    written: false,
+    stranded: false,
+    strandedDetail: null,
+    rollback: null,
+    warnings: [],
+    throttled: false,
+    // Filled by the cancel pass, and only then — an absent cancel and a cancel
+    // that did nothing are different facts.
+    cancel: null,
+  };
+
+  if (error !== null && error !== undefined) {
+    return {
+      ...base,
+      outcome: 'network',
+      reason: 'network',
+      state: 'failed',
+      label: 'failed',
+      // Verbatim — D6. A paraphrase of an error nobody has seen before is how
+      // new behaviour becomes invisible.
+      detail: `The request did not reach Clubworx: ${error}. Nothing is known about this student — `
+        + 'check Clubworx before running them again.',
+    };
+  }
+
+  const reply = body ?? {};
+  const outcome = reply.outcome ?? 'failed';
+  const bookings = Array.isArray(reply.bookings) ? reply.bookings : [];
+  const booked = bookings.filter((b) => b?.state === 'booked').length;
+  const alreadyBooked = bookings.filter((b) => b?.state === 'already booked').length;
+  const throttled = reply.reason === 'throttled';
+
+  const row = {
+    ...base,
+    outcome,
+    reason: reply.reason ?? null,
+    bookings,
+    booked,
+    alreadyBooked,
+    contactKey: reply.contact?.contact_key ?? base.contactKey,
+    contactCreated: reply.contact?.state === 'created',
+    passGranted: GRANTED_PASS.has(reply.pass?.state),
+    written: reply.written === true,
+    stranded: reply.stranded === true,
+    strandedDetail: reply.strandedDetail ?? null,
+    rollback: reply.rollback ?? null,
+    warnings: Array.isArray(reply.warnings) ? reply.warnings : [],
+    throttled,
+    detail: reply.message ?? '',
+  };
+
+  // A throttle that changed nothing (the Worker's 429) is the one answer that
+  // is not about this student at all — the allowance is gym-wide. Saying
+  // "failed" would send staff looking at the row.
+  if (throttled && row.written === false) {
+    return {
+      ...row,
+      state: 'not run',
+      label: 'not run',
+      detail: 'Clubworx is busy — this can be caused by another system, not this page. '
+        + 'Nothing was written for this student.',
+    };
+  }
+
+  return { ...row, ...display(row) };
+}
+
+/** The cell and the sentence, from an outcome that has already been counted. */
+function display(row) {
+  if (row.outcome === 'complete') {
+    const state = row.booked > 0 ? 'booked' : 'already booked';
+    return {
+      state,
+      label: row.booked > 0
+        ? `${plural(row.booked, 'booking')}${row.alreadyBooked > 0 ? ` · ${row.alreadyBooked} already there` : ''}`
+        : `${plural(row.alreadyBooked, 'booking')} already there`,
+      detail: doneLine(row),
+    };
+  }
+
+  if (row.outcome === 'needs-confirmation') {
+    return {
+      state: 'needs you',
+      label: 'needs you',
+      detail: `${row.detail} Nothing has been written for this student.`,
+    };
+  }
+
+  if (row.outcome === 'refused') {
+    return { state: 'refused', label: 'refused', detail: row.detail || 'Refused before anything was written.' };
+  }
+
+  if (row.outcome === 'unverified') {
+    return { state: 'unverified', label: 'unverified', detail: row.detail };
+  }
+
+  // `abandoned` and `failed`. Which of the two it is matters less than whether
+  // a permanent record was left behind, which is what a human has to finish.
+  return {
+    state: row.stranded ? 'stranded' : 'failed',
+    label: row.stranded ? 'stranded' : 'failed',
+    detail: [row.detail, row.strandedDetail].filter(Boolean).join(' '),
+  };
+}
+
+/** The past-tense sentence for one completed student. */
+function doneLine(row) {
+  const made = [];
+  if (row.contactCreated) made.push('contact created (permanent)');
+  if (row.passGranted) made.push('School Pass assigned (permanent)');
+  if (row.booked > 0) made.push(`${plural(row.booked, 'booking')} made (cancellable)`);
+  if (row.alreadyBooked > 0) made.push(`${plural(row.alreadyBooked, 'booking')} already there`);
+  return made.join(' · ');
+}
+
+/**
+ * The bookings a cancel may act on — D12's interlock.
+ *
+ * Three conditions, and each removes a different way of cancelling something
+ * this run did not make:
+ *
+ *   - `state === 'booked'`, never `already booked`. The second is Clubworx
+ *     refusing our duplicate, which means the booking predates this run.
+ *   - a `booking_id`, because there is nothing to send without one.
+ *   - not already cancelled, so a second click on the control does not re-send
+ *     ids that are gone and read the refusals as a new failure.
+ */
+export function cancellable(record) {
+  const gone = new Set((record?.cancel?.cancelledIds ?? []).map(String));
+  return (record?.bookings ?? []).filter(
+    (b) => b?.state === 'booked' && b?.booking_id && !gone.has(String(b.booking_id)),
+  );
+}
+
+/** Whether anything in the run can still be cancelled. */
+export function anyCancellable(records) {
+  return (records ?? []).some((r) => cancellable(r).length > 0);
+}
+
+/** The run's tally, with the three permanence classes kept apart. */
+export function resultTotals(records) {
+  const rows = records ?? [];
+  const totals = {
+    students: rows.length,
+    contacts: 0,
+    passes: 0,
+    bookings: 0,
+    alreadyBooked: 0,
+    refused: 0,
+    failed: 0,
+    stranded: 0,
+    cancelled: 0,
+    notRun: 0,
+  };
+
+  for (const row of rows) {
+    if (row.contactCreated) totals.contacts += 1;
+    if (row.passGranted) totals.passes += 1;
+    totals.bookings += row.booked;
+    totals.alreadyBooked += row.alreadyBooked;
+    totals.cancelled += row.cancel?.cancelled ?? 0;
+    if (row.stranded) totals.stranded += 1;
+    if (row.state === 'refused') totals.refused += 1;
+    if (row.state === 'not run') totals.notRun += 1;
+    if (row.state === 'failed' || row.state === 'stranded' || row.state === 'unverified') totals.failed += 1;
+  }
+
+  return totals;
+}
+
+/** Row numbers, 1-based, for the states staff have to go and look at. */
+const rowsWhere = (records, predicate) =>
+  (records ?? [])
+    .map((row, index) => (predicate(row) ? index + 1 : null))
+    .filter((n) => n !== null);
+
+/**
+ * D11's summary — the same sentence the preview showed, in past tense.
+ *
+ * Refusals and failures are pointed at **by row number**, because that is the
+ * only handle staff have on a table of 63 students, and a count with nowhere to
+ * go is a count that gets ignored.
+ */
+export function resultLine(records) {
+  const rows = records ?? [];
+  if (rows.length === 0) return '';
+
+  const t = resultTotals(rows);
+  const parts = [
+    `${plural(t.contacts, 'contact')} created (permanent)`,
+    `${passes(t.passes)} assigned (permanent)`,
+    // "can be cancelled" stops being true the moment they have been, and a
+    // line that still offers the option after it was taken is the sentence
+    // staff would read to check whether the cancel worked.
+    t.cancelled > 0
+      ? `${plural(t.bookings, 'booking')} made, ${t.cancelled} cancelled since`
+      : `${plural(t.bookings, 'booking')} made (can be cancelled)`,
+  ];
+  if (t.alreadyBooked > 0) parts.push(`${t.alreadyBooked} already booked`);
+
+  const refused = rowsWhere(rows, (r) => r.state === 'refused');
+  if (refused.length > 0) parts.push(`${refused.length} refused — see ${rowList(refused)}`);
+
+  const failed = rowsWhere(rows, (r) => r.state === 'failed' || r.state === 'stranded' || r.state === 'unverified');
+  if (failed.length > 0) parts.push(`${failed.length} did not finish — see ${rowList(failed)}`);
+
+  const notRun = rowsWhere(rows, (r) => r.state === 'not run');
+  if (notRun.length > 0) parts.push(`${notRun.length} not run`);
+
+  return parts.join(' · ');
+}
+
+const rowList = (numbers) =>
+  numbers.length === 1 ? `row ${numbers[0]}` : `rows ${numbers.join(', ')}`;
+
+/**
+ * The stranded students, named.
+ *
+ * Not optional decoration: under D3's rollback an abandoned student is
+ * *guaranteed* to be left with a permanent contact and pass and no bookings, so
+ * this is a routine outcome staff must be able to see and finish by hand.
+ */
+export function strandedWarning(records) {
+  const stranded = (records ?? []).filter((r) => r.stranded);
+  if (stranded.length === 0) return '';
+  return `⚠ ${plural(stranded.length, 'student')} ${stranded.length === 1 ? 'has' : 'have'} a contact `
+    + `and a pass but no bookings: ${stranded.map((r) => r.name).join(', ')}. `
+    + 'Contacts and passes cannot be deleted — finish these by hand in Clubworx.';
+}
+
+/**
+ * The record staff keep — D10.
+ *
+ * JSON rather than prose, because the thing being defended against is a page
+ * reload destroying the only record of creations that cannot be undone, and the
+ * booking ids in it are what a later cancel or a hand-finish needs. It is
+ * pasted into a ticket or handed back to this page; either way a human re-typing
+ * a booking id is the failure this avoids.
+ */
+export function runRecordText(records, meta = {}) {
+  return JSON.stringify(
+    {
+      tool: 'school-booking',
+      school: meta.school ?? null,
+      at: meta.at ?? null,
+      sessions: meta.sessions ?? [],
+      summary: resultLine(records),
+      stranded: strandedWarning(records),
+      students: (records ?? []).map((row) => ({
+        name: row.name,
+        dob: row.dob,
+        contact_key: row.contactKey,
+        outcome: row.outcome,
+        state: row.state,
+        detail: row.detail,
+        contact_created: row.contactCreated,
+        pass_granted: row.passGranted,
+        bookings: row.bookings,
+        cancel: row.cancel,
+      })),
+    },
+    null,
+    2,
+  );
+}

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -1,0 +1,333 @@
+// school-booking/run.js
+//
+// The run engine: Apply, the per-student loop, the circuit breaker, and the
+// cancel. A pure module over an **injected caller** — the page publishes it as
+// `window.schoolBookingRun` and hands it a function that does the `fetch`.
+//
+// staff-site#73, seam decided on #78. Design:
+// `docs/superpowers/specs/2026-08-19-school-group-booking-design.md`
+// §10 (D1, the browser drives the run), §11 (D7 the breaker, D8 retries),
+// §12 (D10 the record, D12 the cancel interlock).
+//
+// ---------------------------------------------------------------------------
+// Why the caller is injected
+// ---------------------------------------------------------------------------
+// There is no DOM test infrastructure in this repo and none is being added, so
+// anything written inside the Alpine component has no automated cover at all.
+// Everything in this file runs when things are **already going wrong** — a
+// throttle, a run of failures, a page reload mid-run — which is precisely the
+// code nobody exercises by hand before shipping. With the caller injected it is
+// all reachable from vitest with no network.
+//
+// ---------------------------------------------------------------------------
+// D1 — one Worker call per student, and the browser paces them
+// ---------------------------------------------------------------------------
+// A four-minute one-shot response is not a shape the web is good at, and its
+// failure mode — **writes landed, log lost** — is the unrecoverable one here,
+// because a contact can never be deleted. Per-student calls make every
+// completed student durable on the client the instant it lands: `onRow` fires
+// after each one, and the page writes it to `localStorage` from there (D10).
+//
+// ---------------------------------------------------------------------------
+// A 429 is not about the student it landed on
+// ---------------------------------------------------------------------------
+// The Clubworx allowance is **gym-wide** — one account key, shared with the
+// roster Worker and n8n. Backing off one row while the rest continue just
+// spends the next window failing, which is what #51 measured: 49 successes,
+// then 41 consecutive 429s. So a throttle pauses the **whole run**, and it is
+// detected on the `reason` field rather than the status: once the call has
+// written something the Worker answers 200 and carries `reason: "throttled"`,
+// because the body is then the only record of what was written.
+
+import { cancellable, isFailure, studentRecord } from './outcome.js?v=2';
+
+/** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
+export const RETRY_BACKOFF_MS = 20_000;
+export const MAX_ATTEMPTS = 2;
+
+/** D7. One row failing is data; three in a row is a systemic condition. */
+export const FAILURE_LIMIT = 3;
+
+export const THROTTLE_MESSAGE =
+  'Clubworx is busy — this can be caused by another system, not this page. Try again shortly.';
+
+const defaultSleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+/**
+ * One call, with D8's retry policy and nothing else.
+ *
+ * **Never a 400.** All three known 400s are permanent for that attempt, and the
+ * fourth kind is unknown by definition — retrying an unrecognised refusal is
+ * how a run spends its allowance learning nothing. A 200 is never retried
+ * either, even when it reports the student was abandoned: that answer is final
+ * and the row is the record of it.
+ *
+ * @returns {Promise<{status: number|null, body: object|null, error: string|null}>}
+ */
+async function attempt(call, payload, sleep) {
+  let last = { status: null, body: null, error: 'the request was never made' };
+
+  for (let n = 1; n <= MAX_ATTEMPTS; n += 1) {
+    try {
+      const answer = await call(payload);
+      last = { status: answer?.status ?? null, body: answer?.body ?? null, error: null };
+    } catch (error) {
+      last = { status: null, body: null, error: String(error?.message || error) };
+    }
+
+    const retryable = last.error !== null || last.status === 429 || (last.status ?? 0) >= 500;
+    if (!retryable) return last;
+    if (n < MAX_ATTEMPTS) await sleep(RETRY_BACKOFF_MS);
+  }
+
+  return last;
+}
+
+/** Whether this answer means the gym-wide allowance is spent. */
+const throttled = (answer) => answer.status === 429 || answer.body?.reason === 'throttled';
+
+/**
+ * Apply — the whole run.
+ *
+ * Stops for exactly three reasons, and says which: a throttle, three
+ * consecutive failures, or the page asking it to. In all three the completed
+ * rows are left intact and handed back, because the halt is a pause in a run
+ * whose earlier students are already permanent.
+ *
+ * @param {object} opts
+ * @param {Array<{payload: object}>} opts.students what `runList` built, in table order
+ * @param {(payload: object) => Promise<{status: number, body: object}>} opts.call injected
+ * @param {(record: object, records: object[]) => void} [opts.onRow] fired per student — D10
+ * @param {() => boolean} [opts.stopped] asked between students
+ * @param {(ms: number) => Promise<void>} [opts.sleep]
+ * @returns {Promise<{state: 'complete'|'halted', reason: string|null, message: string,
+ *   records: object[], remaining: number}>}
+ */
+export async function runStudents({
+  students = [],
+  call,
+  onRow = () => {},
+  stopped = () => false,
+  sleep = defaultSleep,
+} = {}) {
+  const records = [];
+  let consecutive = 0;
+
+  const halt = (reason, message, index) => ({
+    state: 'halted',
+    reason,
+    message,
+    records,
+    remaining: students.length - index,
+  });
+
+  for (let i = 0; i < students.length; i += 1) {
+    if (stopped()) return halt('stopped', 'The run was stopped. Everything above is done.', i);
+
+    const answer = await attempt(call, students[i].payload, sleep);
+    const record = studentRecord({
+      student: students[i],
+      status: answer.status,
+      body: answer.body,
+      error: answer.error,
+    });
+
+    records.push(record);
+    // Before any halt decision. A record that exists only when the run finished
+    // tidily is a record missing in exactly the case it was built for.
+    onRow(record, records);
+
+    if (throttled(answer)) return halt('throttled', THROTTLE_MESSAGE, i + 1);
+
+    consecutive = isFailure(record) ? consecutive + 1 : 0;
+    if (consecutive >= FAILURE_LIMIT) {
+      return halt(
+        'consecutive-failures',
+        `${FAILURE_LIMIT} students in a row did not finish, so the run stopped rather than `
+          + 'spending the gym’s Clubworx allowance repeating the same failure. '
+          + 'Everything above is done and is not affected.',
+        i + 1,
+      );
+    }
+  }
+
+  return { state: 'complete', reason: null, message: '', records, remaining: 0 };
+}
+
+/**
+ * The rows to send to `POST /unbook` for one student.
+ *
+ * The whole array `POST /student` handed back, less anything a previous cancel
+ * already removed — **not** pre-filtered down to `booked`. The Worker's
+ * `cancelRunBookings` owns the interlock and takes each row's own
+ * `contact_key`, so handing it the rows as they came keeps one authority for
+ * the rule rather than two that can drift.
+ *
+ * Dropping ids a previous pass already cancelled is a different thing: those
+ * bookings are gone, and re-sending them turns a clean partial cancel into a
+ * screenful of new failures.
+ */
+function cancelRows(record) {
+  const gone = new Set((record?.cancel?.cancelledIds ?? []).map(String));
+  return (record?.bookings ?? []).filter((b) => !gone.has(String(b?.booking_id ?? '')));
+}
+
+/**
+ * "Cancel bookings from this run" — D12.
+ *
+ * One student per call, the same shape Apply uses and for the same reason: a
+ * whole-run cancel is up to 150 DELETEs plus a verifying re-read per student,
+ * which is minutes in a single invocation and the failure mode D1 rejected.
+ *
+ * A student with nothing this run booked is **never sent**. The Worker refuses
+ * those rows too, and that is not a reason for the page to offer them: an
+ * `already booked` row means Clubworx refused our duplicate, so the booking
+ * predates this run and may be one a real member made themselves.
+ *
+ * @param {object} opts
+ * @param {object[]} opts.records the run's records, mutated only by replacement
+ * @param {(payload: object) => Promise<{status: number, body: object}>} opts.call injected
+ * @param {(record: object, records: object[]) => void} [opts.onRow]
+ * @param {(ms: number) => Promise<void>} [opts.sleep]
+ */
+export async function cancelStudents({
+  records = [],
+  call,
+  onRow = () => {},
+  stopped = () => false,
+  sleep = defaultSleep,
+} = {}) {
+  const out = [...records];
+
+  for (let i = 0; i < out.length; i += 1) {
+    const record = out[i];
+    if (cancellable(record).length === 0) continue;
+    if (stopped()) {
+      return { state: 'halted', reason: 'stopped', message: 'The cancel was stopped.', records: out };
+    }
+
+    const answer = await attempt(
+      call,
+      { contact_key: record.contactKey ?? null, bookings: cancelRows(record) },
+      sleep,
+    );
+
+    out[i] = {
+      ...record,
+      cancel: answer.error !== null
+        ? {
+          ok: false,
+          outcome: 'failed',
+          reason: 'network',
+          message: `The cancel did not reach Clubworx: ${answer.error}. The bookings are probably `
+            + 'still there — check this student in Clubworx.',
+          cancelled: 0,
+          cancelledIds: [],
+          failed: [],
+          stillBooked: [],
+          verified: false,
+        }
+        : (answer.body ?? { ok: false, outcome: 'failed', reason: 'empty-reply', cancelled: 0, cancelledIds: [] }),
+    };
+    onRow(out[i], out);
+
+    if (throttled(answer)) {
+      return { state: 'halted', reason: 'throttled', message: THROTTLE_MESSAGE, records: out };
+    }
+  }
+
+  return { state: 'complete', reason: null, message: '', records: out };
+}
+
+/**
+ * The browser-only record — D10.
+ *
+ * Wrapped over an injected storage rather than reaching for `localStorage`, so
+ * the failure paths are testable: a private window has no storage at all, and a
+ * full one throws on write. **Neither may take the run down.** Losing the copy
+ * is bad; losing the run because the copy failed is worse, and the records are
+ * still in memory and on screen either way.
+ */
+export function runStore(storage, key) {
+  return {
+    save(value) {
+      try {
+        storage?.setItem(key, JSON.stringify(value));
+      } catch {
+        /* see above */
+      }
+    },
+    load() {
+      try {
+        const raw = storage?.getItem(key);
+        return raw ? JSON.parse(raw) : null;
+      } catch {
+        return null;
+      }
+    },
+    clear() {
+      try {
+        storage?.removeItem(key);
+      } catch {
+        /* see above */
+      }
+    },
+  };
+}
+
+/**
+ * Turn the preview into the exact list of calls Apply will make.
+ *
+ * Pure, and separate from the loop, so what gets sent to a route that writes
+ * permanent records is readable in one place and testable without a run.
+ *
+ * Two things are refused rather than defaulted, because both would write:
+ * a preview with no resolved plan (there is no pass to grant), and a missing
+ * school marker (the marker is the only provenance this system will ever have,
+ * §4 — a contact created without one cannot be found again).
+ *
+ * @param {object} opts
+ * @param {object} opts.preview `buildPreview`'s result
+ * @param {object[]} opts.rows step 3's rows, which carry the **write form** of the name
+ * @param {string} opts.email the school marker
+ */
+export function runList({ preview, rows, email } = {}) {
+  const plan = preview?.plan ?? null;
+  if (!plan?.membership_plan_id || !email) return [];
+
+  const source = new Map((rows ?? []).map((r) => [r.key, r]));
+  const events = (preview?.sessions ?? []).map((e) => ({
+    event_id: e.event_id,
+    // The write chain reads the lead time off `starts_at`; the events route
+    // calls the same field `event_start_at`. Renamed once, here.
+    starts_at: e.event_start_at ?? e.starts_at ?? null,
+    spaces_available: e.spaces_available ?? null,
+  }));
+
+  return (preview?.rows ?? [])
+    .filter((row) => !row.needsHuman)
+    .map((row) => {
+      const from = source.get(row.key) ?? {};
+      return {
+        key: row.key,
+        name: row.name,
+        dob: row.dob,
+        sessions: row.sessions ?? events.length,
+        contactKey: row.contactKey ?? null,
+        payload: {
+          student: {
+            // Write form — accents and case as the school typed them. The
+            // compare form is for matching and never for writing.
+            first_name: from.firstName ?? '',
+            last_name: from.lastName ?? '',
+            dob: from.dob ?? row.dob ?? '',
+            email,
+          },
+          contact_key: row.contactKey ?? null,
+          membership_plan_id: plan.membership_plan_id,
+          membership_duration: plan.membership_duration ?? '',
+          events,
+        },
+      };
+    });
+}

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -39,7 +39,7 @@
 // written something the Worker answers 200 and carries `reason: "throttled"`,
 // because the body is then the only record of what was written.
 
-import { cancellable, isFailure, studentRecord } from './outcome.js?v=2';
+import { cancelRows, cancellable, isFailure, studentRecord } from './outcome.js?v=2';
 
 /** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
 export const RETRY_BACKOFF_MS = 20_000;
@@ -89,16 +89,15 @@ const throttled = (answer) => answer.status === 429 || answer.body?.reason === '
 /**
  * Apply — the whole run.
  *
- * Stops for exactly three reasons, and says which: a throttle, three
- * consecutive failures, or the page asking it to. In all three the completed
- * rows are left intact and handed back, because the halt is a pause in a run
- * whose earlier students are already permanent.
+ * Stops for exactly two reasons, and says which: a throttle, or three
+ * consecutive failures. In both the completed rows are left intact and handed
+ * back, because the halt is a pause in a run whose earlier students are already
+ * permanent.
  *
  * @param {object} opts
  * @param {Array<{payload: object}>} opts.students what `runList` built, in table order
  * @param {(payload: object) => Promise<{status: number, body: object}>} opts.call injected
  * @param {(record: object, records: object[]) => void} [opts.onRow] fired per student — D10
- * @param {() => boolean} [opts.stopped] asked between students
  * @param {(ms: number) => Promise<void>} [opts.sleep]
  * @returns {Promise<{state: 'complete'|'halted', reason: string|null, message: string,
  *   records: object[], remaining: number}>}
@@ -107,7 +106,6 @@ export async function runStudents({
   students = [],
   call,
   onRow = () => {},
-  stopped = () => false,
   sleep = defaultSleep,
 } = {}) {
   const records = [];
@@ -122,8 +120,6 @@ export async function runStudents({
   });
 
   for (let i = 0; i < students.length; i += 1) {
-    if (stopped()) return halt('stopped', 'The run was stopped. Everything above is done.', i);
-
     const answer = await attempt(call, students[i].payload, sleep);
     const record = studentRecord({
       student: students[i],
@@ -155,24 +151,6 @@ export async function runStudents({
 }
 
 /**
- * The rows to send to `POST /unbook` for one student.
- *
- * The whole array `POST /student` handed back, less anything a previous cancel
- * already removed — **not** pre-filtered down to `booked`. The Worker's
- * `cancelRunBookings` owns the interlock and takes each row's own
- * `contact_key`, so handing it the rows as they came keeps one authority for
- * the rule rather than two that can drift.
- *
- * Dropping ids a previous pass already cancelled is a different thing: those
- * bookings are gone, and re-sending them turns a clean partial cancel into a
- * screenful of new failures.
- */
-function cancelRows(record) {
-  const gone = new Set((record?.cancel?.cancelledIds ?? []).map(String));
-  return (record?.bookings ?? []).filter((b) => !gone.has(String(b?.booking_id ?? '')));
-}
-
-/**
  * "Cancel bookings from this run" — D12.
  *
  * One student per call, the same shape Apply uses and for the same reason: a
@@ -194,7 +172,6 @@ export async function cancelStudents({
   records = [],
   call,
   onRow = () => {},
-  stopped = () => false,
   sleep = defaultSleep,
 } = {}) {
   const out = [...records];
@@ -202,9 +179,6 @@ export async function cancelStudents({
   for (let i = 0; i < out.length; i += 1) {
     const record = out[i];
     if (cancellable(record).length === 0) continue;
-    if (stopped()) {
-      return { state: 'halted', reason: 'stopped', message: 'The cancel was stopped.', records: out };
-    }
 
     const answer = await attempt(
       call,

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -39,7 +39,7 @@
 // written something the Worker answers 200 and carries `reason: "throttled"`,
 // because the body is then the only record of what was written.
 
-import { cancelRows, cancellable, isFailure, studentRecord } from './outcome.js?v=2';
+import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=2';
 
 /** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
 export const RETRY_BACKOFF_MS = 20_000;
@@ -111,13 +111,21 @@ export async function runStudents({
   const records = [];
   let consecutive = 0;
 
-  const halt = (reason, message, index) => ({
-    state: 'halted',
-    reason,
-    message,
-    records,
-    remaining: students.length - index,
-  });
+  // A halt does not shorten the table. The students it never reached are added
+  // as `not run` rows so the result stays the preview's row set in the
+  // preview's order (D11) — the point of that being that staff can see WHERE
+  // the run stopped, which a table missing its tail cannot show. Nothing was
+  // written for them, so a re-run is how they are finished (D5).
+  const halt = (reason, message, index) => {
+    const untried = students.slice(index);
+    for (const student of untried) {
+      records.push(notRunRecord(
+        student,
+        'The run stopped before reaching this student. Nothing was written for them.',
+      ));
+    }
+    return { state: 'halted', reason, message, records, remaining: untried.length };
+  };
 
   for (let i = 0; i < students.length; i += 1) {
     const answer = await attempt(call, students[i].payload, sleep);

--- a/school-booking/test/outcome.test.js
+++ b/school-booking/test/outcome.test.js
@@ -14,8 +14,11 @@
 import { describe, expect, test } from 'vitest';
 import {
   cancelReport,
+  cancelRows,
   cancellable,
+  bookingRows,
   isFailure,
+  notRunRecord,
   resultLine,
   resultTotals,
   runRecordText,
@@ -385,5 +388,88 @@ describe('cancelReport — what a human still has to do', () => {
     expect(report.verified).toBe(false);
     expect(report.byHand).toEqual([]);
     expect(report.cancelled).toBe(2);
+  });
+});
+
+describe('D3’s rollback is already a cancel — the interlock has to see it', () => {
+  // `abandon()` in the Worker hands back the booking rows UNMUTATED: they still
+  // read `state: 'booked'` and still carry their ids, and what actually
+  // happened to them is in `rollback.cancelledIds`. Reading only `cancel`
+  // offers to cancel bookings the Worker already cancelled — on the very rows
+  // whose own `strandedDetail` says the student has no bookings from this run.
+  const abandoned = (over = {}) => record({}, {
+    ...complete(),
+    ok: false,
+    outcome: 'abandoned',
+    reason: 'booking-refused',
+    message: 'Sorry, this class has no free spaces available.',
+    stranded: true,
+    strandedDetail: 'This student has a contact and a School Pass and no bookings from this run.',
+    rollback: { cancelled: 2, cancelledIds: ['b1', 'b2'], failed: [], stillBooked: [], verified: true, skipped: 0 },
+    ...over,
+  });
+
+  test('a rolled-back booking is not offered for cancelling', () => {
+    expect(cancellable(abandoned())).toEqual([]);
+  });
+
+  test('and is not re-sent to the unbook route', () => {
+    expect(cancelRows(abandoned())).toEqual([]);
+  });
+
+  test('a rollback that could only cancel one leaves the other cancellable', () => {
+    const partial = abandoned({
+      rollback: { cancelled: 1, cancelledIds: ['b1'], failed: [{ booking_id: 'b2', attempted: true, reason: 'refused' }], stillBooked: [], verified: true, skipped: 0 },
+    });
+    expect(cancellable(partial).map((b) => b.booking_id)).toEqual(['b2']);
+  });
+
+  test('the row does not count bookings the rollback removed as ones staff can cancel', () => {
+    const row = abandoned();
+    expect(row.booked).toBe(0);
+    expect(row.rolledBack).toBe(2);
+    // Otherwise the table says "2 bookings made (can be cancelled)" beside a
+    // detail line saying the student has none.
+    expect(resultTotals([row])).toMatchObject({ bookings: 0, rolledBack: 2 });
+  });
+
+  test('the summary accounts for them rather than just showing a lower total', () => {
+    expect(resultLine([abandoned()])).toContain('2 bookings rolled back');
+  });
+
+  test('the bookings list says `rolled back`, not `booked`, beside a dead id', () => {
+    // A row still reading `booked` sends a human into Clubworx hunting for a
+    // booking that is not there.
+    expect(bookingRows(abandoned()).map((b) => b.state)).toEqual(['rolled back', 'rolled back']);
+  });
+
+  test('a human cancel marks its own rows too', () => {
+    const done = { ...record({}, complete()), cancel: { outcome: 'cancelled', cancelled: 1, cancelledIds: ['b1'] } };
+    expect(bookingRows(done).map((b) => b.state)).toEqual(['cancelled', 'booked']);
+  });
+
+  test('an already-booked row is never relabelled — it was never this run’s', () => {
+    const row = record({}, complete({
+      bookings: [booking({ state: 'already booked', booking_id: null, bookingId: null })],
+      rollback: { cancelled: 0, cancelledIds: [], failed: [], stillBooked: [], verified: false, skipped: 1 },
+    }));
+    expect(bookingRows(row).map((b) => b.state)).toEqual(['already booked']);
+  });
+});
+
+describe('notRunRecord — the students a halt never reached', () => {
+  test('it is a real row with nothing written', () => {
+    const row = notRunRecord(student({ key: 9, name: 'Alan Turing' }), 'The run stopped first.');
+    expect(row.state).toBe('not run');
+    expect(row.name).toBe('Alan Turing');
+    expect(row.written).toBe(false);
+    expect(isFailure(row)).toBe(true);
+    expect(cancellable(row)).toEqual([]);
+  });
+
+  test('it is counted as not run and never as a failure staff must chase', () => {
+    const rows = [record({}, complete()), notRunRecord(student({ key: 2 }), 'stopped')];
+    expect(resultTotals(rows)).toMatchObject({ notRun: 1, failed: 0, stranded: 0 });
+    expect(resultLine(rows)).toContain('1 not run');
   });
 });

--- a/school-booking/test/outcome.test.js
+++ b/school-booking/test/outcome.test.js
@@ -13,6 +13,7 @@
 
 import { describe, expect, test } from 'vitest';
 import {
+  cancelReport,
   cancellable,
   isFailure,
   resultLine,
@@ -329,5 +330,60 @@ describe('the record staff keep — D10', () => {
     expect(text).toContain('b1');
     // Parseable, so a later tool can read it rather than a human re-typing it.
     expect(() => JSON.parse(text)).not.toThrow();
+  });
+});
+
+describe('cancelReport — what a human still has to do', () => {
+  const withCancel = (cancel) => ({ bookings: [], cancel });
+
+  test('no cancel yet is null, not an empty report', () => {
+    // Absent and "did nothing" are different facts.
+    expect(cancelReport({ bookings: [] })).toBe(null);
+  });
+
+  test('rows the Worker did not try after a throttle are kept out of the by-hand list', () => {
+    const report = cancelReport(withCancel({
+      outcome: 'partial',
+      cancelled: 1,
+      cancelledIds: ['b1'],
+      verified: true,
+      stillBooked: [],
+      failed: [
+        { booking_id: 'b2', event_id: 'e2', reason: 'refused', attempted: true },
+        { booking_id: 'b3', event_id: 'e3', reason: 'not attempted — throttling', attempted: false },
+      ],
+    }));
+    // b3 is still there and still cancellable from this page; naming it as a
+    // manual job sends staff into Clubworx to do what one more click does.
+    expect(report.byHand.map((f) => f.booking_id)).toEqual(['b2']);
+    expect(report.notAttempted.map((f) => f.booking_id)).toEqual(['b3']);
+  });
+
+  test('a pre-send refusal has no `attempted` flag at all and still needs a hand', () => {
+    const report = cancelReport(withCancel({
+      cancelled: 0, cancelledIds: [], verified: false, stillBooked: [],
+      failed: [{ booking_id: null, event_id: 'e1', reason: 'Clubworx returned no booking id' }],
+    }));
+    expect(report.byHand).toHaveLength(1);
+    expect(report.notAttempted).toEqual([]);
+  });
+
+  test('an id the re-read found still present joins the by-hand list', () => {
+    const report = cancelReport(withCancel({
+      outcome: 'still-booked', cancelled: 2, cancelledIds: ['b1', 'b2'],
+      verified: false, stillBooked: ['b2'], failed: [],
+    }));
+    expect(report.byHand.map((f) => f.booking_id)).toEqual(['b2']);
+    expect(report.byHand[0].reason).toContain('still there on a re-read');
+  });
+
+  test('unverified is reported as unverified, not as failed', () => {
+    const report = cancelReport(withCancel({
+      outcome: 'unverified', cancelled: 2, cancelledIds: ['b1', 'b2'],
+      verified: false, stillBooked: [], failed: [],
+    }));
+    expect(report.verified).toBe(false);
+    expect(report.byHand).toEqual([]);
+    expect(report.cancelled).toBe(2);
   });
 });

--- a/school-booking/test/outcome.test.js
+++ b/school-booking/test/outcome.test.js
@@ -1,0 +1,333 @@
+// What a `POST /student` answer means, in the words the result table uses.
+//
+// The engine (`run.js`) decides *when* to call; this file is about what comes
+// back. Two of its jobs are safety-critical rather than cosmetic:
+//
+//   - **`isFailure`** feeds D7's circuit breaker. Counting a `needs-confirmation`
+//     as a failure would halt a run on three students who merely hold a pass
+//     that does not cover the term — a routine outcome, not a systemic one.
+//   - **`cancellable`** is the interlock. A row marked `already booked` was NOT
+//     made by this run, and cancelling it deletes a booking a real member may
+//     have made themselves (#50's worst outcome). The Worker enforces this too;
+//     the page must not send those rows anyway.
+
+import { describe, expect, test } from 'vitest';
+import {
+  cancellable,
+  isFailure,
+  resultLine,
+  resultTotals,
+  runRecordText,
+  strandedWarning,
+  studentRecord,
+} from '../outcome.js';
+
+const student = (over = {}) => ({
+  key: 1,
+  name: 'Ada Lovelace',
+  dob: '2010-12-10',
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  contactKey: null,
+  sessions: 2,
+  ...over,
+});
+
+const booking = (over = {}) => ({
+  event_id: 'e1',
+  state: 'booked',
+  booking_id: 'b1',
+  bookingId: 'b1',
+  refusal: null,
+  message: null,
+  shown: null,
+  ...over,
+});
+
+/** A `complete` answer for a student this run created. */
+const complete = (over = {}) => ({
+  ok: true,
+  outcome: 'complete',
+  written: true,
+  contact: { contact_key: 'c1', state: 'created' },
+  pass: { state: 'created-with-contact', expiration_date: null, detail: 'created with the contact' },
+  bookings: [booking(), booking({ event_id: 'e2', booking_id: 'b2', bookingId: 'b2' })],
+  rollback: null,
+  stranded: false,
+  strandedDetail: null,
+  warnings: [],
+  requests: 5,
+  reason: null,
+  message: null,
+  ...over,
+});
+
+const record = (studentOver, body, status = 200) =>
+  studentRecord({ student: student(studentOver), status, body });
+
+describe('studentRecord — the three permanence classes stay apart', () => {
+  test('a created student counts a contact, a pass and its bookings', () => {
+    const row = record({}, complete());
+    expect(row.state).toBe('booked');
+    expect(row.contactCreated).toBe(true);
+    expect(row.passGranted).toBe(true);
+    expect(row.booked).toBe(2);
+    expect(row.alreadyBooked).toBe(0);
+    expect(row.contactKey).toBe('c1');
+  });
+
+  test('a returning student granted a pass counts the pass and no contact', () => {
+    const row = record(
+      { contactKey: 'c9' },
+      complete({
+        contact: { contact_key: 'c9', state: 'matched' },
+        pass: { state: 'granted', expiration_date: '2027-02-18', detail: '26 weeks' },
+      }),
+    );
+    expect(row.contactCreated).toBe(false);
+    expect(row.passGranted).toBe(true);
+  });
+
+  test('a returning student who already held a covering pass counts neither', () => {
+    const row = record(
+      { contactKey: 'c9' },
+      complete({
+        contact: { contact_key: 'c9', state: 'matched' },
+        pass: { state: 'covering', expiration_date: '2027-01-01', detail: 'already covers' },
+      }),
+    );
+    expect(row.contactCreated).toBe(false);
+    expect(row.passGranted).toBe(false);
+    expect(row.state).toBe('booked');
+  });
+
+  test('every booking already there reads as `already booked`, never as an error', () => {
+    const row = record(
+      { contactKey: 'c9' },
+      complete({
+        contact: { contact_key: 'c9', state: 'matched' },
+        pass: { state: 'covering', expiration_date: null, detail: null },
+        bookings: [
+          booking({ state: 'already booked', booking_id: null, bookingId: null }),
+          booking({ event_id: 'e2', state: 'already booked', booking_id: null, bookingId: null }),
+        ],
+      }),
+    );
+    expect(row.state).toBe('already booked');
+    expect(row.alreadyBooked).toBe(2);
+    expect(row.booked).toBe(0);
+    expect(isFailure(row)).toBe(false);
+  });
+});
+
+describe('studentRecord — the outcomes that are not success', () => {
+  test('an abandoned student with a pass is named stranded, with the detail carried', () => {
+    const row = record({}, {
+      ...complete(),
+      ok: false,
+      outcome: 'abandoned',
+      reason: 'booking-refused',
+      message: 'Sorry, this class has no free spaces available.',
+      stranded: true,
+      strandedDetail: 'This student has a contact and a School Pass and no bookings from this run.',
+      rollback: { cancelled: 1, failed: [], stillBooked: [], verified: true, skipped: 0 },
+    });
+    expect(row.state).toBe('stranded');
+    expect(row.stranded).toBe(true);
+    expect(row.detail).toContain('no free spaces');
+    expect(isFailure(row)).toBe(true);
+  });
+
+  test('a non-covering pass is a row that needs a human, and does not feed the breaker', () => {
+    const row = record({ contactKey: 'c9' }, {
+      ...complete(),
+      ok: false,
+      outcome: 'needs-confirmation',
+      reason: 'pass-not-covering',
+      message: 'the held pass runs out before the last session',
+      written: false,
+      bookings: [],
+      pass: { state: 'needs-confirmation', expiration_date: '2026-09-30', detail: 'runs out first' },
+    });
+    expect(row.state).toBe('needs you');
+    expect(row.passGranted).toBe(false);
+    expect(isFailure(row)).toBe(false);
+  });
+
+  test('a refusal before any write is `refused` and nothing is counted', () => {
+    const row = studentRecord({
+      student: student(),
+      status: 400,
+      body: { outcome: 'refused', reason: 'lead-time', message: 'a session starts within 24 hours', written: false },
+    });
+    expect(row.state).toBe('refused');
+    expect(row.written).toBe(false);
+    expect(row.contactCreated).toBe(false);
+    expect(isFailure(row)).toBe(true);
+  });
+
+  test('`unverified` says go and look, and is not a synonym for failed', () => {
+    const row = record({}, {
+      ...complete(),
+      ok: false,
+      outcome: 'unverified',
+      reason: 'bookings-unread',
+      message: 'every booking was accepted but they could not be re-read to confirm',
+    });
+    expect(row.state).toBe('unverified');
+    expect(row.detail).toContain('could not be re-read');
+    // Bookings were accepted, so they are still this run's to cancel.
+    expect(cancellable(row)).toHaveLength(2);
+  });
+
+  test('a throttle that wrote nothing is `not run`, and the student can be re-run', () => {
+    const row = studentRecord({
+      student: student(),
+      status: 429,
+      body: { outcome: 'failed', reason: 'throttled', message: 'Clubworx is busy', written: false },
+    });
+    expect(row.state).toBe('not run');
+    expect(row.throttled).toBe(true);
+    expect(row.written).toBe(false);
+  });
+
+  test('a network error names itself rather than borrowing an outcome', () => {
+    const row = studentRecord({ student: student(), error: 'Failed to fetch' });
+    expect(row.state).toBe('failed');
+    expect(row.outcome).toBe('network');
+    expect(row.detail).toContain('Failed to fetch');
+    expect(row.written).toBe(false);
+    expect(isFailure(row)).toBe(true);
+  });
+
+  test('an unknown Clubworx message travels verbatim and is never re-worded', () => {
+    const row = record({}, {
+      ...complete(),
+      ok: false,
+      outcome: 'failed',
+      reason: 'unknown',
+      message: 'Sorry! Something entirely new happened.',
+      bookings: [booking({ state: 'failed', booking_id: null, bookingId: null, shown: 'Sorry! Something entirely new happened.' })],
+    });
+    expect(row.detail).toContain('Sorry! Something entirely new happened.');
+  });
+});
+
+describe('cancellable — the interlock', () => {
+  test('it takes rows this run booked and never one that was already there', () => {
+    const row = record({}, complete({
+      bookings: [
+        booking(),
+        booking({ event_id: 'e2', state: 'already booked', booking_id: null, bookingId: null }),
+        booking({ event_id: 'e3', booking_id: 'b3', bookingId: 'b3' }),
+      ],
+    }));
+    expect(cancellable(row).map((b) => b.booking_id)).toEqual(['b1', 'b3']);
+  });
+
+  test('a booked row with no id is not cancellable — there is nothing to send', () => {
+    const row = record({}, complete({ bookings: [booking({ booking_id: null, bookingId: null })] }));
+    expect(cancellable(row)).toEqual([]);
+  });
+
+  test('a row already cancelled is not offered a second time', () => {
+    const row = record({}, complete());
+    const cancelled = { ...row, cancel: { outcome: 'cancelled', cancelledIds: ['b1', 'b2'] } };
+    expect(cancellable(cancelled)).toEqual([]);
+  });
+
+  test('a partial cancel leaves the bookings that are still there', () => {
+    const row = record({}, complete());
+    const partial = { ...row, cancel: { outcome: 'partial', cancelledIds: ['b1'] } };
+    expect(cancellable(partial).map((b) => b.booking_id)).toEqual(['b2']);
+  });
+});
+
+describe('the summary — D11, the permanence line in past tense', () => {
+  const rows = () => [
+    record({ key: 1 }, complete()),
+    record({ key: 2, name: 'Grace Hopper' }, complete({
+      contact: { contact_key: 'c2', state: 'matched' },
+      pass: { state: 'covering', expiration_date: null, detail: null },
+      bookings: [
+        booking({ state: 'already booked', booking_id: null, bookingId: null }),
+        booking({ event_id: 'e2', state: 'already booked', booking_id: null, bookingId: null }),
+      ],
+    })),
+    studentRecord({
+      student: student({ key: 3, name: 'Alan Turing' }),
+      status: 400,
+      body: { outcome: 'refused', reason: 'lead-time', message: 'a session starts within 24 hours' },
+    }),
+  ];
+
+  test('the three permanence classes are counted apart, never collapsed', () => {
+    const totals = resultTotals(rows());
+    expect(totals).toMatchObject({
+      contacts: 1,
+      passes: 1,
+      bookings: 2,
+      alreadyBooked: 2,
+      refused: 1,
+      stranded: 0,
+    });
+  });
+
+  test('the line says what was made permanent, and points at the row that refused', () => {
+    const line = resultLine(rows());
+    expect(line).toContain('1 contact created (permanent)');
+    expect(line).toContain('1 School Pass assigned (permanent)');
+    expect(line).toContain('2 bookings made (can be cancelled)');
+    expect(line).toContain('2 already booked');
+    expect(line).toContain('1 refused');
+    // The row, by its position in the table — the only number staff can find.
+    expect(line).toContain('row 3');
+  });
+
+  test('a stranded student is named, because finishing them by hand is the routine case', () => {
+    const stranded = record({ key: 4, name: 'Katherine Johnson' }, {
+      ...complete(),
+      ok: false,
+      outcome: 'abandoned',
+      reason: 'booking-refused',
+      message: 'refused',
+      stranded: true,
+      strandedDetail: 'contact and pass, no bookings',
+      bookings: [],
+    });
+    const warning = strandedWarning([...rows(), stranded]);
+    expect(warning).toContain('1 student has a contact and a pass but no bookings');
+    expect(warning).toContain('Katherine Johnson');
+  });
+
+  test('no stranded student means no warning at all, rather than a zero', () => {
+    expect(strandedWarning(rows())).toBe('');
+  });
+
+  test('once bookings are cancelled the line stops offering to cancel them', () => {
+    const [first, ...rest] = rows();
+    const line = resultLine([
+      { ...first, cancel: { outcome: 'cancelled', cancelled: 2, cancelledIds: ['b1', 'b2'] } },
+      ...rest,
+    ]);
+    expect(line).toContain('2 bookings made, 2 cancelled since');
+    expect(line).not.toContain('can be cancelled');
+  });
+
+  test('an empty run says nothing', () => {
+    expect(resultLine([])).toBe('');
+    expect(strandedWarning([])).toBe('');
+  });
+});
+
+describe('the record staff keep — D10', () => {
+  test('it carries the names, the outcomes and the booking ids a human would need', () => {
+    const text = runRecordText([record({}, complete())], { school: 'newman', at: '2026-08-21T10:00:00+08:00' });
+    expect(text).toContain('newman');
+    expect(text).toContain('Ada Lovelace');
+    expect(text).toContain('booked');
+    expect(text).toContain('b1');
+    // Parseable, so a later tool can read it rather than a human re-typing it.
+    expect(() => JSON.parse(text)).not.toThrow();
+  });
+});

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -1609,8 +1609,13 @@ describe('the run reports the bad outcomes honestly', () => {
     expect(app.runMessage).toContain('another system');
     // Two students done, the third attempted twice, and nobody after it sent.
     expect(app.__writes).toHaveLength(4);
-    expect(app.runRecords).toHaveLength(3);
+    // The table still holds all six — D11's row set survives the halt, so the
+    // screen shows where the run got to rather than a shorter list.
+    expect(app.runRecords).toHaveLength(6);
+    expect(app.runRecords.filter((r) => r.state === 'not run')).toHaveLength(4);
+    expect(app.runRemaining).toBe(3);
     expect(app.resultLine()).toContain('2 contacts created (permanent)');
+    expect(app.resultLine()).toContain('4 not run');
   });
 
   test('a stranded student is named on screen, not buried in a count', async () => {
@@ -1666,6 +1671,43 @@ describe('cancelling — D12, and never called Undo', () => {
     expect(app.cancellableCount()).toBe(0);
     app.askCancel();
     expect(app.cancelConfirming).toBe(false);
+    await app.cancelRun();
+    expect(app.__writes.filter((w) => w.route === 'unbook')).toHaveLength(0);
+  });
+
+  test('a student D3 already rolled back offers nothing, and is never re-sent', async () => {
+    // The Worker cancelled these itself when it abandoned the student, and
+    // hands the rows back unmutated — still reading `booked`, still carrying
+    // their ids. Offering them would re-send ids that are already gone.
+    const app = await upToApply(component({
+      student: () => ({
+        status: 200,
+        body: {
+          ...STUDENT_OK,
+          ok: false,
+          outcome: 'abandoned',
+          reason: 'booking-refused',
+          message: 'Sorry, this class has no free spaces available.',
+          stranded: true,
+          strandedDetail: 'This student has a contact and a School Pass and no bookings from this run.',
+          rollback: {
+            cancelled: 2, cancelledIds: ['bk-1', 'bk-2'], failed: [], stillBooked: [], verified: true, skipped: 0,
+          },
+        },
+      }),
+    }));
+
+    expect(app.runRecords[0].state).toBe('stranded');
+    // Three abandoned students in a row is a systemic condition, so D7 stops it.
+    expect(app.runState).toBe('halted');
+    expect(app.runReason).toBe('consecutive-failures');
+
+    expect(app.cancellableCount()).toBe(0);
+    // And the table does not claim bookings that no longer exist.
+    expect(app.resultLine()).toContain('0 bookings made');
+    expect(app.resultLine()).toContain('6 bookings rolled back');
+    expect(app.bookingRows(app.runRecords[0]).every((b) => b.state === 'rolled back')).toBe(true);
+
     await app.cancelRun();
     expect(app.__writes.filter((w) => w.route === 'unbook')).toHaveLength(0);
   });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -18,6 +18,8 @@ import * as identity from '../identity.js';
 import * as events from '../events.js';
 import * as preview from '../preview.js';
 import * as calendar from '../calendar.js';
+import * as outcome from '../outcome.js';
+import * as run from '../run.js';
 
 const html = readFileSync(new URL('../../school-booking.html', import.meta.url), 'utf8');
 const fixture = (name) =>
@@ -44,9 +46,10 @@ const SCHOOLS = [
   { tag: 'harlow', email: 'noreply+harlow@urbanjungleirc.com', contacts: 4 },
 ];
 
-// The four routes steps 1–5 read, all of them GETs. Nothing on this page has a
-// write path yet — Apply is #73 — so a component test that ever sees a POST is
-// a test that has caught the page doing something it must not.
+// The four routes steps 1–5 read, all of them GETs, plus the two #73 writes.
+// The GET half is asserted to stay a GET half: a write reaching Clubworx from
+// any step before Apply is the fault this fixture exists to catch, and the
+// `writes` counter below is what a step 1–5 test checks.
 const EVENTS = [
   {
     event_id: 'e1', event_name: 'School Session — Newman', event_start_at: '2026-09-01T09:00:00+08:00',
@@ -82,6 +85,41 @@ const PLAN = {
   },
 };
 
+// A clean `POST /student` answer for a student this run created: a permanent
+// contact, a permanent pass, and two cancellable bookings.
+const STUDENT_OK = {
+  ok: true,
+  outcome: 'complete',
+  written: true,
+  contact: { contact_key: 'c-new', state: 'created' },
+  pass: { state: 'created-with-contact', expiration_date: null, detail: 'created with the contact' },
+  bookings: [
+    { event_id: 'e1', state: 'booked', booking_id: 'bk-1', bookingId: 'bk-1', shown: null },
+    { event_id: 'e2', state: 'booked', booking_id: 'bk-2', bookingId: 'bk-2', shown: null },
+  ],
+  rollback: null,
+  stranded: false,
+  strandedDetail: null,
+  warnings: [],
+  requests: 8,
+  reason: null,
+  message: null,
+};
+
+const UNBOOK_OK = {
+  ok: true,
+  outcome: 'cancelled',
+  reason: null,
+  message: '2 booking(s) cancelled and confirmed gone',
+  cancelled: 2,
+  cancelledIds: ['bk-1', 'bk-2'],
+  skipped: 0,
+  failed: [],
+  stillBooked: [],
+  verified: true,
+  requests: 3,
+};
+
 function component({
   schools = SCHOOLS,
   schoolsFail = false,
@@ -90,7 +128,17 @@ function component({
   plan = PLAN,
   candidatesFor = () => [],
   contactsFail = false,
+  // #73's two write routes. `student` and `unbook` are called with the parsed
+  // body and answer `{status, body}`, so a test can throttle the fifth student
+  // or refuse one row without touching the engine's own tests.
+  student = () => ({ status: 200, body: STUDENT_OK }),
+  unbook = () => ({ status: 200, body: UNBOOK_OK }),
+  restored = null,
 } = {}) {
+  const stored = new Map();
+  if (restored) stored.set('uj-school-booking-run', JSON.stringify(restored));
+  const listeners = [];
+  const writes = [];
   globalThis.window = {
     schoolListParser: parser,
     schoolBookingSteps: steps,
@@ -98,8 +146,20 @@ function component({
     schoolBookingEvents: events,
     schoolBookingPreview: preview,
     schoolBookingCalendar: calendar,
+    schoolBookingOutcome: outcome,
+    schoolBookingRun: run,
+    localStorage: {
+      getItem: (k) => (stored.has(k) ? stored.get(k) : null),
+      setItem: (k, v) => stored.set(k, String(v)),
+      removeItem: (k) => stored.delete(k),
+    },
+    addEventListener: (name, fn) => listeners.push([name, fn]),
+    removeEventListener: (name, fn) => {
+      const at = listeners.findIndex(([n, f]) => n === name && f === fn);
+      if (at > -1) listeners.splice(at, 1);
+    },
   };
-  globalThis.fetch = vi.fn(async (url) => {
+  globalThis.fetch = vi.fn(async (url, options) => {
     const target = String(url);
     if (target.includes('/api/clubworx/schools')) {
       if (schoolsFail) return { ok: false, status: 502, json: async () => ({ error: 'upstream' }) };
@@ -126,9 +186,20 @@ function component({
         json: async () => ({ candidates: candidatesFor(params.get('last_name'), params.get('dob')) }),
       };
     }
+    if (target.includes('/api/clubworx/student') || target.includes('/api/clubworx/unbook')) {
+      const body = JSON.parse(options?.body ?? '{}');
+      const route = target.includes('/unbook') ? 'unbook' : 'student';
+      writes.push({ route, body });
+      const answer = (route === 'unbook' ? unbook : student)(body, writes.length);
+      return { ok: answer.status < 400, status: answer.status, json: async () => answer.body };
+    }
     return { ok: true, status: 200, json: async () => ({ email: 'staff@urbanjungleirc.com' }) };
   });
-  return makeComponent();
+  const app = makeComponent();
+  app.__writes = writes;
+  app.__listeners = listeners;
+  app.__stored = stored;
+  return app;
 }
 
 // init() kicks off two fetches without awaiting them — Alpine ignores what a
@@ -1341,5 +1412,302 @@ describe('the picker’s Today button (#108)', () => {
     app.goToday();
     expect(app.eventsTo).toBe('2027-02-01');
     expect(app.datePicker).toBe('to');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 6 — Apply, the run, and the cancel (#73)
+// ---------------------------------------------------------------------------
+// The engine's own behaviour — retries, the breaker, the throttle halt, the
+// interlock — is pinned in `run.test.js` against a fake caller. What is checked
+// here is the half only the page can get wrong: the gate in front of Apply, the
+// single-flight lock, the payload actually put on the wire, and the record
+// reaching storage per student rather than at the end.
+
+const upToApply = async (app, opts = {}) => {
+  await upToPreview(app, opts);
+  app.askApply();
+  await app.apply();
+  return app;
+};
+
+describe('Apply — the gate in front of the first permanent write', () => {
+  test('Apply asks before it runs, and says what the run costs', async () => {
+    const app = await upToPreview(component());
+    app.askApply();
+    expect(app.confirming).toBe(true);
+    // Nothing is written by asking.
+    expect(app.__writes).toHaveLength(0);
+    // §6: the allowance is gym-wide, so the cost is somebody else's problem too.
+    expect(app.runCost()).toContain('shared with the whole gym');
+    expect(app.runCost()).toMatch(/About \d+ Clubworx requests/);
+  });
+
+  test('standing down leaves the preview exactly as it was', async () => {
+    const app = await upToPreview(component());
+    app.askApply();
+    app.standDown();
+    expect(app.confirming).toBe(false);
+    expect(app.__writes).toHaveLength(0);
+    expect(app.stepIndex).toBe(4);
+  });
+
+  test('a blocked preview cannot be applied at all', async () => {
+    const app = await upToPreview(component({
+      candidatesFor: (lastName, dob) => (lastName === 'Fernsby'
+        ? [{ contact_key: 'ck-1', first_name: 'Katherine', last_name: 'Fernsby', dob, status_view: 'members' }]
+        : []),
+    }));
+    expect(app.preview.ready).toBe(false);
+    app.askApply();
+    await app.apply();
+    expect(app.confirming).toBe(false);
+    expect(app.__writes).toHaveLength(0);
+  });
+
+  test('steps 1–5 write nothing — every route they touch is a GET', async () => {
+    const app = await upToPreview(component());
+    expect(app.__writes).toHaveLength(0);
+  });
+});
+
+describe('the run — what actually goes on the wire', () => {
+  test('one call per student, to the write route, carrying the school marker', async () => {
+    const app = await upToApply(component());
+    expect(app.__writes).toHaveLength(6);
+    expect(app.__writes.every((w) => w.route === 'student')).toBe(true);
+    const [first] = app.__writes;
+    expect(first.body.student.email).toBe('noreply+newman@urbanjungleirc.com');
+    expect(first.body.membership_plan_id).toBe('mp-school');
+    expect(first.body.membership_duration).toBe('26 weeks');
+    expect(first.body.events.map((e) => e.event_id)).toEqual(['e1', 'e2']);
+    // `new` — this run creates the contact. Sent explicitly rather than left
+    // out, because absent and null must not be the same thing on this route.
+    expect(first.body.contact_key).toBe(null);
+  });
+
+  test('the run lands on step 6 and reports in past tense', async () => {
+    const app = await upToApply(component());
+    expect(app.stepIndex).toBe(5);
+    expect(app.runState).toBe('complete');
+    expect(app.runRecords).toHaveLength(6);
+    expect(app.resultLine()).toContain('6 contacts created (permanent)');
+    expect(app.resultLine()).toContain('6 School Passes assigned (permanent)');
+    expect(app.resultLine()).toContain('12 bookings made (can be cancelled)');
+    expect(app.strandedWarning()).toBe('');
+  });
+
+  test('a second Apply mid-run is refused — D13’s single-flight lock', async () => {
+    let release;
+    const held = new Promise((resolve) => { release = resolve; });
+    const app = await upToPreview(component({
+      student: () => ({ status: 200, body: STUDENT_OK }),
+    }));
+    // Hold the very first call open, then try to start a second run.
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (...args) => { await held; return original(...args); });
+
+    const running = app.apply();
+    await Promise.resolve();
+    await app.apply();
+    release();
+    await running;
+
+    // Six students, once each — not twelve.
+    expect(app.__writes).toHaveLength(6);
+    globalThis.fetch = original;
+  });
+
+  test('the tab is guarded while the run is in flight, and released after', async () => {
+    const app = await upToPreview(component());
+    let duringRun = 0;
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (...args) => {
+      duringRun = app.__listeners.filter(([n]) => n === 'beforeunload').length;
+      return original(...args);
+    });
+    await app.apply();
+    // A reload mid-run destroys the only record of contacts that cannot be
+    // deleted, which is the one thing worth interrupting a page unload for.
+    expect(duringRun).toBe(1);
+    expect(app.__listeners.filter(([n]) => n === 'beforeunload')).toHaveLength(0);
+    globalThis.fetch = original;
+  });
+});
+
+describe('the record — D10', () => {
+  test('it is written per student, not at the end of the run', async () => {
+    const seen = [];
+    const app = await upToPreview(component({
+      student: (body, n) => {
+        seen.push(JSON.parse(app.__stored.get('uj-school-booking-run') ?? '{"records":[]}').records.length);
+        return { status: 200, body: STUDENT_OK };
+      },
+    }));
+    await app.apply();
+    // Before each call, storage already holds every student that came before.
+    expect(seen).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(JSON.parse(app.__stored.get('uj-school-booking-run')).records).toHaveLength(6);
+  });
+
+  test('a run left in this browser is offered on the way back in, never opened', async () => {
+    const saved = {
+      at: '2026-08-21T09:00:00+08:00',
+      school: 'newman',
+      state: 'complete',
+      records: [{ key: 1, name: 'Ada Lovelace', state: 'booked', bookings: [], cancel: null }],
+    };
+    const app = await settled(component({ restored: saved }));
+    expect(app.restored).not.toBe(null);
+    expect(app.restoredLine()).toContain('1 student');
+    expect(app.restoredLine()).toContain('newman');
+    // Offered — the operator is still on step 1, not looking at a result table
+    // they may mistake for the run they just did.
+    expect(app.stepIndex).toBe(0);
+
+    app.openRestored();
+    expect(app.stepIndex).toBe(5);
+    expect(app.runRecords).toHaveLength(1);
+  });
+
+  test('discarding it clears the browser copy too, not just the banner', async () => {
+    const app = await settled(component({
+      restored: { at: 'x', records: [{ key: 1, name: 'Ada', bookings: [] }] },
+    }));
+    app.discardRestored();
+    expect(app.restored).toBe(null);
+    expect(app.__stored.get('uj-school-booking-run')).toBe(undefined);
+  });
+
+  test('the copy staff keep carries the booking ids a hand-fix needs', async () => {
+    const app = await upToApply(component());
+    const text = app.recordText();
+    expect(text).toContain('bk-1');
+    expect(text).toContain('newman');
+    expect(JSON.parse(text).students).toHaveLength(6);
+  });
+});
+
+describe('the run reports the bad outcomes honestly', () => {
+  test('a throttle halts the whole run and says the cause may be elsewhere', async () => {
+    const app = await upToPreview(component({
+      student: (body, n) => (n <= 2
+        ? { status: 200, body: STUDENT_OK }
+        : { status: 429, body: { outcome: 'failed', reason: 'throttled', written: false } }),
+    }));
+    // The backoff is a real 20-second wait in the page (D8's floor, sized on
+    // #51's measured ~18 s). Driven with fake timers rather than shortened, so
+    // what runs here is what runs in production.
+    vi.useFakeTimers();
+    const running = app.apply();
+    await vi.runAllTimersAsync();
+    await running;
+    vi.useRealTimers();
+
+    expect(app.runState).toBe('halted');
+    expect(app.runReason).toBe('throttled');
+    expect(app.runMessage).toContain('another system');
+    // Two students done, the third attempted twice, and nobody after it sent.
+    expect(app.__writes).toHaveLength(4);
+    expect(app.runRecords).toHaveLength(3);
+    expect(app.resultLine()).toContain('2 contacts created (permanent)');
+  });
+
+  test('a stranded student is named on screen, not buried in a count', async () => {
+    const app = await upToPreview(component({
+      student: (body, n) => (n === 1
+        ? {
+          status: 200,
+          body: {
+            ...STUDENT_OK,
+            ok: false,
+            outcome: 'abandoned',
+            reason: 'booking-refused',
+            message: 'Sorry, this class has no free spaces available.',
+            stranded: true,
+            strandedDetail: 'This student has a contact and a School Pass and no bookings from this run.',
+            bookings: [],
+          },
+        }
+        : { status: 200, body: STUDENT_OK }),
+    }));
+    await app.apply();
+    expect(app.strandedWarning()).toContain('a contact and a pass but no bookings');
+    expect(app.runRecords[0].state).toBe('stranded');
+    // The run carried on — one abandoned student is data, not a systemic halt.
+    expect(app.runState).toBe('complete');
+  });
+});
+
+describe('cancelling — D12, and never called Undo', () => {
+  test('the control counts only what this run booked', async () => {
+    const app = await upToApply(component());
+    expect(app.cancellableCount()).toBe(12);
+  });
+
+  test('a re-run over students who were already booked offers nothing to cancel', async () => {
+    // Booking is idempotent, so a re-run marks rows `already booked` — and a
+    // cancel scoped to the whole row set would delete bookings this run did
+    // not make, possibly ones a real member made themselves (#50).
+    const app = await upToApply(component({
+      student: () => ({
+        status: 200,
+        body: {
+          ...STUDENT_OK,
+          contact: { contact_key: 'c-old', state: 'matched' },
+          pass: { state: 'covering', expiration_date: '2027-02-18', detail: 'already covers' },
+          bookings: [
+            { event_id: 'e1', state: 'already booked', booking_id: null, bookingId: null, shown: null },
+            { event_id: 'e2', state: 'already booked', booking_id: null, bookingId: null, shown: null },
+          ],
+        },
+      }),
+    }));
+    expect(app.cancellableCount()).toBe(0);
+    app.askCancel();
+    expect(app.cancelConfirming).toBe(false);
+    await app.cancelRun();
+    expect(app.__writes.filter((w) => w.route === 'unbook')).toHaveLength(0);
+  });
+
+  test('a cancel asks first, then sends one student per call', async () => {
+    const app = await upToApply(component());
+    app.askCancel();
+    expect(app.cancelConfirming).toBe(true);
+    await app.cancelRun();
+
+    const unbooks = app.__writes.filter((w) => w.route === 'unbook');
+    expect(unbooks).toHaveLength(6);
+    expect(unbooks[0].body.contact_key).toBe('c-new');
+    expect(unbooks[0].body.bookings.map((b) => b.booking_id)).toEqual(['bk-1', 'bk-2']);
+    expect(app.cancelState).toBe('done');
+    expect(app.cancellableCount()).toBe(0);
+  });
+
+  test('the cancelled bookings are added to the record, and the permanent records are not undone', async () => {
+    const app = await upToApply(component());
+    await app.cancelRun();
+    expect(app.resultLine()).toContain('12 bookings made, 12 cancelled since');
+    // The two permanent classes still read as made, because they still exist.
+    expect(app.resultLine()).toContain('6 contacts created (permanent)');
+    expect(app.resultLine()).toContain('6 School Passes assigned (permanent)');
+  });
+
+  test('a throttle mid-cancel stops it and says so', async () => {
+    const app = await upToApply(component({
+      unbook: (body, n) => (n <= 8
+        ? { status: 200, body: UNBOOK_OK }
+        : { status: 429, body: { outcome: 'failed', reason: 'throttled', cancelled: 0 } }),
+    }));
+    vi.useFakeTimers();
+    const cancelling = app.cancelRun();
+    await vi.runAllTimersAsync();
+    await cancelling;
+    vi.useRealTimers();
+
+    expect(app.cancelState).toBe('halted');
+    expect(app.cancelMessage).toContain('another system');
+    // What did get cancelled is kept, and the rest is still cancellable.
+    expect(app.cancellableCount()).toBeGreaterThan(0);
   });
 });

--- a/school-booking/test/run.test.js
+++ b/school-booking/test/run.test.js
@@ -243,22 +243,6 @@ describe('runStudents — D7, the circuit breaker', () => {
   });
 });
 
-describe('runStudents — the single-flight caller can stop it', () => {
-  test('a stop signal ends the run cleanly between students', async () => {
-    let stop = false;
-    const call = vi.fn(async () => { stop = true; return ok(completeBody()); });
-    const result = await runStudents({
-      students: [student(1), student(2), student(3)],
-      call,
-      stopped: () => stop,
-      sleep: nosleep,
-    });
-    expect(result.state).toBe('halted');
-    expect(result.reason).toBe('stopped');
-    expect(call).toHaveBeenCalledTimes(1);
-  });
-});
-
 describe('cancelStudents — D12', () => {
   const done = (key) => ({
     key,

--- a/school-booking/test/run.test.js
+++ b/school-booking/test/run.test.js
@@ -170,9 +170,10 @@ describe('runStudents — a 429 pauses the whole run', () => {
     expect(result.reason).toBe('throttled');
     expect(call).toHaveBeenCalledTimes(1);
     // Completed rows are left intact — the halt states its reason and destroys
-    // nothing.
-    expect(result.records).toHaveLength(1);
+    // nothing — and the student it never reached is still in the table.
+    expect(result.records).toHaveLength(2);
     expect(result.records[0].stranded).toBe(true);
+    expect(result.records[1].state).toBe('not run');
   });
 });
 
@@ -189,8 +190,12 @@ describe('runStudents — D7, the circuit breaker', () => {
 
     expect(result.state).toBe('halted');
     expect(result.reason).toBe('consecutive-failures');
-    expect(result.records).toHaveLength(FAILURE_LIMIT);
     expect(result.remaining).toBe(2);
+    // D11 — the table keeps the whole row set. Three failures, then the two
+    // the run never reached, so the halt is visible as a position in the list.
+    expect(result.records).toHaveLength(5);
+    expect(result.records.filter((r) => r.state === 'not run')).toHaveLength(2);
+    expect(result.records[4].detail).toContain('stopped before reaching this student');
   });
 
   test('a success between failures resets the count', async () => {

--- a/school-booking/test/run.test.js
+++ b/school-booking/test/run.test.js
@@ -1,0 +1,439 @@
+// The run engine, driven with a fake caller.
+//
+// #78's seam decision: this is a pure module taking an injected caller, not
+// code inside the Alpine component, because there is no DOM test infrastructure
+// in this repo and none is being added. Everything below runs when things are
+// already going wrong, which is exactly the half that would otherwise have no
+// automated cover at all:
+//
+//   - retry only on 429 / network / 5xx, and never on a 400
+//   - halt after 3 consecutive failures
+//   - a 429 pausing the whole run rather than one row
+//   - the record written per student rather than at the end
+//   - the cancel interlock, and the halt inside a cancel
+//
+// #51 measured the throttle failure mode as 49 successes followed by 41
+// consecutive 429s. That is the case the breaker exists for and it is pinned
+// below.
+
+import { describe, expect, test, vi } from 'vitest';
+import {
+  FAILURE_LIMIT,
+  MAX_ATTEMPTS,
+  RETRY_BACKOFF_MS,
+  cancelStudents,
+  runList,
+  runStore,
+  runStudents,
+} from '../run.js';
+
+const student = (key, over = {}) => ({
+  key,
+  name: `Student ${key}`,
+  dob: '2010-01-01',
+  sessions: 2,
+  contactKey: null,
+  payload: { student: { first_name: 'S', last_name: String(key), dob: '2010-01-01', email: 'noreply+x@urbanjungleirc.com' } },
+  ...over,
+});
+
+const booking = (over = {}) => ({
+  event_id: 'e1', state: 'booked', booking_id: 'b1', bookingId: 'b1', shown: null, ...over,
+});
+
+const completeBody = (over = {}) => ({
+  ok: true,
+  outcome: 'complete',
+  written: true,
+  contact: { contact_key: 'c1', state: 'created' },
+  pass: { state: 'created-with-contact' },
+  bookings: [booking()],
+  stranded: false,
+  warnings: [],
+  ...over,
+});
+
+const ok = (body) => ({ status: 200, body });
+const nosleep = vi.fn(async () => {});
+
+describe('runStudents — the ordinary path', () => {
+  test('it runs one student at a time, in order, and publishes each as it lands', async () => {
+    const seen = [];
+    const call = vi.fn(async () => ok(completeBody()));
+    const result = await runStudents({
+      students: [student(1), student(2), student(3)],
+      call,
+      onRow: (record, records) => seen.push([record.name, records.length]),
+      sleep: nosleep,
+    });
+
+    expect(result.state).toBe('complete');
+    expect(result.records).toHaveLength(3);
+    expect(call).toHaveBeenCalledTimes(3);
+    // Published per student — D10's whole point is that the record survives a
+    // reload mid-run, which an end-of-run write does not give.
+    expect(seen).toEqual([['Student 1', 1], ['Student 2', 2], ['Student 3', 3]]);
+  });
+
+  test('the caller gets the payload the page built, untouched', async () => {
+    const call = vi.fn(async () => ok(completeBody()));
+    await runStudents({ students: [student(1)], call, sleep: nosleep });
+    expect(call).toHaveBeenCalledWith(student(1).payload);
+  });
+
+  test('an empty list is a complete run, not a halt', async () => {
+    const result = await runStudents({ students: [], call: vi.fn(), sleep: nosleep });
+    expect(result.state).toBe('complete');
+    expect(result.records).toEqual([]);
+  });
+});
+
+describe('runStudents — D8, what may be retried', () => {
+  test('a 429 is retried once, after the backoff floor', async () => {
+    const sleep = vi.fn(async () => {});
+    const call = vi.fn()
+      .mockResolvedValueOnce({ status: 429, body: { outcome: 'failed', reason: 'throttled', written: false } })
+      .mockResolvedValueOnce(ok(completeBody()));
+
+    const result = await runStudents({ students: [student(1)], call, sleep });
+
+    expect(call).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+    expect(sleep).toHaveBeenCalledWith(RETRY_BACKOFF_MS);
+    expect(result.state).toBe('complete');
+    expect(result.records[0].state).toBe('booked');
+  });
+
+  test('a 5xx is retried', async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce({ status: 502, body: { outcome: 'failed', reason: 'upstream-error', message: 'bad gateway' } })
+      .mockResolvedValueOnce(ok(completeBody()));
+    const result = await runStudents({ students: [student(1)], call, sleep: nosleep });
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(result.records[0].state).toBe('booked');
+  });
+
+  test('a network error is retried, and its second failure is recorded as network', async () => {
+    const call = vi.fn(async () => { throw new Error('Failed to fetch'); });
+    const result = await runStudents({ students: [student(1)], call, sleep: nosleep });
+    expect(call).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+    expect(result.records[0].outcome).toBe('network');
+  });
+
+  test('a 400 is never retried — all three known refusals are permanent for that attempt', async () => {
+    const call = vi.fn(async () => ({ status: 400, body: { outcome: 'refused', reason: 'lead-time', message: 'too soon' } }));
+    await runStudents({ students: [student(1)], call, sleep: nosleep });
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  test('a 200 is never retried, even when the student was abandoned', async () => {
+    const call = vi.fn(async () => ok({
+      ...completeBody(), ok: false, outcome: 'abandoned', reason: 'booking-refused', message: 'refused', stranded: true,
+    }));
+    await runStudents({ students: [student(1)], call, sleep: nosleep });
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runStudents — a 429 pauses the whole run', () => {
+  test('a throttle surviving the backoff halts before the next student', async () => {
+    const throttle = { status: 429, body: { outcome: 'failed', reason: 'throttled', written: false } };
+    const call = vi.fn(async () => throttle);
+
+    const result = await runStudents({
+      students: [student(1), student(2), student(3)],
+      call,
+      sleep: nosleep,
+    });
+
+    expect(result.state).toBe('halted');
+    expect(result.reason).toBe('throttled');
+    // Honest about where the cause may be — the allowance is gym-wide.
+    expect(result.message).toContain('another system');
+    // Two attempts on student 1, and student 2 never sent.
+    expect(call).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+    expect(result.remaining).toBe(2);
+  });
+
+  test('a throttle that struck after a write still halts, and keeps the row', async () => {
+    // The Worker leaves this as a 200 because something WAS written and the
+    // body is the only record of it. The page pauses on `reason`, not status.
+    const call = vi.fn()
+      .mockResolvedValueOnce(ok({
+        ...completeBody(), ok: false, outcome: 'abandoned', reason: 'throttled',
+        message: 'Clubworx is busy', written: true, stranded: true, strandedDetail: 'contact and pass, no bookings',
+      }))
+      .mockResolvedValue(ok(completeBody()));
+
+    const result = await runStudents({ students: [student(1), student(2)], call, sleep: nosleep });
+
+    expect(result.state).toBe('halted');
+    expect(result.reason).toBe('throttled');
+    expect(call).toHaveBeenCalledTimes(1);
+    // Completed rows are left intact — the halt states its reason and destroys
+    // nothing.
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].stranded).toBe(true);
+  });
+});
+
+describe('runStudents — D7, the circuit breaker', () => {
+  test('three consecutive failures halt the run', async () => {
+    const fail = ok({ outcome: 'failed', reason: 'unknown', message: 'Sorry! Something new.', written: false });
+    const call = vi.fn(async () => fail);
+
+    const result = await runStudents({
+      students: [student(1), student(2), student(3), student(4), student(5)],
+      call,
+      sleep: nosleep,
+    });
+
+    expect(result.state).toBe('halted');
+    expect(result.reason).toBe('consecutive-failures');
+    expect(result.records).toHaveLength(FAILURE_LIMIT);
+    expect(result.remaining).toBe(2);
+  });
+
+  test('a success between failures resets the count', async () => {
+    const fail = ok({ outcome: 'failed', reason: 'unknown', message: 'nope', written: false });
+    const call = vi.fn()
+      .mockResolvedValueOnce(fail)
+      .mockResolvedValueOnce(fail)
+      .mockResolvedValueOnce(ok(completeBody()))
+      .mockResolvedValueOnce(fail)
+      .mockResolvedValueOnce(fail);
+
+    const result = await runStudents({
+      students: [1, 2, 3, 4, 5].map((k) => student(k)),
+      call,
+      sleep: nosleep,
+    });
+
+    expect(result.state).toBe('complete');
+    expect(result.records).toHaveLength(5);
+  });
+
+  test('a considered refusal about one student does not feed the breaker', async () => {
+    // `needs-confirmation` is #90's open question answered honestly for one
+    // student — not a systemic condition. Three of them must not stop a run.
+    const needs = ok({
+      outcome: 'needs-confirmation', reason: 'pass-not-covering', message: 'the held pass runs out first',
+      written: false, contact: { contact_key: 'c9', state: 'matched' }, bookings: [],
+    });
+    const call = vi.fn(async () => needs);
+    const result = await runStudents({ students: [1, 2, 3, 4].map((k) => student(k)), call, sleep: nosleep });
+    expect(result.state).toBe('complete');
+    expect(result.records).toHaveLength(4);
+  });
+
+  test('#51 in miniature — successes, then the back half throttles and it stops', async () => {
+    const call = vi.fn(async (payload) => {
+      const n = Number(payload.student.last_name);
+      if (n <= 4) return ok(completeBody());
+      return { status: 429, body: { outcome: 'failed', reason: 'throttled', written: false } };
+    });
+
+    const result = await runStudents({ students: [1, 2, 3, 4, 5, 6, 7, 8].map((k) => student(k)), call, sleep: nosleep });
+
+    expect(result.state).toBe('halted');
+    expect(result.reason).toBe('throttled');
+    // Four succeeded and are kept; the run stopped on the fifth rather than
+    // spending the next window failing forty more times.
+    expect(result.records.filter((r) => r.state === 'booked')).toHaveLength(4);
+    expect(result.remaining).toBe(3);
+  });
+});
+
+describe('runStudents — the single-flight caller can stop it', () => {
+  test('a stop signal ends the run cleanly between students', async () => {
+    let stop = false;
+    const call = vi.fn(async () => { stop = true; return ok(completeBody()); });
+    const result = await runStudents({
+      students: [student(1), student(2), student(3)],
+      call,
+      stopped: () => stop,
+      sleep: nosleep,
+    });
+    expect(result.state).toBe('halted');
+    expect(result.reason).toBe('stopped');
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('cancelStudents — D12', () => {
+  const done = (key) => ({
+    key,
+    name: `Student ${key}`,
+    contactKey: `c${key}`,
+    state: 'booked',
+    bookings: [booking({ booking_id: `b${key}`, bookingId: `b${key}` })],
+    cancel: null,
+  });
+
+  const cancelled = (over = {}) => ({
+    ok: true, outcome: 'cancelled', reason: null, message: null,
+    cancelled: 1, cancelledIds: ['b1'], skipped: 0, failed: [], stillBooked: [], verified: true,
+    ...over,
+  });
+
+  test('it sends one student per call, with that student’s own rows', async () => {
+    const call = vi.fn(async () => ok(cancelled()));
+    const records = [done(1), done(2)];
+    const result = await cancelStudents({ records, call, sleep: nosleep });
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call.mock.calls[0][0]).toEqual({ contact_key: 'c1', bookings: records[0].bookings });
+    expect(result.state).toBe('complete');
+    expect(result.records[0].cancel.outcome).toBe('cancelled');
+  });
+
+  test('a student with nothing this run booked is never sent', async () => {
+    const already = {
+      ...done(3),
+      state: 'already booked',
+      bookings: [booking({ state: 'already booked', booking_id: null, bookingId: null })],
+    };
+    const call = vi.fn(async () => ok(cancelled()));
+    await cancelStudents({ records: [already], call, sleep: nosleep });
+    // The interlock, before a request is spent: cancelling a booking this run
+    // did not make is #50's worst outcome, and it is not made safe by the
+    // Worker also refusing it.
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  test('a throttle pauses the whole cancel, exactly as it pauses the run', async () => {
+    const call = vi.fn(async () => ({ status: 429, body: { outcome: 'failed', reason: 'throttled', cancelled: 0 } }));
+    const result = await cancelStudents({ records: [done(1), done(2)], call, sleep: nosleep });
+    expect(result.state).toBe('halted');
+    expect(result.reason).toBe('throttled');
+    expect(call).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+  });
+
+  test('an unverified cancel is kept as unverified, not rewritten as done', async () => {
+    const call = vi.fn(async () => ok(cancelled({
+      ok: false, outcome: 'unverified', verified: false,
+      message: 'accepted but could not be confirmed by re-reading',
+    })));
+    const result = await cancelStudents({ records: [done(1)], call, sleep: nosleep });
+    expect(result.records[0].cancel.outcome).toBe('unverified');
+    expect(result.records[0].cancel.verified).toBe(false);
+  });
+
+  test('a second cancel does not re-send ids the first one removed', async () => {
+    const first = { ...done(1), cancel: { outcome: 'partial', cancelledIds: ['b1'] } };
+    const two = {
+      ...first,
+      bookings: [booking({ booking_id: 'b1', bookingId: 'b1' }), booking({ event_id: 'e2', booking_id: 'b9', bookingId: 'b9' })],
+    };
+    const call = vi.fn(async () => ok(cancelled({ cancelledIds: ['b9'] })));
+    await cancelStudents({ records: [two], call, sleep: nosleep });
+    expect(call.mock.calls[0][0].bookings.map((b) => b.booking_id)).toEqual(['b9']);
+  });
+
+  test('each cancelled student is published as it lands', async () => {
+    const seen = [];
+    const call = vi.fn(async () => ok(cancelled()));
+    await cancelStudents({ records: [done(1), done(2)], call, onRow: (r) => seen.push(r.name), sleep: nosleep });
+    expect(seen).toEqual(['Student 1', 'Student 2']);
+  });
+});
+
+describe('runStore — the record that survives a reload', () => {
+  const fakeStorage = () => {
+    const map = new Map();
+    return {
+      getItem: (k) => (map.has(k) ? map.get(k) : null),
+      setItem: (k, v) => map.set(k, String(v)),
+      removeItem: (k) => map.delete(k),
+    };
+  };
+
+  test('it round-trips the records', () => {
+    const store = runStore(fakeStorage(), 'uj-school-run');
+    store.save({ at: '2026-08-21', records: [{ name: 'Ada' }] });
+    expect(store.load().records[0].name).toBe('Ada');
+  });
+
+  test('an empty store loads as nothing rather than throwing', () => {
+    expect(runStore(fakeStorage(), 'k').load()).toBe(null);
+  });
+
+  test('corrupt contents load as nothing rather than taking the page down', () => {
+    const storage = fakeStorage();
+    storage.setItem('k', 'not json');
+    expect(runStore(storage, 'k').load()).toBe(null);
+  });
+
+  test('a storage that refuses to write does not stop the run', () => {
+    const storage = { ...fakeStorage(), setItem: () => { throw new Error('QuotaExceeded'); } };
+    // Losing the copy is bad; losing the run because the copy failed is worse,
+    // and the records are still in memory and on screen either way.
+    expect(() => runStore(storage, 'k').save({ records: [] })).not.toThrow();
+  });
+
+  test('a missing storage is tolerated — a private window has none', () => {
+    const store = runStore(null, 'k');
+    expect(() => store.save({ records: [] })).not.toThrow();
+    expect(store.load()).toBe(null);
+  });
+});
+
+describe('runList — turning the preview into calls', () => {
+  const preview = {
+    rows: [
+      { key: 1, name: 'Ada Lovelace', dob: '2010-12-10', needsHuman: false, clubworx: 'new', contactKey: null, sessions: 2 },
+      { key: 2, name: 'Grace Hopper', dob: '2009-12-09', needsHuman: false, clubworx: 'matched', contactKey: 'c2', sessions: 2 },
+      { key: 3, name: 'Blocked Row', dob: null, needsHuman: true, clubworx: '', contactKey: null, sessions: 2 },
+    ],
+    sessions: [
+      { event_id: 'e1', event_start_at: '2026-09-01T09:00:00+08:00', spaces_available: 30 },
+      { event_id: 'e2', event_start_at: '2026-09-08T09:00:00+08:00', spaces_available: 30 },
+    ],
+    plan: { membership_plan_id: 'mp-school', membership_duration: '26 weeks' },
+  };
+
+  const rows = [
+    { key: 1, bucket: 'record', firstName: 'Ada', lastName: 'Lovelace', dob: '2010-12-10' },
+    { key: 2, bucket: 'record', firstName: 'Grace', lastName: 'Hopper', dob: '2009-12-09' },
+    { key: 3, bucket: 'record', firstName: '', lastName: 'Row', dob: null },
+  ];
+
+  test('only rows nothing is waiting on are run, in table order', () => {
+    const list = runList({ preview, rows, email: 'noreply+newman@urbanjungleirc.com' });
+    expect(list.map((s) => s.key)).toEqual([1, 2]);
+  });
+
+  test('the write form of the name is sent, with the school marker as the email', () => {
+    const [ada] = runList({ preview, rows, email: 'noreply+newman@urbanjungleirc.com' });
+    expect(ada.payload.student).toEqual({
+      first_name: 'Ada', last_name: 'Lovelace', dob: '2010-12-10',
+      email: 'noreply+newman@urbanjungleirc.com',
+    });
+    // Null means `new`, and `new` creates a contact Clubworx cannot delete.
+    expect(ada.payload.contact_key).toBe(null);
+  });
+
+  test('a matched student carries the contact key the operator resolved', () => {
+    const [, grace] = runList({ preview, rows, email: 'noreply+newman@urbanjungleirc.com' });
+    expect(grace.payload.contact_key).toBe('c2');
+  });
+
+  test('the plan and the sessions travel with every student', () => {
+    const [ada] = runList({ preview, rows, email: 'noreply+x@urbanjungleirc.com' });
+    expect(ada.payload.membership_plan_id).toBe('mp-school');
+    expect(ada.payload.membership_duration).toBe('26 weeks');
+    // `starts_at` is the name the write chain reads the lead time off.
+    expect(ada.payload.events).toEqual([
+      { event_id: 'e1', starts_at: '2026-09-01T09:00:00+08:00', spaces_available: 30 },
+      { event_id: 'e2', starts_at: '2026-09-08T09:00:00+08:00', spaces_available: 30 },
+    ]);
+  });
+
+  test('a preview with no resolved plan produces no calls at all', () => {
+    const list = runList({ preview: { ...preview, plan: null }, rows, email: 'noreply+x@urbanjungleirc.com' });
+    expect(list).toEqual([]);
+  });
+
+  test('no school marker produces no calls — the marker is the only provenance there is', () => {
+    expect(runList({ preview, rows, email: '' })).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #73. Part of #46, §10–§12 of the design spec. **Still not linked from `tools.json`** — that is #46's last step (§17).

## The seam

Per #78, the run engine is a **pure module taking an injected caller**, not code inside the Alpine component. There is no DOM test infrastructure in this repo and none is added here, so anything living in the component would have no cover — and everything in the engine runs when things are *already going wrong*.

- **`school-booking/run.js`** — the per-student loop (D1), D8's retry policy, D7's circuit breaker, the throttle halt, the cancel loop, and D10's store. 31 tests.
- **`school-booking/outcome.js`** — what one `/student` answer means and what a run of them adds up to. `isFailure()` feeds the breaker; `cancellable()` is D12's interlock. 37 tests.
- **`school-booking.html`** — the confirm gate, the single-flight lock, step 6's table, the cancel control, the storage. 19 new component tests.

## What it does

- **Apply** asks first, stating the run's cost in §6's own arithmetic: about 300 Clubworx requests for 25 students × 6 sessions, ~4 minutes of an allowance **shared with the whole gym**.
- **A 429 pauses the whole run**, detected on the `reason` field rather than the status — once a call has written something the Worker answers 200 carrying `reason: "throttled"`, because the body is then the only record of the write.
- **D7's breaker** halts after 3 consecutive failures. A `needs-confirmation` is data about one student and does not count. #51's failure shape — successes, then the whole back half throttling — is pinned as a test.
- **A halt does not shorten the table.** Students never reached appear as `not run`, so the result stays the preview's row set (D11) and staff can see where it stopped.
- **D11's summary** in past tense, three permanence classes apart: `N contacts created (permanent) · N School Passes assigned (permanent) · N bookings made (can be cancelled) · …`, with refusals pointed at by row number, and stranded students **named**.
- **D10** — every student written to `localStorage` as it lands, with copy and download, and a run left in the browser offered on the way back in.
- **D12** — "Cancel bookings from this run", never "Undo", with the permanence of contacts and passes stated beside it. `failed[]`, `stillBooked[]` and `verified` are rendered honestly, and rows the Worker did not try after a throttle are kept out of the by-hand list — they are still cancellable from this page.
- **D13** — Apply disabled while a run is in flight, plus a `beforeunload` warning.

## Worth knowing

Two findings from `/code-review` are fixed in here; one was a real bug:

> **D3's rollback is already a cancel.** When the chain abandons a student it cancels that student's bookings itself and reports them in `rollback.cancelledIds` — but hands the rows back **unmutated**, still reading `state: 'booked'` with live-looking ids. The interlock read only `cancel.cancelledIds`, so the page offered to cancel bookings the Worker had already cancelled, on the very rows whose `strandedDetail` says the student has none.

## Verification

1,407 tests pass across the repo (435 in `school-booking`). `npx vitest run` in each package — the repo's only workflow still runs no tests, so this is by hand, as §14 says.

Not yet done against production: §14's UAT, which needs a real list and a purpose-made School Session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn