### PR TITLE
School booking: the run says it is alive while it works (#112)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,14 +121,18 @@ school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #10
                           only the confirm gate, the single-flight lock, the
                           storage and the rendering — the run itself is run.js
                           (#78's seam), and a component test asserts that steps
-                          1-5 issue no POST. BOTH serial waits — the Clubworx
-                          check between 4 and 5, and the run on 6 — have a
-                          STICKY banner carrying the `.spinner` defined in this
-                          file's own style block (#112). Each publishes a row
-                          per student, so the table growing underneath carries a
-                          static banner off the top, and a count that moves once
-                          per student says nothing between two students or
-                          through D8's backoff. openRestored() CLAMPS a stored
+                          1-5 issue no POST. ALL THREE serial waits — the
+                          Clubworx check between 4 and 5, the run on 6, and
+                          D12's cancel — carry the `.spinner` defined in this
+                          file's own style block (#112), because a count that
+                          moves once per student says nothing between two of
+                          them or through D8's backoff. The first two are also
+                          STICKY: each publishes a row per student, so the table
+                          growing underneath carries a static banner off the
+                          top. The cancel is NOT — it rewrites rows in place
+                          rather than adding them, and nothing grows under it.
+                          Its denominator is cancellableStudents(), not the row
+                          or booking count. openRestored() CLAMPS a stored
                           `running` to a halt: the store is written per student,
                           so a tab closed mid-run leaves `running` behind, and a
                           spinner on that is a dead page claiming to be alive.
@@ -212,9 +216,12 @@ school-booking/outcome.js - what one `POST /student` answer means, and what a
                           rendered as live. The three permanence classes are
                           counted apart, never collapsed into a success total.
                           progressLine() is #112's in-progress text — display
-                          only, built from the two counts the run already holds
-                          and never from the records, so it cannot be wrong
-                          about what happened. It is the SPINNER beside it that
+                          only, built from two counts and never from the
+                          records, so it cannot be wrong about what happened.
+                          cancellableStudents() is the cancel's denominator and
+                          MUST stay the same predicate run.js skips on, or the
+                          count stops short of its own total and reads as a
+                          stall. It is the SPINNER beside it that
                           carries liveness: this line changes once per student
                           and says nothing at all through D8's 20-second
                           backoff, which is the quiet the report was about.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,15 @@ school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #10
                           only the confirm gate, the single-flight lock, the
                           storage and the rendering — the run itself is run.js
                           (#78's seam), and a component test asserts that steps
-                          1-5 issue no POST.
+                          1-5 issue no POST. Step 6's running banner is STICKY
+                          and carries the `.spinner` defined in this file's own
+                          style block (#112): the result table adds a row per
+                          student, so an indicator that scrolls away is not one,
+                          and a count that moves once per student says nothing
+                          through D8's backoff. openRestored() CLAMPS a stored
+                          `running` to a halt: the store is written per student,
+                          so a tab closed mid-run leaves `running` behind, and a
+                          spinner on that is a dead page claiming to be alive.
 school-booking/events.js - what a SELECTION of sessions is: the same-name,
                           same-location pre-tick (no recurrence field exists,
                           so any automatic rule is a guess), the lead-time and
@@ -201,6 +209,13 @@ school-booking/outcome.js - what one `POST /student` answer means, and what a
                           intact. bookingRows() is what stops a dead id being
                           rendered as live. The three permanence classes are
                           counted apart, never collapsed into a success total.
+                          progressLine() is #112's in-progress text — display
+                          only, built from the two counts the run already holds
+                          and never from the records, so it cannot be wrong
+                          about what happened. It is the SPINNER beside it that
+                          carries liveness: this line changes once per student
+                          and says nothing at all through D8's 20-second
+                          backoff, which is the quiet the report was about.
 school-booking/parse.js - turns a pasted school student list into rows plus the
                           list-level inferences (layout, column mapping, date
                           orientation). Pure and unit tested; §7 of the design

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,11 +121,13 @@ school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #10
                           only the confirm gate, the single-flight lock, the
                           storage and the rendering — the run itself is run.js
                           (#78's seam), and a component test asserts that steps
-                          1-5 issue no POST. Step 6's running banner is STICKY
-                          and carries the `.spinner` defined in this file's own
-                          style block (#112): the result table adds a row per
-                          student, so an indicator that scrolls away is not one,
-                          and a count that moves once per student says nothing
+                          1-5 issue no POST. BOTH serial waits — the Clubworx
+                          check between 4 and 5, and the run on 6 — have a
+                          STICKY banner carrying the `.spinner` defined in this
+                          file's own style block (#112). Each publishes a row
+                          per student, so the table growing underneath carries a
+                          static banner off the top, and a count that moves once
+                          per student says nothing between two students or
                           through D8's backoff. openRestored() CLAMPS a stored
                           `running` to a halt: the store is written per student,
                           so a tab closed mid-run leaves `running` behind, and a

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -1052,6 +1052,43 @@ staff must be able to see and finish by hand.
 The specific failure this defends against is a page reload destroying the only
 record of creations that cannot be undone.
 
+**D15 — The run says it is alive, continuously and where the operator is
+looking.** Added on [#112](https://github.com/urbanjungleirc/staff-site/issues/112)
+after the same UAT as #111. Display only: it changes nothing about what the run
+does, how it paces, or when it stops.
+
+The report says "nothing else on the page indicates a run is under way", but a
+banner with a live count **was** on screen the whole time. Two things explain
+that, and the count on its own fixed neither:
+
+- It sits above a table that adds a row per student, so it leaves the viewport
+  as the run goes on. *This part is inference* — the report does not say the
+  banner scrolled away, only that nothing indicated a run. It is the reading
+  that fits a banner being present and unseen.
+- Its text changes once per student, so through D8's 20-second backoff it says
+  nothing at all — the pause where the run is deliberately waiting and is least
+  distinguishable from a dead page.
+
+So the banner is **sticky**, and it carries a **spinner** as well as the count.
+The spinner is the part that keeps moving when nothing else does; under
+`prefers-reduced-motion` it is slowed, not stopped, because a ring that does not
+turn reads as the failure this removes.
+
+**Clearing it is four paths, not three.** The engine's three endings —
+completion, the breaker halt, the throttle halt — all leave `runState`, and the
+banner is bound to it. The fourth is the one D10 exists for: the store is
+written per student, so a tab closed on student 19 leaves `state: 'running'` in
+`localStorage`, and `openRestored()` restored that verbatim. A restored
+`running` is the one value that cannot be true — nothing is calling anything —
+and before this it merely showed a stale sentence. With a spinner on it, it
+becomes a page actively claiming liveness over a dead run, while
+`runState !== 'running'` hides the very result table the store was written to
+preserve. So a restored `running` is clamped to a **halt** with reason
+`interrupted`, and D5's re-run finishes it like any other.
+
+The text itself is `progressLine()` in `outcome.js`, built from the two counts
+the run already holds and never from the records.
+
 ### Doing it twice
 
 **D5 — Recovery is a restart-safe re-run. No stored run state, no resume.**

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -1089,6 +1089,14 @@ preserve. So a restored `running` is clamped to a **halt** with reason
 The text itself is `progressLine()` in `outcome.js`, built from the two counts
 the run already holds and never from the records.
 
+**It applies to both serial waits, not just the run.** The Clubworx check
+between steps 4 and 5 (§6, strictly one student at a time) has the same shape
+and had the same gap: minutes for a class of 25, a preview row published per
+student, and a count that moves once per student. Same sticky banner, same
+spinner. Its two exits both clear it — the end of the loop, and §11's early stop
+on an unresolved plan — and neither `checkStudent` nor `lookupPlan` throws, so
+there is no third path to clamp the way the restored run needed.
+
 ### Doing it twice
 
 **D5 — Recovery is a restart-safe re-run. No stored run state, no resume.**

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -1089,13 +1089,33 @@ preserve. So a restored `running` is clamped to a **halt** with reason
 The text itself is `progressLine()` in `outcome.js`, built from the two counts
 the run already holds and never from the records.
 
-**It applies to both serial waits, not just the run.** The Clubworx check
-between steps 4 and 5 (§6, strictly one student at a time) has the same shape
-and had the same gap: minutes for a class of 25, a preview row published per
-student, and a count that moves once per student. Same sticky banner, same
-spinner. Its two exits both clear it — the end of the loop, and §11's early stop
-on an unresolved plan — and neither `checkStudent` nor `lookupPlan` throws, so
-there is no third path to clamp the way the restored run needed.
+**It applies to all three serial waits, not just the run.**
+
+The **Clubworx check** between steps 4 and 5 (§6, strictly one student at a
+time) has the same shape and had the same gap: minutes for a class of 25, a
+preview row published per student, and a count that moves once per student. Same
+sticky banner, same spinner. Its two exits both clear it — the end of the loop,
+and §11's early stop on an unresolved plan — and neither `checkStudent` nor
+`lookupPlan` throws, so there is no third path to clamp the way the restored run
+needed.
+
+**D12's cancel** had the least of the three: no count at all. It is up to 150
+DELETEs plus a verifying re-read per student, which is minutes of a page saying
+nothing while it deletes things. It gets the spinner and a count, but **not**
+the sticky banner — nothing grows underneath it. The cancel rewrites the
+result table's rows in place rather than adding to it, and the panel the
+operator just clicked in is where they are already looking. Sticky is the answer
+to a table that pushes the banner away, which is not this.
+
+Its denominator is the awkward part, and it is `cancellableStudents()` in
+`outcome.js`. It is neither the row count nor the booking count the control
+above quotes ("Cancel 12 bookings from this run"): `cancelStudents` sends one
+call per student and skips a record with nothing this run booked, so a
+denominator that counted those would sit permanently short of its own total and
+read as the stall it was meant to disprove. It is deliberately the *same*
+predicate the engine skips on — two copies of that rule is how the counter
+starts lying. That is also why the line says the word "students": the control
+beside it counts bookings, and the two numbers differ.
 
 ### Doing it twice
 

--- a/school-booking.html
+++ b/school-booking.html
@@ -385,11 +385,11 @@
 
   /* #112 — something is still happening.
 
-     Used by both of the page's serial, one-student-at-a-time waits: the
-     Clubworx check between steps 4 and 5, and the run on step 6. A count that
-     changes once per student is not an activity indicator — between two
-     students, and right through D8's 20-second retry backoff, it says nothing
-     at all. This is the part that keeps saying something. */
+     Used by all three of the page's serial, one-student-at-a-time waits: the
+     Clubworx check between steps 4 and 5, the run on step 6, and D12's cancel.
+     A count that changes once per student is not an activity indicator —
+     between two students, and right through D8's 20-second retry backoff, it
+     says nothing at all. This is the part that keeps saying something. */
   @keyframes uj-spin { to { transform: rotate(360deg); } }
 
   .spinner {
@@ -1501,7 +1501,17 @@
             </div>
           </div>
 
-          <div class="text-xs mt-2" x-show="cancelState === 'running'" x-cloak>Cancelling, one student at a time…</div>
+          <!-- #112. Not sticky, unlike the other two: nothing grows underneath
+               this one. The cancel rewrites the table's rows in place rather
+               than adding to it, and the panel the operator just clicked in is
+               where they are already looking. -->
+          <div class="text-xs mt-2 flex items-center gap-2" x-show="cancelState === 'running'" x-cloak>
+            <span class="spinner" aria-hidden="true"></span>
+            <span>
+              <span role="status" x-text="cancelProgress"></span>
+              Cancelling, one student at a time…
+            </span>
+          </div>
           <div class="text-xs mt-2 text-rose-700" x-show="cancelState === 'halted'" x-cloak x-text="cancelMessage"></div>
         </div>
 
@@ -1643,6 +1653,10 @@ function schoolBooking() {
     expandedResult: null,
     cancelState: 'idle',
     cancelMessage: '',
+    // #112. The cancel's own count. Kept apart from `runProgress` because the
+    // two can never be on screen together and sharing one would make a stale
+    // line from the run readable during a cancel.
+    cancelProgress: '',
     cancelConfirming: false,
     // A run found in this browser's storage at load — D10's whole purpose. It
     // is offered, never auto-opened: it may be yesterday's, and the operator
@@ -2790,6 +2804,14 @@ function schoolBooking() {
       this.running = true;
       this.cancelState = 'running';
       this.cancelMessage = '';
+      // #112. The denominator is the students the loop will actually call for,
+      // which is neither the row count nor the booking count the control above
+      // quotes: a record with nothing this run booked is skipped by the engine
+      // (D12's interlock), so counting it would leave this permanently short of
+      // its own total. `cancellableStudents` is the engine's own predicate.
+      const toCall = window.schoolBookingOutcome.cancellableStudents(this.runRecords);
+      let called = 0;
+      this.cancelProgress = window.schoolBookingOutcome.progressLine({ done: 0, total: toCall });
       this.guardUnload(true);
 
       const result = await window.schoolBookingRun.cancelStudents({
@@ -2797,6 +2819,10 @@ function schoolBooking() {
         call: (payload) => this.callWorker('/api/clubworx/unbook', payload),
         onRow: (record, records) => {
           this.runRecords = [...records];
+          // Counted here rather than off `records.length`: that array is every
+          // row in the run and does not move as the loop skips.
+          called += 1;
+          this.cancelProgress = window.schoolBookingOutcome.progressLine({ done: called, total: toCall });
           this.saveRun();
         },
       });
@@ -2804,6 +2830,7 @@ function schoolBooking() {
       this.runRecords = [...result.records];
       this.cancelState = result.state === 'halted' ? 'halted' : 'done';
       this.cancelMessage = result.message;
+      this.cancelProgress = '';
       this.running = false;
       this.guardUnload(false);
       // #111. Taking the bookings back retires the claim that this import is

--- a/school-booking.html
+++ b/school-booking.html
@@ -383,11 +383,13 @@
   .lane-bad  { border-left-color: #e11d48; }
   .lane-ok   { border-left-color: #10b981; }
 
-  /* #112 — the run is alive.
+  /* #112 — something is still happening.
 
-     A count that changes once per student is not an activity indicator: between
-     two students, and right through D8's 20-second retry backoff, it says
-     nothing at all. This is the part that keeps saying something. */
+     Used by both of the page's serial, one-student-at-a-time waits: the
+     Clubworx check between steps 4 and 5, and the run on step 6. A count that
+     changes once per student is not an activity indicator — between two
+     students, and right through D8's 20-second retry backoff, it says nothing
+     at all. This is the part that keeps saying something. */
   @keyframes uj-spin { to { transform: rotate(360deg); } }
 
   .spinner {
@@ -1144,11 +1146,21 @@
         <!-- The check is serial and a class of 25 takes minutes, so the count
              says which student it is on. It lives here rather than on step 4's
              button because the page has already moved: answers are published
-             per student, so a check that stalls on 19 shows eighteen rows. -->
-        <div class="rounded-xl bg-sky-50 border border-sky-200 text-sky-900 px-3.5 py-2.5 text-sm mb-3"
+             per student, so a check that stalls on 19 shows eighteen rows.
+
+             #112, same as step 6's. Publishing per student means a table grows
+             underneath this and carries it off the top, and the count moves
+             once per student — so between two students there is nothing on
+             screen saying the check is alive. The spinner is that. -->
+        <div class="sticky top-0 z-10 rounded-xl bg-sky-50 border border-sky-200 text-sky-900 px-3.5 py-2.5 text-sm mb-3 flex items-start gap-2.5"
              x-show="checkState === 'running'" x-cloak>
-          <span x-text="checkProgress"></span>
-          One student at a time — the Clubworx allowance is shared with the whole gym.
+          <span class="spinner mt-1" aria-hidden="true"></span>
+          <span>
+            <!-- The live region is the count alone; on the whole banner the
+                 static sentence is re-read on every one of 25 updates. -->
+            <span role="status" x-text="checkProgress"></span>
+            One student at a time — the Clubworx allowance is shared with the whole gym.
+          </span>
         </div>
 
         <template x-if="preview">

--- a/school-booking.html
+++ b/school-booking.html
@@ -68,14 +68,14 @@
      or missing module into a visible refusal rather than a page whose gates
      quietly do nothing. -->
 <script type="module">
-  import * as parser from './school-booking/parse.js?v=3';
-  import * as steps from './school-booking/steps.js?v=3';
-  import * as identity from './school-booking/identity.js?v=3';
-  import * as events from './school-booking/events.js?v=3';
-  import * as preview from './school-booking/preview.js?v=3';
-  import * as calendar from './school-booking/calendar.js?v=3';
-  import * as outcome from './school-booking/outcome.js?v=3';
-  import * as run from './school-booking/run.js?v=3';
+  import * as parser from './school-booking/parse.js?v=4';
+  import * as steps from './school-booking/steps.js?v=4';
+  import * as identity from './school-booking/identity.js?v=4';
+  import * as events from './school-booking/events.js?v=4';
+  import * as preview from './school-booking/preview.js?v=4';
+  import * as calendar from './school-booking/calendar.js?v=4';
+  import * as outcome from './school-booking/outcome.js?v=4';
+  import * as run from './school-booking/run.js?v=4';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
   window.schoolBookingIdentity = identity;
@@ -382,6 +382,30 @@
   .lane-need { border-left-color: #f59e0b; }
   .lane-bad  { border-left-color: #e11d48; }
   .lane-ok   { border-left-color: #10b981; }
+
+  /* #112 — the run is alive.
+
+     A count that changes once per student is not an activity indicator: between
+     two students, and right through D8's 20-second retry backoff, it says
+     nothing at all. This is the part that keeps saying something. */
+  @keyframes uj-spin { to { transform: rotate(360deg); } }
+
+  .spinner {
+    width: 0.85rem;
+    height: 0.85rem;
+    flex: none;
+    border-radius: 9999px;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    animation: uj-spin 0.8s linear infinite;
+  }
+
+  /* Slowed rather than stopped. A ring that does not turn reads as a spinner
+     that has died, which is the exact impression this whole thing exists to
+     remove — so reduced motion gets a calmer one, not a frozen one. */
+  @media (prefers-reduced-motion: reduce) {
+    .spinner { animation-duration: 3s; }
+  }
 </style>
 </head>
 
@@ -1283,10 +1307,20 @@
           Bookings are the one thing that can be taken back.
         </p>
 
-        <div class="rounded-xl bg-sky-50 border border-sky-200 text-sky-900 px-3.5 py-2.5 text-sm mb-3"
+        <!-- #112. Sticky, because the fault reported at UAT was not a missing
+             banner — it was this one, above a table that adds a row per
+             student and pushes it off the top by the twelfth. An indicator
+             that has scrolled away is not an indicator. -->
+        <div class="sticky top-0 z-10 rounded-xl bg-sky-50 border border-sky-200 text-sky-900 px-3.5 py-2.5 text-sm mb-3 flex items-start gap-2.5"
              x-show="runState === 'running'" x-cloak>
-          <span x-text="runProgress"></span>
-          One student at a time — the Clubworx allowance is shared with the whole gym. Leave this tab open.
+          <span class="spinner mt-1" aria-hidden="true"></span>
+          <span>
+            <!-- The live region is the count and nothing else. On the whole
+                 banner it would re-read the static sentence below on every
+                 update, which on a class of 63 is sixty-three times. -->
+            <span role="status" x-text="runProgress"></span>
+            One student at a time — the Clubworx allowance is shared with the whole gym. Leave this tab open.
+          </span>
         </div>
 
         <!-- A halt says why, and says that what is above it is untouched. -->
@@ -2592,7 +2626,9 @@ function schoolBooking() {
       const fingerprint = this.preview.fingerprint;
       this.expandedResult = null;
       this.runRemaining = 0;
-      this.runProgress = `Starting ${students.length} student${students.length === 1 ? '' : 's'}…`;
+      // #112. The line is `outcome.js`'s, not the page's — one plural rule, in
+      // a place a test can reach.
+      this.runProgress = window.schoolBookingOutcome.progressLine({ done: 0, total: students.length });
       this.guardUnload(true);
       this.go(5);
 
@@ -2603,7 +2639,10 @@ function schoolBooking() {
           // Published and stored per student. An end-of-run write is the one
           // that is missing when the tab is closed on student 19.
           this.runRecords = [...records];
-          this.runProgress = `${records.length} of ${students.length} done…`;
+          this.runProgress = window.schoolBookingOutcome.progressLine({
+            done: records.length,
+            total: students.length,
+          });
           this.saveRun();
         },
       });
@@ -2812,7 +2851,23 @@ function schoolBooking() {
       this.runRecords = this.restored.records ?? [];
       this.runAt = this.restored.at ?? null;
       this.runSessionStarts = this.restored.sessions ?? [];
-      this.runState = this.restored.state ?? 'complete';
+      // #112. The store is written per student (D10), so a tab closed on
+      // student 19 leaves `running` behind — and a restored `running` is the
+      // one state that cannot be true, because nothing is calling anything.
+      // Left as-is it puts a turning spinner and "Leave this tab open" over a
+      // dead page, and hides the result table behind `runState !== 'running'`,
+      // which is the very record the store exists to preserve. It is a halt,
+      // and D5's re-run is how it is finished — the same as any other.
+      const interrupted = this.restored.state === 'running';
+      this.runState = interrupted ? 'halted' : (this.restored.state ?? 'complete');
+      this.runReason = interrupted ? 'interrupted' : null;
+      this.runMessage = interrupted
+        ? 'This run did not finish — the tab was closed or reloaded while it was working. '
+          + 'Everything below is done and is not affected. Students the run never reached are '
+          + 'not listed, because nothing was recorded for them.'
+        : '';
+      this.runRemaining = 0;
+      this.runProgress = '';
       // #111. A fingerprint the stored run does not carry leaves the gate open
       // rather than closed: an older run predating this field is not evidence
       // that today's list has been applied, and guessing it would refuse an

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -24,7 +24,7 @@
 // already has a contact comes back as `new`, and a second permanent contact is
 // written for them. Nothing throws: both spellings are individually valid, and
 // contacts cannot be deleted.
-import { compareForm } from './parse.js?v=3';
+import { compareForm } from './parse.js?v=4';
 
 // ---------------------------------------------------------------------------
 // Match states (P2b)

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -534,3 +534,21 @@ export function runRecordText(records, meta = {}) {
     2,
   );
 }
+
+/**
+ * The in-progress line — #112.
+ *
+ * Display only, and deliberately made of the two numbers the run already holds:
+ * how many students have come back, and how many were started. It never reads
+ * the records, so it cannot be wrong about what happened — it is about whether
+ * anything is still happening.
+ *
+ * The banner it sits in is cleared by the run *ending* (`runState` leaving
+ * `running`), not by this line, which is why `done === total` still reads as
+ * in-flight: `onRow` fires before the engine has decided whether to halt.
+ */
+export function progressLine({ done = 0, total = 0 } = {}) {
+  if (total <= 0) return '';
+  if (done <= 0) return `Starting ${plural(total, 'student')}…`;
+  return `${done} of ${total} done…`;
+}

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -332,6 +332,22 @@ export function anyCancellable(records) {
   return (records ?? []).some((r) => cancellable(r).length > 0);
 }
 
+/**
+ * How many students the cancel loop will actually call for — #112.
+ *
+ * Not the row count, and not the booking count either. `cancelStudents` sends
+ * one call per student and SKIPS a record with nothing this run booked, so this
+ * has to agree with that skip or the progress it feeds stops short of its own
+ * total and reads as a stall. Same predicate, one place.
+ *
+ * The control above it counts *bookings* — "Cancel 12 bookings from this run" —
+ * because that is the unit of what is being taken back. The loop's unit is
+ * students, which is why the line it feeds says the word.
+ */
+export function cancellableStudents(records) {
+  return (records ?? []).filter((r) => cancellable(r).length > 0).length;
+}
+
 /** The run's tally, with the three permanence classes kept apart. */
 export function resultTotals(records) {
   const rows = records ?? [];
@@ -550,5 +566,5 @@ export function runRecordText(records, meta = {}) {
 export function progressLine({ done = 0, total = 0 } = {}) {
   if (total <= 0) return '';
   if (done <= 0) return `Starting ${plural(total, 'student')}…`;
-  return `${done} of ${total} done…`;
+  return `${done} of ${plural(total, 'student')} done…`;
 }

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -39,7 +39,7 @@
 // written something the Worker answers 200 and carries `reason: "throttled"`,
 // because the body is then the only record of what was written.
 
-import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=3';
+import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=4';
 
 /** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
 export const RETRY_BACKOFF_MS = 20_000;

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -43,7 +43,7 @@
 //
 // Bump this in lockstep with school-booking.html. alpine-bindings.test.js
 // fails if the two ever disagree.
-import { compareForm, readDate, writeForm } from './parse.js?v=3';
+import { compareForm, readDate, writeForm } from './parse.js?v=4';
 
 const DOMAIN = 'urbanjungleirc.com';
 

--- a/school-booking/test/outcome.test.js
+++ b/school-booking/test/outcome.test.js
@@ -19,6 +19,7 @@ import {
   bookingRows,
   isFailure,
   notRunRecord,
+  progressLine,
   resultLine,
   resultTotals,
   runRecordText,
@@ -510,5 +511,41 @@ describe('settledRun — did this run leave anything worth doing again?', () => 
 
   test('an empty run is not a settled one', () => {
     expect(settledRun('halted', [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #112 — the line that says the run is alive
+// ---------------------------------------------------------------------------
+// Display only. It reads two numbers the run already has and never touches what
+// the run does. It lives here rather than inline in the page because the page's
+// own copy of it was two template literals with a plural rule in each, which is
+// the shape that quietly says "1 students".
+
+describe('progressLine (#112)', () => {
+  test('a run with nothing in it has nothing to say', () => {
+    expect(progressLine({ done: 0, total: 0 })).toBe('');
+    expect(progressLine()).toBe('');
+  });
+
+  test('before the first student lands it names the size of what was started', () => {
+    expect(progressLine({ done: 0, total: 6 })).toBe('Starting 6 students…');
+  });
+
+  test('one student is one student', () => {
+    expect(progressLine({ done: 0, total: 1 })).toBe('Starting 1 student…');
+  });
+
+  test('mid-run it is a position in the list, not a percentage', () => {
+    // A count staff can check against the table under it. A percentage is a
+    // number with nothing on screen to reconcile it against.
+    expect(progressLine({ done: 3, total: 6 })).toBe('3 of 6 done…');
+  });
+
+  test('the last student still reads as in-flight — the run has not returned yet', () => {
+    // `onRow` fires before the engine decides whether to halt, so `6 of 6` is a
+    // real state and briefly on screen. The banner is cleared by the run
+    // ending, not by this line.
+    expect(progressLine({ done: 6, total: 6 })).toBe('6 of 6 done…');
   });
 });

--- a/school-booking/test/outcome.test.js
+++ b/school-booking/test/outcome.test.js
@@ -18,6 +18,7 @@ import {
   cancellable,
   bookingRows,
   isFailure,
+  cancellableStudents,
   notRunRecord,
   progressLine,
   resultLine,
@@ -539,13 +540,43 @@ describe('progressLine (#112)', () => {
   test('mid-run it is a position in the list, not a percentage', () => {
     // A count staff can check against the table under it. A percentage is a
     // number with nothing on screen to reconcile it against.
-    expect(progressLine({ done: 3, total: 6 })).toBe('3 of 6 done…');
+    expect(progressLine({ done: 3, total: 6 })).toBe('3 of 6 students done…');
   });
 
   test('the last student still reads as in-flight — the run has not returned yet', () => {
     // `onRow` fires before the engine decides whether to halt, so `6 of 6` is a
     // real state and briefly on screen. The banner is cleared by the run
     // ending, not by this line.
-    expect(progressLine({ done: 6, total: 6 })).toBe('6 of 6 done…');
+    expect(progressLine({ done: 6, total: 6 })).toBe('6 of 6 students done…');
+  });
+});
+
+describe('cancellableStudents (#112)', () => {
+  // The cancel loop SKIPS a record with nothing this run booked, so the
+  // denominator of its progress is not the row count. This has to agree with
+  // run.js's own `cancellable(record).length === 0 → continue`, or the counter
+  // stops short of its own total and reads as a stall.
+  const booked = () => record({}, complete());
+
+  test('a run nothing was booked in has nobody to send', () => {
+    expect(cancellableStudents([])).toBe(0);
+    expect(cancellableStudents()).toBe(0);
+  });
+
+  test('it counts students, not bookings — one call per student is the shape', () => {
+    // Two students, two bookings each: four bookings, two calls.
+    expect(cancellableStudents([booked(), booked()])).toBe(2);
+  });
+
+  test('an already-booked row is not one of them — D12’s interlock', () => {
+    // The booking predates this run and may be one a real member made
+    // themselves. It is never sent, so it is never counted.
+    const already = record({}, complete({ outcome: 'already-booked', bookings: [] }));
+    expect(cancellableStudents([booked(), already])).toBe(1);
+  });
+
+  test('it agrees with anyCancellable on the empty case', () => {
+    const already = record({}, complete({ outcome: 'already-booked', bookings: [] }));
+    expect(cancellableStudents([already])).toBe(0);
   });
 });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -1879,3 +1879,196 @@ describe('the already-run gate (#111)', () => {
     expect(app.preview.blockers.some((b) => b.kind === 'already-run')).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// The in-progress indicator (#112)
+// ---------------------------------------------------------------------------
+// UAT of #74 reported the page looking idle mid-run. It was not: the banner
+// with the count was on screen the whole time. It was just **above** a table
+// growing a row per student, so by student twelve the only thing saying the run
+// was alive had scrolled off the top — and in the moments that matter most, a
+// 20-second retry backoff or a paced pause, its text does not change either.
+//
+// The fix is display only, and these tests hold it to that: the run's own
+// numbers are untouched, and the indicator clears on all three of the endings
+// the engine has, not just the tidy one.
+
+describe('the in-progress indicator (#112)', () => {
+  test('mid-run it says where the run has got to', async () => {
+    let release;
+    const held = new Promise((resolve) => { release = resolve; });
+    const app = await upToPreview(component());
+    const original = globalThis.fetch;
+    const seen = [];
+    globalThis.fetch = vi.fn(async (...args) => {
+      seen.push(app.runProgress);
+      if (seen.length === 3) await held;
+      return original(...args);
+    });
+
+    const running = app.apply();
+    await Promise.resolve();
+    // Held open on the third student: this is the state the operator is
+    // looking at while nothing on the wire is moving.
+    await vi.waitFor(() => expect(seen).toHaveLength(3));
+    expect(app.running).toBe(true);
+    expect(app.runState).toBe('running');
+    expect(app.runProgress).toBe('2 of 6 done…');
+
+    release();
+    await running;
+    globalThis.fetch = original;
+
+    // The line before the first student came back names the size of the run
+    // rather than showing `0 of 6`, which reads as stalled at the one moment
+    // there is nothing to report yet.
+    expect(seen[0]).toBe('Starting 6 students…');
+    expect(seen[1]).toBe('1 of 6 done…');
+  });
+
+  test('a completed run clears it', async () => {
+    const app = await upToApply(component());
+    expect(app.runState).toBe('complete');
+    expect(app.runProgress).toBe('');
+    expect(app.running).toBe(false);
+  });
+
+  test('a halt on the circuit breaker clears it', async () => {
+    const app = await upToPreview(component({
+      student: () => ({ status: 200, body: { ...STUDENT_OK, ok: false, outcome: 'failed', reason: 'clubworx' } }),
+    }));
+    await app.apply();
+    expect(app.runState).toBe('halted');
+    expect(app.runReason).toBe('consecutive-failures');
+    expect(app.runProgress).toBe('');
+    expect(app.running).toBe(false);
+  });
+
+  test('a halt on a throttle clears it', async () => {
+    const app = await upToPreview(component({
+      student: (body, n) => (n <= 2
+        ? { status: 200, body: STUDENT_OK }
+        : { status: 429, body: { outcome: 'failed', reason: 'throttled', written: false } }),
+    }));
+    vi.useFakeTimers();
+    const running = app.apply();
+    await vi.runAllTimersAsync();
+    await running;
+    vi.useRealTimers();
+
+    expect(app.runState).toBe('halted');
+    expect(app.runReason).toBe('throttled');
+    // The quiet 20 seconds of backoff are exactly when the operator most needs
+    // to see the run is alive, and exactly when this line does not change. It
+    // is the spinner beside it that carries that; this only has to stop.
+    expect(app.runProgress).toBe('');
+    expect(app.running).toBe(false);
+  });
+
+  test('it is display only — the run makes the same calls either way', async () => {
+    const app = await upToApply(component());
+    expect(app.__writes).toHaveLength(6);
+    expect(app.runRecords).toHaveLength(6);
+    expect(app.resultLine()).toContain('6 contacts created (permanent)');
+  });
+});
+
+// The indicator itself is markup, and this repo has no DOM test infrastructure
+// and is not gaining any (#78). What the indicator has to be, though, is
+// visible and moving — two properties of the page's text, which is what these
+// read. The same reasoning as `alpine-bindings.test.js`: where the cheap check
+// is also the complete one for the class of fault, it is the right check.
+describe('the indicator is on the page, and moves (#112)', () => {
+  const banner = (() => {
+    const at = html.indexOf(`x-show="runState === 'running'"`);
+    expect(at, 'step 6’s running banner is not in the page').toBeGreaterThan(-1);
+    const open = html.lastIndexOf('<div', at);
+    return html.slice(open, html.indexOf('</div>', at));
+  })();
+
+  test('the banner carries a spinner, not only a line of text', () => {
+    // The text changes once per student. Between two students — and through a
+    // 20-second retry backoff — it is the only thing on screen that has to say
+    // "alive", and it says it by not changing.
+    expect(banner).toContain('spinner');
+  });
+
+  test('the spinner is decoration, and the banner announces itself instead', () => {
+    // A spinning ring has nothing to read out. The count beside it does, and
+    // `role="status"` is what gets it read without stealing focus mid-run.
+    expect(banner).toMatch(/<span[^>]*class="[^"]*spinner[^"]*"[^>]*aria-hidden="true"/);
+    // Scoped to the count. On the whole banner, every update re-reads the
+    // static sentence beside it — sixty-three times, for a class of 63.
+    expect(banner).toMatch(/role="status"[^>]*x-text="runProgress"/);
+  });
+
+  test('it stays on screen as the table grows underneath it', () => {
+    // The reported fault. The banner was there the whole time; by student
+    // twelve it was above the fold of a table adding a row per student.
+    expect(banner).toContain('sticky');
+  });
+
+  test('the spinner class is actually animated, and not at full speed for everyone', () => {
+    const style = html.slice(html.indexOf('<style>'), html.indexOf('</style>'));
+    expect(style).toMatch(/@keyframes\s+uj-spin/);
+    expect(style).toMatch(/\.spinner\s*\{[^}]*animation:[^}]*uj-spin/);
+    // Motion is the point, so it is slowed rather than stopped — a still ring
+    // reads as a dead spinner, which is the fault this is fixing, inverted.
+    expect(style).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^}]*\.spinner/);
+  });
+});
+
+describe('a run the tab outlived does not restore as one still going (#112)', () => {
+  // The store is written per student (D10), so a tab closed on student 19
+  // leaves `state: 'running'` behind. Before #112 that restored as a stale
+  // sentence. With a spinner on it, it restores as a page actively claiming a
+  // run is in flight, with "Leave this tab open" under a ring that will turn
+  // for as long as the tab is open — the exact fault #112 removes, inverted,
+  // and on the one path D10 exists for.
+  const interrupted = {
+    at: '2026-08-22T09:00:00+08:00',
+    school: 'newman',
+    sessions: [],
+    state: 'running',
+    records: [
+      { key: 1, name: 'Ada Lovelace', state: 'booked', bookings: [], cancel: null },
+      { key: 2, name: 'Grace Hopper', state: 'booked', bookings: [], cancel: null },
+    ],
+  };
+
+  test('it opens as a halt, so nothing on screen says a run is working', async () => {
+    const app = await settled(component({ restored: interrupted }));
+    app.openRestored();
+    expect(app.runState).not.toBe('running');
+    expect(app.runState).toBe('halted');
+    expect(app.running).toBe(false);
+    expect(app.runProgress).toBe('');
+  });
+
+  test('it says the tab is why, rather than showing an empty red box', async () => {
+    const app = await settled(component({ restored: interrupted }));
+    app.openRestored();
+    expect(app.runReason).toBe('interrupted');
+    expect(app.runMessage).toMatch(/closed|reload/i);
+  });
+
+  test('the students that did land are on screen — that is what the record is for', async () => {
+    // `x-show="runRecords.length > 0 && runState !== 'running'"` hides the
+    // table while a run is going. Restoring as `running` hid the very rows the
+    // store was written to preserve.
+    const app = await settled(component({ restored: interrupted }));
+    app.openRestored();
+    expect(app.runRecords).toHaveLength(2);
+    expect(app.runRecords.length > 0 && app.runState !== 'running').toBe(true);
+  });
+
+  test('a run that did finish is untouched', async () => {
+    const app = await settled(component({
+      restored: { ...interrupted, state: 'complete' },
+    }));
+    app.openRestored();
+    expect(app.runState).toBe('complete');
+    expect(app.runReason).toBe(null);
+    expect(app.runMessage).toBe('');
+  });
+});

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -2072,3 +2072,44 @@ describe('a run the tab outlived does not restore as one still going (#112)', ()
     expect(app.runMessage).toBe('');
   });
 });
+
+// The Clubworx check between steps 4 and 5 is the same shape as the run and
+// had the same gap: serial, one student at a time, minutes for a class of 25,
+// publishing a preview row per student — so its banner scrolls away under a
+// growing table exactly as step 6's did, and its count moves once per student.
+// Same treatment, and the same reasoning.
+describe('the check between 4 and 5 shows it is working too', () => {
+  const banner = (() => {
+    const at = html.indexOf(`x-show="checkState === 'running'"`);
+    expect(at, 'the check banner is not in the page').toBeGreaterThan(-1);
+    const open = html.lastIndexOf('<div', at);
+    return html.slice(open, html.indexOf('</div>', at));
+  })();
+
+  test('it carries a spinner and stays on screen', () => {
+    expect(banner).toContain('spinner');
+    expect(banner).toContain('sticky');
+  });
+
+  test('the live region is the count, and the spinner is decoration', () => {
+    expect(banner).toMatch(/<span[^>]*class="[^"]*spinner[^"]*"[^>]*aria-hidden="true"/);
+    expect(banner).toMatch(/role="status"[^>]*x-text="checkProgress"/);
+  });
+
+  test('a check that ends clears it — including the plan refusal that ends it early', async () => {
+    // `toPreview` has two exits. The early one is §11's hard stop: an
+    // unresolved plan stops the check before it spends the allowance on reads
+    // for a run that cannot proceed. A spinner left turning on that path is a
+    // page that never comes back.
+    const app = await upToPreview(component({ plan: { ok: false, reason: 'not-found', error: 'no such plan' } }));
+    expect(app.plan.ok).toBe(false);
+    expect(app.checkState).toBe('done');
+    expect(app.checkProgress).toBe('');
+  });
+
+  test('a check that runs to the end clears it', async () => {
+    const app = await upToPreview(component());
+    expect(app.checkState).toBe('done');
+    expect(app.checkProgress).toBe('');
+  });
+});

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -1913,7 +1913,7 @@ describe('the in-progress indicator (#112)', () => {
     await vi.waitFor(() => expect(seen).toHaveLength(3));
     expect(app.running).toBe(true);
     expect(app.runState).toBe('running');
-    expect(app.runProgress).toBe('2 of 6 done…');
+    expect(app.runProgress).toBe('2 of 6 students done…');
 
     release();
     await running;
@@ -1923,7 +1923,7 @@ describe('the in-progress indicator (#112)', () => {
     // rather than showing `0 of 6`, which reads as stalled at the one moment
     // there is nothing to report yet.
     expect(seen[0]).toBe('Starting 6 students…');
-    expect(seen[1]).toBe('1 of 6 done…');
+    expect(seen[1]).toBe('1 of 6 students done…');
   });
 
   test('a completed run clears it', async () => {
@@ -2111,5 +2111,96 @@ describe('the check between 4 and 5 shows it is working too', () => {
     const app = await upToPreview(component());
     expect(app.checkState).toBe('done');
     expect(app.checkProgress).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The cancel says how far it has got too (#112)
+// ---------------------------------------------------------------------------
+// D12's cancel is the same paced, one-call-per-student loop as Apply, and it
+// had less to show for it than either of the others: no count at all, just
+// "Cancelling, one student at a time…". A whole-run cancel is up to 150 DELETEs
+// plus a verifying re-read per student, so it is minutes of a page saying
+// nothing while it deletes things.
+//
+// Its denominator is the awkward part. The loop SKIPS a record with nothing
+// this run booked, so it is neither the row count nor the booking count the
+// control above it quotes.
+
+describe('the cancel reports its progress (#112)', () => {
+  test('it counts the students it will actually call for, not the rows', async () => {
+    const app = await upToApply(component());
+    // Six students, two bookings each: the control offers 12 bookings, the
+    // loop makes 6 calls. The progress is in the loop's unit and says so.
+    expect(app.cancellableCount()).toBe(12);
+
+    const seen = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (...args) => {
+      seen.push(app.cancelProgress);
+      return original(...args);
+    });
+    app.askCancel();
+    await app.cancelRun();
+    globalThis.fetch = original;
+
+    expect(seen[0]).toBe('Starting 6 students…');
+    expect(seen[1]).toBe('1 of 6 students done…');
+    expect(seen).toHaveLength(6);
+  });
+
+  test('a row this run did not book is not in the denominator', async () => {
+    // D12's interlock: an `already booked` row is never sent, so counting it
+    // would leave the progress permanently short of its own total.
+    const app = await upToApply(component({
+      student: (body, n) => (n <= 2
+        ? { status: 200, body: { ...STUDENT_OK, outcome: 'already-booked', bookings: [] } }
+        : { status: 200, body: STUDENT_OK }),
+    }));
+    const seen = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (...args) => { seen.push(app.cancelProgress); return original(...args); });
+    app.askCancel();
+    await app.cancelRun();
+    globalThis.fetch = original;
+
+    expect(seen[0]).toBe('Starting 4 students…');
+    expect(seen).toHaveLength(4);
+  });
+
+  test('a completed cancel clears it', async () => {
+    const app = await upToApply(component());
+    app.askCancel();
+    await app.cancelRun();
+    expect(app.cancelState).toBe('done');
+    expect(app.cancelProgress).toBe('');
+    expect(app.running).toBe(false);
+  });
+
+  test('a throttled cancel clears it too', async () => {
+    const app = await upToApply(component({
+      unbook: (body, n) => (n <= 1
+        ? { status: 200, body: UNBOOK_OK }
+        : { status: 429, body: { ok: false, outcome: 'failed', reason: 'throttled', cancelled: 0, cancelledIds: [] } }),
+    }));
+    vi.useFakeTimers();
+    app.askCancel();
+    const cancelling = app.cancelRun();
+    await vi.runAllTimersAsync();
+    await cancelling;
+    vi.useRealTimers();
+
+    expect(app.cancelState).toBe('halted');
+    expect(app.cancelProgress).toBe('');
+    expect(app.running).toBe(false);
+  });
+
+  test('the line is on the page, with a spinner beside it', () => {
+    const at = html.indexOf(`x-show="cancelState === 'running'"`);
+    expect(at, 'the cancel’s running line is not in the page').toBeGreaterThan(-1);
+    const open = html.lastIndexOf('<div', at);
+    const line = html.slice(open, html.indexOf('</div>', at));
+    expect(line).toContain('spinner');
+    expect(line).toMatch(/role="status"[^>]*x-text="cancelProgress"/);
   });
 });


### PR DESCRIPTION
Closes #112.

## What the report was actually about

UAT of #74 said the page looked idle mid-run. A banner with a live count was on screen the whole time, which is the part worth explaining — and the reason a counter alone was never the fix:

- It sits **above** a table that adds a row per student, so it leaves the viewport as the run goes on. *This half is inference*: the report doesn't say the banner scrolled away, only that nothing indicated a run. It's the reading that fits a banner being present and unseen.
- Its text moves **once per student**, so through D8's 20-second retry backoff it says nothing at all — the pause where the run is deliberately waiting and is least distinguishable from a dead page.

So the banner is **sticky**, and carries a **spinner** beside the count. The spinner is the part that keeps moving when nothing else does. Under `prefers-reduced-motion` it's slowed rather than stopped: a ring that doesn't turn reads as the failure this removes.

## Display only

The run makes the same calls, paces the same way, stops in the same places — asserted, not assumed. `run.js` changes only its import query string.

## Clearing it is four paths, not three

The issue names three endings and all three work: completion, the breaker halt, the throttle halt — each leaves `runState`, and the banner is bound to it.

The fourth is the one D10 exists for, and it was found in review. The store is written per student, so a tab closed on student 19 leaves `state: 'running'` in `localStorage`, and `openRestored()` restored that verbatim. A restored `running` is the one value that cannot be true — nothing is calling anything. Harmless before as a stale sentence; with a spinner on it, it's a dead page actively claiming to be alive, while `runState !== 'running'` hides the very result table the store was written to preserve. It's now clamped to a halt with reason `interrupted`, and D5's re-run finishes it like any other.

## Also

- `progressLine()` moves to `outcome.js` — the two inline template literals each carried their own plural rule.
- `?v=` bumped 3 → 4 across the whole chain (page + the sibling imports inside `identity.js`, `run.js`, `steps.js`), per the house rule for a module gaining an export.
- Spec §12 **D15**; `CLAUDE.md` module notes.

## Tests

18 new. Full repo suite green: 477 school-booking, 83 worker, 665 clubworx, 217 vouchers, 9 payments-proxy.

**Merging this deploys** — `main` is production here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn