### PR TITLE
School booking: a settled import closes the door behind it (#111)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,15 @@ school-booking/preview.js - step 5: the STUDENT/DOB/READ/CLUBWORX/OUTCOME table,
                           Apply" rather than "pass already active". An absent
                           answer is `pending`, never `new` — `new` writes a
                           contact Clubworx cannot delete.
+                          runFingerprint() is #111's already-run gate, and it
+                          SUPERSEDES §12 D13, which decided the opposite — read
+                          the note there before touching it. Its own header says
+                          why a fingerprint and not a hasRun flag, and what is
+                          deliberately left out. What closes the door is
+                          outcome.js's settledRun(), never `state ===
+                          'complete'` read here: a finished run can still have
+                          stranded a student, and D5 makes re-running the
+                          recovery for exactly that.
 school-booking/run.js   - step 6's engine: Apply's per-student loop, D8's retry
                           policy, D7's circuit breaker, the throttle halt, the
                           cancel loop, and D10's browser-only store. Takes an

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -1068,6 +1068,29 @@ guard: it shows 0 new contacts, 0 new passes, N already booked. Warning against
 it would train staff to click through the warning on the one path D5 prescribes
 for recovery.
 
+> **Superseded 2026-08-22 by [#111](https://github.com/urbanjungleirc/staff-site/issues/111),
+> after #74's UAT.** The operator ran the tool against production, then walked
+> back from a finished result table and found Apply live on an unchanged list.
+> D13 is right that a *warning* would be corrosive, and it stays right — so what
+> #111 built is not a warning. Applying an unchanged import after a **settled**
+> run is refused outright, and the refusal cannot be clicked through.
+>
+> **D5 is untouched, and that is the whole design of the gate.** A run is
+> settled only when it both finished *and* left nobody behind, so the gate never
+> appears on the recovery path: not after a halt, not after a stranded student,
+> not after a failure. The predicate is `settledRun()` in `outcome.js` — it is
+> deliberately not a `state === 'complete'` test, because a run can reach the
+> end having stranded somebody, and that is precisely a re-run case.
+>
+> Cancelling the run's bookings also retires the claim, because it is no longer
+> true. Without that, taking the bookings back would leave Apply dark with
+> nothing on the page able to clear it — a refusal with no exit, which is worse
+> than the warning D13 rejected.
+>
+> What D13 got right and this preserves: the preview is still the guard. The
+> gate is one more blocker in the same list, in the same shape, read by the same
+> `ready` flag.
+
 **A double-click on Apply, or a mid-run resubmit, is different** and does need a
 single-flight lock: Apply disabled while a run is in progress, plus a
 `beforeunload` warning.

--- a/school-booking.html
+++ b/school-booking.html
@@ -68,14 +68,14 @@
      or missing module into a visible refusal rather than a page whose gates
      quietly do nothing. -->
 <script type="module">
-  import * as parser from './school-booking/parse.js?v=2';
-  import * as steps from './school-booking/steps.js?v=2';
-  import * as identity from './school-booking/identity.js?v=2';
-  import * as events from './school-booking/events.js?v=2';
-  import * as preview from './school-booking/preview.js?v=2';
-  import * as calendar from './school-booking/calendar.js?v=2';
-  import * as outcome from './school-booking/outcome.js?v=2';
-  import * as run from './school-booking/run.js?v=2';
+  import * as parser from './school-booking/parse.js?v=3';
+  import * as steps from './school-booking/steps.js?v=3';
+  import * as identity from './school-booking/identity.js?v=3';
+  import * as events from './school-booking/events.js?v=3';
+  import * as preview from './school-booking/preview.js?v=3';
+  import * as calendar from './school-booking/calendar.js?v=3';
+  import * as outcome from './school-booking/outcome.js?v=3';
+  import * as run from './school-booking/run.js?v=3';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
   window.schoolBookingIdentity = identity;
@@ -1590,6 +1590,10 @@ function schoolBooking() {
     runRemaining: 0,
     runAt: null,
     runSessionStarts: [],
+    // #111: what the last finished run covered, as `{ state, fingerprint }`.
+    // Only a `complete` one closes Apply, and only against an identical
+    // fingerprint — the rules are preview.js's, not this page's.
+    lastRun: null,
     expandedResult: null,
     cancelState: 'idle',
     cancelMessage: '',
@@ -2473,6 +2477,8 @@ function schoolBooking() {
         review: this.reviewed,
         plan: this.plan,
         decisions: this.decisions,
+        schoolTag: this.tag,
+        lastRun: this.lastRun,
       });
     },
 
@@ -2583,6 +2589,7 @@ function schoolBooking() {
       this.cancelMessage = '';
       this.runAt = new Date().toISOString();
       this.runSessionStarts = (this.preview.sessions ?? []).map((e) => e.event_start_at);
+      const fingerprint = this.preview.fingerprint;
       this.expandedResult = null;
       this.runRemaining = 0;
       this.runProgress = `Starting ${students.length} student${students.length === 1 ? '' : 's'}…`;
@@ -2609,6 +2616,18 @@ function schoolBooking() {
       this.runProgress = '';
       this.running = false;
       this.guardUnload(false);
+      // #111. The claim is about what was *applied*, so it carries the
+      // fingerprint taken before the run rather than one rebuilt from the page
+      // afterwards — the two agree today, and this stays true of a page that
+      // later lets the operator touch the list while a run is in flight.
+      // `settledRun` is what keeps the gate off D5's recovery re-run.
+      this.lastRun = {
+        settled: window.schoolBookingOutcome.settledRun(result.state, result.records),
+        fingerprint,
+      };
+      // So the gate is already on the preview when the operator walks back to
+      // it. Nothing else on that path rebuilds it.
+      this.refreshPreview();
       this.saveRun();
     },
 
@@ -2642,6 +2661,11 @@ function schoolBooking() {
         sessions: this.runSessionStarts,
         state: this.runState,
         records: this.runRecords,
+        // #111. Without these the gate dies with the tab, and reopening a
+        // finished run is exactly when an operator is most likely to press
+        // Apply again — they have just been shown a page that looks unfinished.
+        fingerprint: this.lastRun?.fingerprint ?? null,
+        settled: this.lastRun?.settled === true,
       });
     },
 
@@ -2731,6 +2755,14 @@ function schoolBooking() {
       this.cancelMessage = result.message;
       this.running = false;
       this.guardUnload(false);
+      // #111. Taking the bookings back retires the claim that this import is
+      // done, because it is no longer true: the contacts and passes survive,
+      // the bookings do not, and re-booking them is a thing an operator may now
+      // legitimately want. Leaving the gate closed here is the one false
+      // positive with no way out — the very reason those bookings were the only
+      // reversible thing in the first place.
+      this.lastRun = null;
+      this.refreshPreview();
       this.saveRun();
     },
 
@@ -2781,7 +2813,22 @@ function schoolBooking() {
       this.runAt = this.restored.at ?? null;
       this.runSessionStarts = this.restored.sessions ?? [];
       this.runState = this.restored.state ?? 'complete';
+      // #111. A fingerprint the stored run does not carry leaves the gate open
+      // rather than closed: an older run predating this field is not evidence
+      // that today's list has been applied, and guessing it would refuse an
+      // import nobody has run.
+      this.lastRun = this.restored.fingerprint
+        ? { settled: this.restored.settled === true, fingerprint: this.restored.fingerprint }
+        : null;
       this.restored = null;
+      // Only when there is already a preview to correct. It was built before
+      // this run was known about, so it is still offering Apply.
+      //
+      // Never build one that was not there: `x-if="preview"` is what keeps
+      // step 5's block off the screen, and a preview conjured here would render
+      // an empty table and a `nobody-to-book` blocker over the restored run the
+      // next line is about to show.
+      if (this.preview) this.refreshPreview();
       this.maxStepReached = 5;
       this.go(5);
     },

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -24,7 +24,7 @@
 // already has a contact comes back as `new`, and a second permanent contact is
 // written for them. Nothing throws: both spellings are individually valid, and
 // contacts cannot be deleted.
-import { compareForm } from './parse.js?v=2';
+import { compareForm } from './parse.js?v=3';
 
 // ---------------------------------------------------------------------------
 // Match states (P2b)

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -410,6 +410,38 @@ const rowsWhere = (records, predicate) =>
     .filter((n) => n !== null);
 
 /**
+ * Did this run leave anything worth doing again? — #111.
+ *
+ * This is the predicate that keeps #111's already-run gate off **D5's recovery
+ * path**, and getting it wrong is how a well-meant gate becomes the thing that
+ * traps an operator.
+ *
+ * §12 D5 makes a re-run *the* recovery: "Re-paste the same list, pick the same
+ * sessions, run again." §12 D13 then refused to warn against a re-paste at all,
+ * on the grounds that warning would "train staff to click through the warning
+ * on the one path D5 prescribes for recovery." A gate that fires on a run with
+ * a stranded student would do exactly the damage D13 named, except worse — it
+ * blocks rather than warns, so there is nothing to click through.
+ *
+ * So the door closes only on a run that both **finished** and **left nobody
+ * behind**. Two conditions, and each rules out a different kind of unfinished:
+ *
+ *   - **`complete`.** A run halted by D7's breaker or a throttle has students
+ *     it never tried, and they are still waiting.
+ *   - **No failures.** A run can reach the end and still have stranded a
+ *     student — D3 rolled their bookings back and named them — or failed one
+ *     outright. That is precisely what D5 says to re-run.
+ *
+ * A *refused* student is deliberately not counted. A refusal is a standing
+ * condition of the run — a session inside its lead time, a pass that will not
+ * cover the term — and running the same list again reproduces it exactly. The
+ * fix is to change something, and changing something re-opens the gate anyway.
+ */
+export function settledRun(state, records) {
+  return state === 'complete' && resultTotals(records).failed === 0;
+}
+
+/**
  * D11's summary — the same sentence the preview showed, in past tense.
  *
  * Refusals and failures are pointed at **by row number**, because that is the

--- a/school-booking/preview.js
+++ b/school-booking/preview.js
@@ -246,6 +246,52 @@ export function permanenceLine(preview) {
 }
 
 /**
+ * What a run *is*, reduced to one comparable string — #111.
+ *
+ * The gate this feeds needs to answer "has this exact work already been done?",
+ * and that question is about a list and a set of sessions under a school tag,
+ * never about the page. A boolean `hasRun` would answer a different question
+ * and answer it wrongly the moment a student is added, which is the realistic
+ * second run and the one #74's UAT actually exercised.
+ *
+ * Three things go in, and each earns its place:
+ *
+ *   - **The school tag.** It is written onto every contact the run creates and
+ *     is the only record of which school a student belongs to, so the same list
+ *     under a second tag is a different write, not a repeat.
+ *   - **Each runnable student**, as identity plus the resolution the operator
+ *     settled on. Same names but `create` where it once said `use` is a new
+ *     permanent contact — a different run wearing the same list.
+ *   - **The session ids**, because the same students booked into a different
+ *     week is a different run by every measure that matters.
+ *
+ * And what stays out matters as much.
+ *
+ * **Blocked rows**, because no run would have written them — so resolving one
+ * is a change and leaving one alone is not.
+ *
+ * **The row key**, which is emphatically not an identity: it is the student's
+ * first line number in the paste. Including it would mean the same list
+ * re-pasted with a blank line on top read as a different import, purely because
+ * every number shifted by one. Name and date of birth are the identity the rest
+ * of this system matches on, and true duplicates are already collapsed before a
+ * row reaches here, so the key adds instability and no discrimination.
+ *
+ * **Order**, on both lists. A paste arriving in a different order is the same
+ * import, and the operator has no way to control it anyway.
+ */
+export function runFingerprint({ schoolTag, preview } = {}) {
+  // JSON per row rather than a joined string: a separator character is only
+  // unambiguous until a name contains it, and names here are arbitrary text.
+  const rows = (preview?.rows ?? [])
+    .filter((r) => !r.needsHuman)
+    .map((r) => JSON.stringify([r.name, r.dob ?? '', r.clubworx, r.contactKey ?? '', r.resolution ?? '']))
+    .sort();
+  const sessions = (preview?.sessions ?? []).map((e) => String(e?.event_id)).sort();
+  return JSON.stringify([String(schoolTag ?? ''), rows, sessions]);
+}
+
+/**
  * Everything step 5 shows, and everything that keeps Apply dark, from one call.
  *
  * @param {object} opts
@@ -255,8 +301,12 @@ export function permanenceLine(preview) {
  * @param {object} [opts.review] step 3's own `review()`, for its gates — see below
  * @param {object|null} opts.plan the `/plan` response body
  * @param {object} opts.decisions the match resolution log
+ * @param {string} [opts.schoolTag] the school tag, for the already-run fingerprint
+ * @param {{settled: boolean, fingerprint: string}|null} [opts.lastRun] the run
+ *   this browser last finished, if any — `settled` is outcome.js's
+ *   `settledRun()`. See the `already-run` gate below.
  */
-export function buildPreview({ rows, matches, selection, review, plan, decisions } = {}) {
+export function buildPreview({ rows, matches, selection, review, plan, decisions, schoolTag, lastRun } = {}) {
   const log = decisions ?? {};
   const found = matches ?? {};
   const picked = selection ?? { events: [], blockers: [], sessions: 0 };
@@ -318,6 +368,29 @@ export function buildPreview({ rows, matches, selection, review, plan, decisions
     });
   }
 
+  const fingerprint = runFingerprint({ schoolTag, preview: { rows: previewed, sessions: picked.events ?? [] } });
+
+  // #111. `settled` is outcome.js's answer to "did this run leave anything
+  // worth doing again", and it is what keeps this gate off §12 D5's recovery
+  // re-run — the path D13 refused to warn against, and which this blocks rather
+  // than warns. The rule lives there; this decides only what it closes.
+  if (lastRun?.settled && lastRun.fingerprint === fingerprint) {
+    blockers.push({
+      key: 'already-run',
+      kind: 'already-run',
+      severity: 'block',
+      title: 'This import has already been run',
+      // Names only what exists today. #113 adds a "start another import"
+      // control, and this line should point at that instead once it lands —
+      // until then, reloading is the honest instruction, and the run is safe
+      // to reload away from because storage offers it back (D10).
+      detail: 'Nothing here has changed since it ran, so applying again would repeat work that is '
+        + 'already done. Add or resolve a student, or change the sessions, and this clears itself. '
+        + 'To import a different school, reload the page — this run is saved in this browser.',
+      actions: [],
+    });
+  }
+
   return {
     rows: previewed,
     totals,
@@ -326,6 +399,7 @@ export function buildPreview({ rows, matches, selection, review, plan, decisions
     plan: plan?.ok ? plan.plan : null,
     sessions: picked.events ?? [],
     lastSession: picked.lastSession ?? null,
+    fingerprint,
   };
 }
 

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -39,7 +39,7 @@
 // written something the Worker answers 200 and carries `reason: "throttled"`,
 // because the body is then the only record of what was written.
 
-import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=2';
+import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=3';
 
 /** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
 export const RETRY_BACKOFF_MS = 20_000;

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -43,7 +43,7 @@
 //
 // Bump this in lockstep with school-booking.html. alpine-bindings.test.js
 // fails if the two ever disagree.
-import { compareForm, readDate, writeForm } from './parse.js?v=2';
+import { compareForm, readDate, writeForm } from './parse.js?v=3';
 
 const DOMAIN = 'urbanjungleirc.com';
 

--- a/school-booking/test/outcome.test.js
+++ b/school-booking/test/outcome.test.js
@@ -22,6 +22,7 @@ import {
   resultLine,
   resultTotals,
   runRecordText,
+  settledRun,
   strandedWarning,
   studentRecord,
 } from '../outcome.js';
@@ -471,5 +472,43 @@ describe('notRunRecord — the students a halt never reached', () => {
     const rows = [record({}, complete()), notRunRecord(student({ key: 2 }), 'stopped')];
     expect(resultTotals(rows)).toMatchObject({ notRun: 1, failed: 0, stranded: 0 });
     expect(resultLine(rows)).toContain('1 not run');
+  });
+});
+
+// #111 — the predicate that keeps the already-run gate off D5's recovery path.
+//
+// This is the half of #111 with the dangerous failure mode. The gate BLOCKS
+// rather than warns, so a run wrongly called settled leaves the operator with
+// no route to the re-run §12 D5 prescribes and no control anywhere that clears
+// it. Everything here errs toward "not settled", which merely re-offers Apply.
+describe('settledRun — did this run leave anything worth doing again?', () => {
+  test('a clean complete run is settled', () => {
+    expect(settledRun('complete', [record({}, complete())])).toBe(true);
+  });
+
+  test('a halt is never settled, however clean the students it did reach', () => {
+    // Every student it tried succeeded; the ones it never tried are the point.
+    expect(settledRun('halted', [record({}, complete())])).toBe(false);
+  });
+
+  test('a stranded student keeps it open — D3 rolled their bookings back', () => {
+    const stranded = record({}, complete({ outcome: 'failed', stranded: true, strandedDetail: 'no bookings' }));
+    expect(settledRun('complete', [record({}, complete()), stranded])).toBe(false);
+  });
+
+  test('an outright failure keeps it open', () => {
+    expect(settledRun('complete', [record({}, complete({ outcome: 'failed', ok: false }))])).toBe(false);
+  });
+
+  test('a refusal does not keep it open — re-running reproduces it exactly', () => {
+    // A session inside its lead time or a pass that will not cover the term is
+    // a standing condition of the run, not a transient failure. The fix is to
+    // change something, and changing something re-opens the gate anyway.
+    const refused = record({}, complete({ ok: false, outcome: 'refused', written: false, reason: 'lead-time' }));
+    expect(settledRun('complete', [refused])).toBe(true);
+  });
+
+  test('an empty run is not a settled one', () => {
+    expect(settledRun('halted', [])).toBe(false);
   });
 });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -1753,3 +1753,129 @@ describe('cancelling — D12, and never called Undo', () => {
     expect(app.cancellableCount()).toBeGreaterThan(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #111 — a completed run closes the door behind it
+// ---------------------------------------------------------------------------
+// Found in #74's UAT: after a run finished, walking back to the preview offered
+// a live Apply on an unchanged list. The rules are preview.js's; what only the
+// page can get wrong is remembering what it ran, and remembering it across the
+// two paths a finished run arrives by — the run that just happened, and the one
+// restored from this browser's storage.
+describe('the already-run gate (#111)', () => {
+  test('a finished run blocks a second Apply on the same list', async () => {
+    const app = await upToApply(component());
+    expect(app.runState).toBe('complete');
+    const written = app.__writes.length;
+
+    // Back to the preview, exactly as the operator did it.
+    app.go(4);
+    expect(app.preview.blockers.some((b) => b.kind === 'already-run')).toBe(true);
+    expect(app.preview.ready).toBe(false);
+
+    // And the refusal is real, not just a message beside a live button.
+    app.askApply();
+    await app.apply();
+    expect(app.__writes).toHaveLength(written);
+  });
+
+  test('a halted run leaves Apply open — it never reached the whole list', async () => {
+    const app = await upToPreview(component({
+      // Every student throttled: the engine halts on the first one, so nobody
+      // after it was tried.
+      student: () => ({ status: 200, body: { ...STUDENT_OK, reason: 'throttled' } }),
+    }));
+    app.askApply();
+    await app.apply();
+    expect(app.runState).toBe('halted');
+
+    app.go(4);
+    expect(app.preview.blockers.some((b) => b.kind === 'already-run')).toBe(false);
+  });
+
+  test('a run that stranded a student leaves Apply open — §12 D5 says re-run', async () => {
+    // Finished, but not settled. This is the case a `state === 'complete'`
+    // test would have got wrong, and getting it wrong blocks the documented
+    // recovery for the one student who actually needs it.
+    let n = 0;
+    const app = await upToPreview(component({
+      // Exactly one, so the breaker never trips and the run reaches its end.
+      student: () => {
+        n += 1;
+        return n === 2
+          ? {
+            status: 200,
+            body: { ...STUDENT_OK, outcome: 'failed', stranded: true, strandedDetail: 'no bookings from this run' },
+          }
+          : { status: 200, body: STUDENT_OK };
+      },
+    }));
+    app.askApply();
+    await app.apply();
+    expect(app.runState).toBe('complete');
+
+    app.go(4);
+    expect(app.preview.blockers.some((b) => b.kind === 'already-run')).toBe(false);
+  });
+
+  test('cancelling the run\u2019s bookings re-opens Apply', async () => {
+    // The false positive with no way out: the bookings are gone, re-booking is
+    // a thing the operator may now want, and before this the gate still said
+    // "already run" with no control anywhere that could clear it.
+    const app = await upToApply(component());
+    app.go(4);
+    expect(app.preview.blockers.some((b) => b.kind === 'already-run')).toBe(true);
+
+    app.go(5);
+    app.askCancel();
+    await app.cancelRun();
+    expect(app.cancelState).toBe('done');
+
+    app.go(4);
+    expect(app.preview.blockers.some((b) => b.kind === 'already-run')).toBe(false);
+  });
+
+  test('opening a restored run does not conjure a preview onto the screen', async () => {
+    // `x-if="preview"` is the whole of what keeps step 5's block off screen.
+    // A preview built here renders an empty table and a `nobody-to-book`
+    // blocker over the restored run being opened.
+    const app = component();
+    app.restored = { at: '2026-08-01T00:00:00Z', school: 'newman', sessions: [], state: 'complete', records: [] };
+    expect(app.preview).toBeNull();
+    app.openRestored();
+    expect(app.preview, 'no list has been pasted, so there is nothing to preview').toBeNull();
+  });
+
+  test('the gate survives the tab: a restored run still closes Apply', async () => {
+    const first = await upToApply(component());
+    expect(first.lastRun?.fingerprint, 'the run records its fingerprint').toBeTruthy();
+    expect(first.lastRun.settled, 'a clean run is settled').toBe(true);
+
+    // A second visit to the same browser, holding the run the first one left.
+    const second = await upToPreview(component({
+      restored: {
+        at: first.runAt,
+        school: 'newman',
+        sessions: first.runSessionStarts,
+        state: 'complete',
+        records: first.runRecords,
+        fingerprint: first.lastRun.fingerprint,
+        settled: true,
+      },
+    }));
+    second.openRestored();
+    second.go(4);
+    expect(second.preview.blockers.some((b) => b.kind === 'already-run')).toBe(true);
+  });
+
+  test('a stored run from before this field leaves Apply open', async () => {
+    // Refusing an import nobody has run is the worse failure of the two: the
+    // operator has no way past it and no way to tell why.
+    const app = await upToPreview(component({
+      restored: { at: '2026-08-01T00:00:00Z', school: 'newman', sessions: [], state: 'complete', records: [] },
+    }));
+    app.openRestored();
+    app.go(4);
+    expect(app.preview.blockers.some((b) => b.kind === 'already-run')).toBe(false);
+  });
+});

--- a/school-booking/test/preview.test.js
+++ b/school-booking/test/preview.test.js
@@ -11,6 +11,7 @@ import {
   matchDecision,
   permanenceLine,
   resolveMatch,
+  runFingerprint,
 } from '../preview.js';
 
 // A step-3 row, in the shape `review()` emits.
@@ -447,5 +448,134 @@ describe('step 3’s gates are hard-stops here too', () => {
     };
     const carried = build({ review: withAction }).blockers.find((b) => b.kind === 'count-mismatch');
     expect(carried.actions[0].answers).toBe('redeclare');
+  });
+});
+
+// #111: a completed run closes the door behind it.
+//
+// The tool proved idempotent against production during #74's UAT — a second
+// Apply on an unchanged list matches the contacts it already made, grants no
+// second pass, and does not rebook anybody. So this gate is not protecting the
+// data; it is protecting the operator's reading of the page. An Apply button
+// that is live when it provably has nothing to do teaches staff that the gate
+// above it means nothing, on the one screen where that lesson is expensive.
+//
+// It is a *fingerprint* rather than a flag because "already run" is a claim
+// about a particular list against particular sessions, not about the page. Add
+// a student and the claim expires; the flag would not have noticed.
+describe('the already-run gate', () => {
+  const lastRun = (over = {}) => ({
+    settled: true,
+    fingerprint: runFingerprint({ schoolTag: 'stmarys', preview: build() }),
+    ...over,
+  });
+
+  test('a completed run on the same list blocks Apply', () => {
+    const preview = build({ schoolTag: 'stmarys', lastRun: lastRun() });
+    const gate = preview.blockers.find((b) => b.kind === 'already-run');
+    expect(gate?.severity).toBe('block');
+    expect(preview.ready).toBe(false);
+  });
+
+  test('no run yet leaves Apply alone', () => {
+    expect(build({ schoolTag: 'stmarys' }).blockers.some((b) => b.kind === 'already-run')).toBe(false);
+  });
+
+  test('an added student re-opens Apply', () => {
+    // The realistic second run, and the one UAT actually exercised: the same
+    // list with more names on the end of it.
+    const more = build({
+      schoolTag: 'stmarys',
+      rows: [row(), row({ key: 4, firstName: 'Bo', lastName: 'Nguyen', dob: '2012-01-04' })],
+      matches: { 3: match(), 4: match() },
+      lastRun: lastRun(),
+    });
+    expect(more.blockers.some((b) => b.kind === 'already-run')).toBe(false);
+  });
+
+  test('a different session selection re-opens Apply', () => {
+    const elsewhere = build({
+      schoolTag: 'stmarys',
+      selection: selection({
+        events: [{ event_id: 'c', event_name: 'School Session', event_start_at: '2026-09-15T09:00:00+08:00' }],
+        sessions: 1,
+      }),
+      lastRun: lastRun(),
+    });
+    expect(elsewhere.blockers.some((b) => b.kind === 'already-run')).toBe(false);
+  });
+
+  test('a different school re-opens Apply', () => {
+    // The same list can legitimately be run twice under two tags — the tag is
+    // written onto every contact this run creates, so it is part of what a run
+    // *is*, not decoration around it.
+    expect(
+      build({ schoolTag: 'holycross', lastRun: lastRun() }).blockers.some((b) => b.kind === 'already-run'),
+    ).toBe(false);
+  });
+
+  test('an unsettled run does not block: §12 D5 says re-run it', () => {
+    // The trap this gate could easily walk into, and the reason `settled` is a
+    // question for outcome.js rather than a `state === 'complete'` test here.
+    // A run halted by the breaker never reached its tail; a run that finished
+    // having stranded a student left work behind. D5 makes re-running the
+    // recovery for both, and D13 refused even to *warn* against that path —
+    // so blocking it would be worse than the thing D13 rejected.
+    expect(
+      build({ schoolTag: 'stmarys', lastRun: lastRun({ settled: false }) })
+        .blockers.some((b) => b.kind === 'already-run'),
+    ).toBe(false);
+  });
+
+  test('resolving a match differently re-opens Apply', () => {
+    // Same names, same sessions — but the operator has since told the page to
+    // create a student it had matched. That is a different write.
+    const decided = build({
+      schoolTag: 'stmarys',
+      matches: { 3: match({ state: 'ambiguous', candidates: [contact()], reason: 'many-candidates' }) },
+      decisions: resolveMatch({}, 3, 'create'),
+      lastRun: lastRun(),
+    });
+    expect(decided.blockers.some((b) => b.kind === 'already-run')).toBe(false);
+  });
+});
+
+describe('runFingerprint', () => {
+  test('is stable across rebuilds of the same inputs', () => {
+    expect(runFingerprint({ schoolTag: 'stmarys', preview: build() }))
+      .toBe(runFingerprint({ schoolTag: 'stmarys', preview: build() }));
+  });
+
+  test('ignores row order, because the operator cannot control it', () => {
+    const a = build({
+      rows: [row(), row({ key: 4, firstName: 'Bo', lastName: 'Nguyen', dob: '2012-01-04' })],
+      matches: { 3: match(), 4: match() },
+    });
+    const b = build({
+      rows: [row({ key: 4, firstName: 'Bo', lastName: 'Nguyen', dob: '2012-01-04' }), row()],
+      matches: { 3: match(), 4: match() },
+    });
+    expect(runFingerprint({ schoolTag: 's', preview: a })).toBe(runFingerprint({ schoolTag: 's', preview: b }));
+  });
+
+  test('ignores the row key, which is a paste line number and not an identity', () => {
+    // The same list with a blank line pasted above it: every key shifts by one
+    // and nothing about the import has changed. Keying on it would re-open
+    // Apply on a list that has provably already been run.
+    const shifted = build({
+      rows: [row({ key: 4, lineNumbers: [4] })],
+      matches: { 4: match() },
+    });
+    expect(runFingerprint({ schoolTag: 's', preview: shifted }))
+      .toBe(runFingerprint({ schoolTag: 's', preview: build() }));
+  });
+
+  test('ignores a blocked row, which no run would have written', () => {
+    const withBlocked = build({
+      rows: [row(), row({ key: 9, needsHuman: true })],
+      matches: { 3: match() },
+    });
+    expect(runFingerprint({ schoolTag: 's', preview: withBlocked }))
+      .toBe(runFingerprint({ schoolTag: 's', preview: build() }));
   });
 });


### PR DESCRIPTION
Closes #111. Found in #74's UAT: after a run finished, walking back to the preview offered a live Apply on an unchanged list.

⚠️ **Merging deploys.** `main` is production on this repo.

## This supersedes a design decision, deliberately

§12 **D13** decided the opposite — *"A deliberate re-paste needs no special handling"* — on the grounds that warning against a re-paste would *"train staff to click through the warning on the one path D5 prescribes for recovery."*

That argument is sound and survives intact. It is why this is **a refusal rather than a warning**, and why the refusal **never appears on D5's recovery path at all**. The spec now records the supersession with the reasoning, rather than being quietly contradicted by the code.

## The load-bearing part

`settledRun()` in `outcome.js` — a run is settled only when it **both finished and left nobody behind**.

It is deliberately *not* a `state === 'complete'` test. A run can reach the end having stranded a student (D3 rolled their bookings back and named them), and §12 D5 makes re-running the recovery for exactly that. A `complete` test would have blocked the documented fix for the one student who needs it.

A *refusal* does not keep the door open: a session inside its lead time reproduces identically on a re-run, and the fix is to change something — which re-opens the gate anyway.

**Cancelling the run's bookings retires the claim too.** Without that, taking the bookings back left Apply dark with nothing on the page able to clear it — a refusal with no exit, which is worse than the warning D13 rejected.

## A fingerprint, not a flag

"Already done" is a claim about a list and a set of sessions under a school tag. Adding students to the end of a run is the realistic second import — the one UAT actually did — and it expires the claim; a `hasRun` flag would not have noticed.

The row **key is excluded**: it is a paste line number, so keying on it would re-open Apply on the same list re-pasted under a blank line. Name and DOB are the identity the rest of the system matches on, and true duplicates are collapsed before a row gets here.

## Two bugs caught in review, worth naming

- `openRestored()` rebuilt the preview unconditionally, which turned `x-if="preview"` truthy and rendered an empty step-5 table with a `nobody-to-book` blocker over the restored run. Now guarded on a preview already existing.
- The cancel false positive above — no test would have caught it, and no control on the page could have cleared it.

## Note on the gate's wording

It says *"reload the page — this run is saved in this browser"*, because #113's "start another import" control does not exist yet, and pointing at a missing control is worse than pointing at a clumsy one. Left a note on #113 to update the line when the reset lands.

## Tests

1433 across the five packages, all green — 24 new. `?v=` bumped to 3 across the chain (both `preview.js` and `outcome.js` gained exports; the guard requires one version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn