### PR TITLE
School booking: the hub entry, and the link check that keeps it honest (#74)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,12 @@ school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #10
                           the name filter is applied in the Worker's memory
                           AFTER the walk, so it shortens the table and never the
                           request count. The date fields are the house picker
-                          (calendar.js), not the browser's. Variant A of §9, decided on #54. NOT in
-                          tools.json and unreachable from the hub until #46's
-                          last step — §17's order, because `main` is production.
+                          (calendar.js), not the browser's. Variant A of §9, decided on #54. In
+                          tools.json and reachable from the hub: that entry is
+                          #74, the last step of #46 and the switch-on for
+                          everything before it, which is why §17 puts it last
+                          and why every earlier step was invisible to staff even
+                          while deployed — `main` is production.
                           Steps 1-5 READ; step 6 WRITES (#73). The page holds
                           only the confirm gate, the single-flight lock, the
                           storage and the rendering — the run itself is run.js

--- a/cloudflare-worker/test/tools-json.test.js
+++ b/cloudflare-worker/test/tools-json.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// The hub's own invariants, not this Worker's behaviour.
+//
+// `tools.json` is the source of truth for every card on ujstaff.happyk.au, and
+// CLAUDE.md's Safety Notes carry the rule this file enforces: "tools.json is
+// user-facing through the hub, so validate links after editing it." A hub entry
+// pointing at nothing is a 404 on the front desk, and index.html renders it
+// exactly as confidently as a working one — there is no broken-link state, so
+// nothing on the page says which card is dead.
+//
+// It sits in cloudflare-worker/ for the same two reasons secret-hygiene.test.js
+// does, and they are worth repeating rather than looked up:
+//
+//   - There is no repo-level vitest harness, so any home is somebody's
+//     subdirectory. This Worker is the least arbitrary one: it owns
+//     `/api/tools.json` and the `validateToolsJson` schema check behind it, so
+//     the file's shape is already this package's business.
+//   - Nothing runs it automatically. pages.yml — the repo's only workflow —
+//     runs no tests at all, so this guard fires only when someone runs vitest
+//     by hand. Wiring tests into CI is staff-site#47's open recommendation.
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const TOOLS = path.join(REPO, 'tools.json');
+const readTools = () => JSON.parse(readFileSync(TOOLS, 'utf8'));
+
+/**
+ * Is this path served out of this repo, rather than off somewhere else?
+ *
+ * Anything carrying a scheme (`https:`, `mailto:`) or a protocol-relative
+ * `//host/x` names another origin and is nobody's file here. Everything else is
+ * ours — including a root-relative `/sls.html`, which the hub resolves against
+ * the site root, and the site root is this directory.
+ */
+const isLocal = (p) => typeof p === 'string' && p !== '' && !/^[a-z][a-z0-9+.-]*:/i.test(p) && !p.startsWith('//');
+
+/**
+ * The file a local path names. A `?query` or `#hash` addresses something inside
+ * the page and never a second file, so both are dropped before the disk is
+ * asked — left on, they turn a working link into a failure with no fault in it.
+ */
+const toRepoPath = (p) => p.replace(/[?#].*$/, '').replace(/^\/+/, '');
+
+describe('tools.json', () => {
+  it('is valid JSON with an entries array', () => {
+    const tools = readTools();
+    expect(Array.isArray(tools.entries)).toBe(true);
+  });
+
+  it('backs every local path with a real file or directory', () => {
+    // Both entry shapes carry paths: a `type: "tool"` has one of its own, and a
+    // `type: "group"` has none but holds an `items` array of them. Checking only
+    // the top level would pass every group vacuously — which is where most of
+    // the paths in this file actually live.
+    const tools = readTools();
+    const paths = tools.entries.flatMap((e) => [e.path, ...(e.items ?? []).map((i) => i.path)]);
+
+    expect(paths.filter(isLocal).length, 'there are local paths to check').toBeGreaterThan(0);
+    for (const entryPath of paths.filter(isLocal)) {
+      expect(
+        existsSync(path.join(REPO, toRepoPath(entryPath))),
+        `tools.json points at \`${entryPath}\`, which is not in this repo`,
+      ).toBe(true);
+    }
+  });
+});

--- a/school-booking/test/alpine-bindings.test.js
+++ b/school-booking/test/alpine-bindings.test.js
@@ -33,6 +33,7 @@ import * as parser from '../parse.js';
 import * as steps from '../steps.js';
 
 const PAGE = new URL('../../school-booking.html', import.meta.url);
+const TOOLS = new URL('../../tools.json', import.meta.url);
 const html = readFileSync(PAGE, 'utf8');
 
 // `x-on:` and `@` are excluded on purpose: an event handler is where a function
@@ -258,11 +259,18 @@ describe('school-booking.html', () => {
     }
   });
 
-  test('the page is not reachable from the hub yet', () => {
+  test('the page is reachable from the hub', () => {
     // §17: the hub entry is the last step of #46, and it is what makes every
-    // earlier step visible to staff. Landing it early ships a half-built tool
-    // to the front desk, because `main` is production.
-    const tools = readFileSync(new URL('../../tools.json', import.meta.url), 'utf8');
-    expect(tools).not.toContain('school-booking');
+    // earlier step visible to staff, so #74 gates merging it on UAT passing
+    // against production — `main` is production, and merging is deploying.
+    // This is the inverse of the guard that held the entry back, so once the
+    // switch is thrown, silently dropping the entry fails rather than passing.
+    const tools = JSON.parse(readFileSync(TOOLS, 'utf8'));
+    const entry = tools.entries.find((e) => e.id === 'school-booking');
+    expect(entry, 'tools.json carries a school-booking entry').toBeTruthy();
+    expect(entry.path).toBe('school-booking.html');
+    // That the path is backed by a real file is checked with the hub's other
+    // invariants, in cloudflare-worker/test/tools-json.test.js — it is a rule
+    // about tools.json, not about this page.
   });
 });

--- a/tools.json
+++ b/tools.json
@@ -9,6 +9,15 @@
       "path": "roster.html",
       "category": "Operations"
     },
+    {
+      "type": "tool",
+      "id": "school-booking",
+      "name": "School Group Booking",
+      "description": "Paste a school's student list, match it against Clubworx, and book the whole group into sessions.",
+      "shortName": "🎒",
+      "path": "school-booking.html",
+      "category": "Operations"
+    },
      {
       "type": "tool",
       "id": "slideshow",


### PR DESCRIPTION
Closes #74's second half. **Draft on purpose: this is the switch-on, and UAT has not been run.**

## ⚠️ Do not merge until UAT passes

`main` is production here — merging this publishes the tool to the front desk, and there is no step after it to hold back. #74 gates it on a UAT run against production that **has not happened**: one real list, one purpose-made School Session, the re-run that is the only real test of the three-write idempotency claim, and the cancel.

The UAT needs a real browser session behind Cloudflare Access, a School Session created in Clubworx by hand, a real (private) school list that must not enter this public repo, and irreversible permanent writes to production Clubworx. None of that is automatable from here, so it is handed over rather than attempted.

## What this changes

- **`tools.json`** — the `school-booking` entry. `type: "tool"`, `category: "Operations"`, placed after the roster.
- **`school-booking/test/alpine-bindings.test.js`** — #78's `the page is not reachable from the hub yet` guard becomes its inverse. Same file, same purpose: the check that stopped the switch being thrown early is the one that stops the entry being dropped by accident later.
- **`cloudflare-worker/test/tools-json.test.js`** (new) — the link validation #74 asks for, walking every entry including group `items`. Most paths in that file live inside groups, so a top-level-only walk would pass five entries vacuously. Query strings and root-relative forms are normalised away before the disk is asked. Mutation-tested against a typo'd file, a missing directory and a root-relative form.
- **`CLAUDE.md`** — the stale "NOT in tools.json and unreachable from the hub" line.

It sits in `cloudflare-worker/` for the reason `secret-hygiene.test.js` does: no repo-level harness, and this Worker already owns `/api/tools.json` and its schema check. Nothing runs it automatically — `pages.yml` still runs no tests (#47).

## Two things checked so UAT is not blocked on them

- **The deployed Worker is current.** `uj-clubworx-api` was last modified 2026-08-21T10:03:56Z; the only `src/` commit near that boundary is `dc36267` (`plans.js`, `coverage_end`). The deployed bundle **contains** `coverage_end` and all six routes including `/student` and `/unbook`, so no redeploy is needed before UAT.
- **The UAT marker slug in #74 is not what the tool will write.** #74 suggests `noreply+uat-<date>@`, but `schoolTag()` strips every non-alphanumeric, so a typed `uat-20260822` writes `noreply+uat20260822@urbanjungleirc.com` — permanently, on contacts Clubworx cannot delete. Type the tag **without the hyphen** so what you search for later is what got written.

## Tests

1409 across the five vitest packages, all green (school-booking 435, cloudflare-worker 83, cloudflare-clubworx 665, payments-proxy 9, vouchers 217). No linter or typechecker is configured in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn