### PR TITLE
School booking: the result step confirms, and the reset starts the next school (#113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,23 @@ school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #10
                           `running` to a halt: the store is written per student,
                           so a tab closed mid-run leaves `running` behind, and a
                           spinner on that is a dead page claiming to be alive.
+                          The result step LEADS with the confirmation (#113):
+                          one panel, tone and heading following the outcome,
+                          D11's summary unmoved inside it. Both the words and
+                          the colour come from outcome.js's successLine(), so
+                          there is no literal a template could show over a run
+                          that did not work. D12's cancel was DEMOTED and
+                          nothing else — same label, same count, same interlock,
+                          same confirm, still visible. startAnotherImport() is
+                          ONE control rendered twice, here and on step 1, and it
+                          keeps three things: the stored run (re-read, so it
+                          comes back as the offer at the top), `lastRun` (#111
+                          still blocks an identical re-paste — this starts a
+                          different import, it does not re-open a finished one)
+                          and `schools`. A component test asserts a reset page
+                          equals a fresh one field by field — the reset restates
+                          the component literal's initial values and nothing in
+                          the language links the two copies.
 school-booking/events.js - what a SELECTION of sessions is: the same-name,
                           same-location pre-tick (no recurrence field exists,
                           so any automatic rule is a guess), the lead-time and
@@ -225,6 +242,13 @@ school-booking/outcome.js - what one `POST /student` answer means, and what a
                           carries liveness: this line changes once per student
                           and says nothing at all through D8's 20-second
                           backoff, which is the quiet the report was about.
+                          successLine() is #113's confirmation and is STRICTER
+                          than settledRun(): every row must read `booked` or
+                          `already booked`, so a refusal or a `needs you` keeps
+                          it away even though settledRun() calls that run
+                          settled. The two answer different questions — "is
+                          there anything worth doing again?" and "did this
+                          work?" — and a cancel since takes the second back.
 school-booking/parse.js - turns a pasted school student list into rows plus the
                           list-level inferences (layout, column mapping, date
                           orientation). Pure and unit tested; §7 of the design

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -1117,6 +1117,71 @@ predicate the engine skips on — two copies of that rule is how the counter
 starts lying. That is also why the line says the word "students": the control
 beside it counts bookings, and the two numbers differ.
 
+**D16 — The result step leads with the confirmation, and the reset is one
+control reached from two ends.** Added on
+[#113](https://github.com/urbanjungleirc/staff-site/issues/113), from the same
+UAT as #111 and #112. The report: the most prominent thing on a finished run was
+*"Cancel bookings from this run"*, with no comparably prominent confirmation
+that the import had worked and no way to move on to the next school. Taking the
+bookings back is the exceptional act and read as the thing to do next.
+
+**The cancel is demoted and nothing else.** Its label, the count behind the
+label, D12's interlock, the confirm in front of it and the permanence sentence
+beside it are all untouched, and it stays visible rather than moving behind a
+disclosure. What changed is its weight, now that there is a primary control
+above it.
+
+**"Successful" is neither "the run ended" nor `settledRun`, and the banner is
+built on the stricter of the two.** `successLine()` in `outcome.js` is empty
+unless every row in the table reads `booked` or `already booked` — so a halt on
+D7's breaker or a throttle, a stranded student, a refusal, and a `needs you` row
+each keep it away. `settledRun` deliberately calls a run with a refused student
+*settled*, because re-running reproduces that refusal exactly and the already-run
+gate should close on it; but that student got nothing, and a banner saying the
+import worked over that row is a lie. `cancelled > 0` takes the banner back
+down: the bookings it would be confirming are gone. It is a string rather than a
+boolean plus a message, in the same shape as `strandedWarning`, so the markup
+shows the banner *on the text* and no template condition can disagree with the
+rule.
+
+D11 is untouched by this. The summary sentence stays where it was, in the same
+panel; the confirmation leads it and the panel's tone follows the outcome.
+
+**The reset is one control, `startAnotherImport()`, rendered on the result step
+and on step 1.** Step 1 needs it because an operator who has walked back there
+is looking at the last school's tag, list and sessions, and choosing a new
+school clears none of them. It clears the school, the paste, the count
+declaration, the resolutions, the session selection, the check, the preview and
+the result table, and returns to step 1 with the step strip wound back — a step
+that can still be clicked forward into is a step holding the last school's
+answers.
+
+Three things it deliberately does **not** clear:
+
+- **The stored run (D10).** Contacts and School Passes cannot be deleted, so
+  that record is the only evidence they were made. It is re-read on reset, so
+  the run just left comes back as the offer at the top of the page. Discarding
+  it stays a separate, named act.
+
+  **But D10 is one key, and the next run overwrites it.** Back-to-back imports
+  are now the designed flow, which makes that overwrite a routine event rather
+  than an edge case, and the reset's confirm says so: the run is offered back
+  *until the next import replaces it*, and copy-or-download is how to keep it.
+  Reassuring an operator that a record is safe while leading them into the act
+  that destroys it is worse than not mentioning it. A per-import history is the
+  real answer and is not this issue's; see §15.
+- **`lastRun`.** #111's gate is the escape valve's counterpart, not its victim:
+  this is how to start a *different* import, not a way to re-enable Apply on a
+  finished one. An identical list re-pasted after a reset meets the same block —
+  and #111's blocker text now names this control instead of saying "reload the
+  page", which was only ever honest because the control did not exist yet.
+- **`schools`.** A read of Clubworx, not an answer of the operator's.
+
+It refuses while the run or the cancel is in flight — both write into
+`runRecords` from a loop the reset cannot stop — and it asks first. What it
+clears is typing rather than data, but on step 3 that typing is a pasted class
+list with a log of hand resolutions on top of it.
+
 ### Doing it twice
 
 **D5 — Recovery is a restart-safe re-run. No stored run state, no resume.**
@@ -1259,6 +1324,13 @@ Carried forward deliberately. None blocks the build.
   refusal's message string is unrecorded, so §11's vocabulary will classify it
   `unknown` — safe, but uninformative — until a run captures it.
 
+- **Whether D10's record should survive more than one import.** It is one
+  `localStorage` key, so the next run overwrites the last run's record — and
+  D16's reset makes back-to-back imports the designed flow, which turns that
+  from an edge case into the normal path. Copy-and-download is the answer today
+  and the confirm says so plainly; a keyed-per-run history is the real one, and
+  is not #113's. Nothing depends on it: the record is a convenience over
+  Clubworx, which holds the writes themselves.
 - **Whether `POST /api/v2/members` works, and whether it can carry
   `membership_plan_id`.** The one write in the chain that has never been run —
   see the callout in §2. Resolved by the first implementation ticket, before

--- a/school-booking.html
+++ b/school-booking.html
@@ -68,14 +68,14 @@
      or missing module into a visible refusal rather than a page whose gates
      quietly do nothing. -->
 <script type="module">
-  import * as parser from './school-booking/parse.js?v=4';
-  import * as steps from './school-booking/steps.js?v=4';
-  import * as identity from './school-booking/identity.js?v=4';
-  import * as events from './school-booking/events.js?v=4';
-  import * as preview from './school-booking/preview.js?v=4';
-  import * as calendar from './school-booking/calendar.js?v=4';
-  import * as outcome from './school-booking/outcome.js?v=4';
-  import * as run from './school-booking/run.js?v=4';
+  import * as parser from './school-booking/parse.js?v=5';
+  import * as steps from './school-booking/steps.js?v=5';
+  import * as identity from './school-booking/identity.js?v=5';
+  import * as events from './school-booking/events.js?v=5';
+  import * as preview from './school-booking/preview.js?v=5';
+  import * as calendar from './school-booking/calendar.js?v=5';
+  import * as outcome from './school-booking/outcome.js?v=5';
+  import * as run from './school-booking/run.js?v=5';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
   window.schoolBookingIdentity = identity;
@@ -496,6 +496,39 @@
           school a contact belongs to that this system will ever have — so a second
           spelling of one school splits its history in two, permanently.
         </p>
+
+        <!-- #113. The same control as the result step's, reached from the other
+             end: an operator who has walked back here is looking at the last
+             school's tag, list and sessions, and picking a new school does not
+             clear any of them. Hidden on a page that has nothing to clear, so
+             a fresh start is not offered a way to start fresher. -->
+        <div class="rounded-xl border border-neutral-200 bg-neutral-50 px-3.5 py-3 text-sm mb-5"
+             x-show="holdingAnImport()" x-cloak>
+          <div x-show="!resetConfirming" x-cloak class="flex items-center justify-between gap-3 flex-wrap">
+            <span class="text-xs text-neutral-500">
+              This page is still holding an import. Starting another clears it.
+            </span>
+            <button type="button" class="chip" :disabled="busy()"
+                    @click="askReset()">Start another import</button>
+          </div>
+          <div x-show="resetConfirming" x-cloak>
+            <div class="text-[0.82rem] font-semibold">Clear this and start another school?</div>
+            <!-- The same sentence as the result step's copy of this confirm.
+                 Two renderings of one control, and the one thing they must
+                 never differ on is what it does. -->
+            <div class="text-xs text-neutral-500 mt-1">
+              The school, the list, the sessions and the result table are cleared. Nothing in
+              Clubworx changes, and a finished run is offered back at the top of the page —
+              until the next import replaces it. Copy or download the record first if you
+              need to keep it.
+            </div>
+            <div class="flex gap-2 mt-2">
+              <button type="button" class="rounded-xl px-4 py-2 text-sm font-semibold bg-uj hover:bg-uj-dark text-white"
+                      @click="startAnotherImport()">Yes, start another</button>
+              <button type="button" class="chip" @click="standDownReset()">Not now</button>
+            </div>
+          </div>
+        </div>
 
         <div class="max-w-lg">
           <span class="field-label">School</span>
@@ -1349,10 +1382,48 @@
           </div>
         </div>
 
-        <div class="rounded-xl px-3.5 py-3 text-sm mb-3 bg-amber-50 border border-amber-300 text-amber-900"
+        <!-- #113. The step leads with what happened, and on a clean run that
+             is a confirmation rather than a warning. D11's sentence does not
+             move: it is the same summary in the same place, with the tone and
+             the heading following the outcome. `successLine()` is empty unless
+             the whole table reads booked — a banner over a halted or stranded
+             run would be the one thing worse than the silence it replaces. -->
+        <div class="rounded-xl px-3.5 py-3 text-sm mb-3 border"
+             :class="successLine()
+               ? 'bg-emerald-50 border-emerald-300 text-emerald-900'
+               : 'bg-amber-50 border-amber-300 text-amber-900'"
              x-show="resultLine()" x-cloak>
-          <div class="font-semibold" x-text="resultLine()"></div>
+          <div class="font-semibold flex items-start gap-2" x-show="successLine()" x-cloak>
+            <span aria-hidden="true">✓</span><span x-text="successLine()"></span>
+          </div>
+          <div :class="successLine() ? 'mt-1 text-[0.82rem] opacity-90' : 'font-semibold'"
+               x-text="resultLine()"></div>
           <div class="mt-1.5" x-show="strandedWarning()" x-cloak x-text="strandedWarning()"></div>
+
+          <!-- The way on to the next school, and the only prominent control on
+               a finished run. Taking the bookings back is the exceptional act
+               and sits below the table, where it stays available and unchanged. -->
+          <div class="mt-3" x-show="!resetConfirming" x-cloak>
+            <button type="button" :disabled="busy()"
+                    class="rounded-xl px-4 py-2 text-sm font-semibold bg-uj hover:bg-uj-dark text-white disabled:opacity-40"
+                    @click="askReset()">Start another import</button>
+          </div>
+          <div class="mt-3" x-show="resetConfirming" x-cloak>
+            <div class="text-[0.82rem] font-semibold">Clear this and start another school?</div>
+            <!-- Word for word step 1's copy of this confirm — see the note
+                 there. Two renderings of one control. -->
+            <div class="text-xs mt-1 opacity-90">
+              The school, the list, the sessions and the result table are cleared. Nothing in
+              Clubworx changes, and a finished run is offered back at the top of the page —
+              until the next import replaces it. Copy or download the record first if you
+              need to keep it.
+            </div>
+            <div class="flex gap-2 mt-2">
+              <button type="button" class="rounded-xl px-4 py-2 text-sm font-semibold bg-uj hover:bg-uj-dark text-white"
+                      @click="startAnotherImport()">Yes, start another</button>
+              <button type="button" class="chip" @click="standDownReset()">Not now</button>
+            </div>
+          </div>
         </div>
 
         <div class="rounded-card border border-neutral-200 overflow-hidden bg-white"
@@ -1478,8 +1549,14 @@
           </div>
 
           <div class="flex gap-2 mt-3 items-center flex-wrap" x-show="!cancelConfirming" x-cloak>
+            <!-- #113 demoted this, and demoted it ONLY. The label, the count,
+                 the interlock behind the count and the confirm below are all
+                 unchanged: taking bookings back is the one reversible thing
+                 this tool does, and it has to stay as honest as it was. What
+                 changed is its weight — it was the most prominent control on a
+                 finished run, which read as the thing to do next. -->
             <button type="button" :disabled="cancellableCount() === 0 || running"
-                    class="rounded-xl px-4 py-2 text-sm font-semibold border border-rose-300 text-rose-700 disabled:opacity-40"
+                    class="rounded-lg px-3 py-1.5 text-[0.82rem] font-medium border border-rose-200 text-rose-700 disabled:opacity-40"
                     @click="askCancel()"
                     x-text="`Cancel ${cancellableCount()} booking${cancellableCount() === 1 ? '' : 's'} from this run`"></button>
             <button type="button" class="chip" @click="copyRecord()"
@@ -1663,6 +1740,12 @@ function schoolBooking() {
     // has to know which run they are looking at.
     restored: null,
     copied: false,
+
+    // #113. The confirm in front of "Start another import". It clears typing
+    // rather than data — but on step 3 that typing is a pasted class list with
+    // a log of hand resolutions on top of it, and a mis-click is the whole of
+    // it gone.
+    resetConfirming: false,
 
     init() {
       // Both modules or neither. Every gate on this page is one of their
@@ -2757,6 +2840,18 @@ function schoolBooking() {
       return window.schoolBookingOutcome.resultLine(this.runRecords);
     },
 
+    /**
+     * #113 — the confirmation, or nothing.
+     *
+     * Empty unless the run is clean, and the markup shows the banner on the
+     * text, so there is no second condition in a template that could disagree
+     * with the rule. Which runs count as clean is outcome.js's business, and
+     * deliberately stricter than the already-run gate's `settledRun`.
+     */
+    successLine() {
+      return window.schoolBookingOutcome.successLine(this.runState, this.runRecords);
+    },
+
     strandedWarning() {
       return window.schoolBookingOutcome.strandedWarning(this.runRecords);
     },
@@ -2783,6 +2878,7 @@ function schoolBooking() {
 
     askCancel() {
       if (this.cancellableCount() === 0 || this.running) return;
+      this.resetConfirming = false; // see askReset — one question at a time
       this.cancelConfirming = true;
     },
 
@@ -2930,6 +3026,138 @@ function schoolBooking() {
     discardRestored() {
       this.store().clear();
       this.restored = null;
+    },
+
+    // --- starting the next school -----------------------------------------
+    // #113. One control, reached from two places: the result step, where the
+    // operator has just finished a school, and step 1, where they may be
+    // looking at the last one's answers. Both call this.
+
+    /**
+     * Is this page holding an operator's answers? — the words the panel uses.
+     *
+     * Deliberately blind to the stored run (D10), which is the one thing the
+     * reset does not clear: a browser holding yesterday's record is not a page
+     * with an import on it.
+     */
+    holdingAnImport() {
+      return Boolean(
+        this.tag || this.schoolQuery || this.rawPaste || this.parsed
+        || this.picked.length > 0 || this.runRecords.length > 0,
+      );
+    },
+
+    /**
+     * Anything in flight that writes into `runRecords` from a loop the page
+     * cannot stop. One rule: the two callers and the two `:disabled` bindings
+     * that read it must not drift apart.
+     */
+    busy() {
+      return this.running || this.cancelState === 'running';
+    },
+
+    askReset() {
+      if (this.busy()) return;
+      // One question at a time. Both confirms live on the result step, and two
+      // open at once is a screen asking whether to cancel the bookings and
+      // whether to throw the table away, with two "Yes" buttons in it.
+      this.cancelConfirming = false;
+      this.resetConfirming = true;
+    },
+
+    standDownReset() {
+      this.resetConfirming = false;
+    },
+
+    /**
+     * Clear the school, the list, the resolutions, the sessions and the table.
+     *
+     * Three things it deliberately does **not** touch:
+     *
+     *   - **The stored run (D10).** Contacts and School Passes cannot be
+     *     deleted, so that record is the only evidence they were made. It is
+     *     re-read here instead, so the run the operator has just left comes
+     *     back as the offer at the top of the page rather than vanishing with
+     *     the screen. Discarding it stays a separate, named act.
+     *   - **`lastRun`.** #111's gate is what stops a second Apply on an
+     *     unchanged list, and this is the way to start a *different* import,
+     *     not a way to re-enable Apply on a finished one. Re-pasting the same
+     *     list after a reset still meets the gate.
+     *   - **`schools`.** A read of Clubworx, not an answer of the operator's.
+     *
+     * It refuses while anything is in flight: the run engine and the cancel
+     * loop both write into `runRecords` from a loop this cannot stop, and a
+     * table cleared out from under them comes back half-populated.
+     */
+    startAnotherImport() {
+      if (this.busy()) return;
+
+      this.schoolOpen = false;
+      this.schoolQuery = '';
+      this.tag = '';
+
+      this.rawPaste = '';
+      this.countValue = '';
+      this.countUnknown = false;
+      this.declaredFor = null;
+
+      this.parsed = null;
+      this.reviewed = null;
+      this.resolutions = {};
+      this.parseOptions = {};
+      this.drafts = {};
+      this.expandedRow = null;
+      this.showIgnored = false;
+      this.showOverrides = false;
+      this.chipMenu = null;
+
+      this.events = [];
+      this.eventsState = 'idle';
+      this.eventsError = '';
+      this.eventsTotal = 0;
+      this.eventsTruncated = false;
+      this.eventsFrom = '';
+      this.eventsTo = '';
+      this.eventsQuery = '';
+      this.loadedFrom = '';
+      this.loadedTo = '';
+      this.datePicker = null;
+      this.pastedEventId = '';
+      this.pastedIdNote = '';
+      this.pastedIdOk = false;
+      this.pastedIdEvent = null;
+      this.picked = [];
+      this.selection = { events: [], blockers: [], ready: false, sessions: 0, students: 0, bookings: 0, firstSession: null, lastSession: null };
+
+      this.plan = null;
+      this.matches = {};
+      this.checkState = 'idle';
+      this.checkProgress = '';
+
+      this.preview = null;
+      this.decisions = {};
+      this.expandedPreview = null;
+      this.confirming = false;
+
+      this.runRecords = [];
+      this.runState = 'idle';
+      this.runReason = null;
+      this.runMessage = '';
+      this.runProgress = '';
+      this.runRemaining = 0;
+      this.runAt = null;
+      this.runSessionStarts = [];
+      this.expandedResult = null;
+      this.cancelState = 'idle';
+      this.cancelMessage = '';
+      this.cancelProgress = '';
+      this.cancelConfirming = false;
+      this.copied = false;
+
+      this.resetConfirming = false;
+      this.restored = this.store().load();
+      this.maxStepReached = 0;
+      this.go(0);
     },
 
     restoredLine() {

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -24,7 +24,7 @@
 // already has a contact comes back as `new`, and a second permanent contact is
 // written for them. Nothing throws: both spellings are individually valid, and
 // contacts cannot be deleted.
-import { compareForm } from './parse.js?v=4';
+import { compareForm } from './parse.js?v=5';
 
 // ---------------------------------------------------------------------------
 // Match states (P2b)

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -568,3 +568,51 @@ export function progressLine({ done = 0, total = 0 } = {}) {
   if (done <= 0) return `Starting ${plural(total, 'student')}…`;
   return `${done} of ${plural(total, 'student')} done…`;
 }
+
+/**
+ * The confirmation, and the conditions it refuses to appear under — #113.
+ *
+ * UAT of #74 found the result step leading with *"Cancel bookings from this
+ * run"* and never saying, with equivalent weight, that the import had worked.
+ * The banner that answers that has exactly one way of being worse than the
+ * silence it replaces: appearing over a run that did not work. So it is a
+ * string that is empty unless the run is clean, in the same shape as
+ * `strandedWarning` — the page shows the banner on the text, and there is one
+ * place deciding whether there is any.
+ *
+ * **"Successful" is neither "the run ended" nor `settledRun`.** They answer
+ * different questions and this needs the stricter one:
+ *
+ *   - `settledRun` asks *"is there anything worth doing again?"*, which is why
+ *     it calls a run with a **refused** student settled — re-running reproduces
+ *     that refusal exactly, so the already-run gate should close on it. But a
+ *     refused student got nothing, and a banner saying the import worked over
+ *     that row is the lie this comment exists to prevent.
+ *   - A **`needs you`** row is the same: considered, not a fault, and still a
+ *     student nobody has booked.
+ *
+ * So the test is every row, not a count: a run is confirmed only when the whole
+ * table reads `booked` or `already booked`. A student already in the session
+ * counts — they are booked, which is what the operator came to achieve, and
+ * whether this run put them there is D11's business, not this line's.
+ *
+ * `cancelled > 0` takes it back down. The bookings it would be confirming are
+ * gone, and a confirmation left standing after a cancel is the sentence an
+ * operator would read to check whether the cancel worked.
+ */
+export function successLine(state, records) {
+  const rows = records ?? [];
+  if (state !== 'complete' || rows.length === 0) return '';
+  if (!rows.every((r) => r.state === 'booked' || r.state === 'already booked')) return '';
+  const t = resultTotals(rows);
+  if (t.cancelled > 0) return '';
+  // `display()` reads a `complete` row that booked nothing as `already
+  // booked`, which includes a row holding no bookings of any kind. Nothing
+  // reaches this page in that state today — a selection with no sessions
+  // cannot get past step 4 — but the sentence below would be the page's only
+  // word on such a row, and it would say the student is booked.
+  if (t.bookings + t.alreadyBooked === 0) return '';
+  return `This import is done — ${
+    t.students === 1 ? 'the student is' : `all ${t.students} students are`
+  } booked.`;
+}

--- a/school-booking/preview.js
+++ b/school-booking/preview.js
@@ -380,13 +380,16 @@ export function buildPreview({ rows, matches, selection, review, plan, decisions
       kind: 'already-run',
       severity: 'block',
       title: 'This import has already been run',
-      // Names only what exists today. #113 adds a "start another import"
-      // control, and this line should point at that instead once it lands —
-      // until then, reloading is the honest instruction, and the run is safe
-      // to reload away from because storage offers it back (D10).
+      // Names the control that exists — #113's reset, which is the escape
+      // valve this gate was always meant to have. Before it landed this line
+      // said "reload the page", because pointing at a control that is not
+      // there is worse than pointing at a clumsy one. The reset deliberately
+      // does NOT re-open this gate: it starts a different import, and an
+      // identical list re-pasted after one meets this same block.
       detail: 'Nothing here has changed since it ran, so applying again would repeat work that is '
         + 'already done. Add or resolve a student, or change the sessions, and this clears itself. '
-        + 'To import a different school, reload the page — this run is saved in this browser.',
+        + 'To import a different school, use "Start another import" — it is on the result step and '
+        + 'on step 1. This run stays saved in this browser.',
       actions: [],
     });
   }

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -39,7 +39,7 @@
 // written something the Worker answers 200 and carries `reason: "throttled"`,
 // because the body is then the only record of what was written.
 
-import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=4';
+import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=5';
 
 /** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
 export const RETRY_BACKOFF_MS = 20_000;

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -43,7 +43,7 @@
 //
 // Bump this in lockstep with school-booking.html. alpine-bindings.test.js
 // fails if the two ever disagree.
-import { compareForm, readDate, writeForm } from './parse.js?v=4';
+import { compareForm, readDate, writeForm } from './parse.js?v=5';
 
 const DOMAIN = 'urbanjungleirc.com';
 

--- a/school-booking/test/outcome.test.js
+++ b/school-booking/test/outcome.test.js
@@ -26,6 +26,7 @@ import {
   runRecordText,
   settledRun,
   strandedWarning,
+  successLine,
   studentRecord,
 } from '../outcome.js';
 
@@ -578,5 +579,83 @@ describe('cancellableStudents (#112)', () => {
   test('it agrees with anyCancellable on the empty case', () => {
     const already = record({}, complete({ outcome: 'already-booked', bookings: [] }));
     expect(cancellableStudents([already])).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The success confirmation (#113)
+// ---------------------------------------------------------------------------
+// UAT of #74 reported the result step leading with "Cancel bookings from this
+// run" and never saying, with equivalent weight, that the import worked. The
+// banner that fixes that has one way to be worse than the silence it replaces:
+// appearing over a run that did not work. "Successful" is not "the run ended"
+// and it is not "no failures" either — a complete run can hold a refused
+// student, a student whose pass needs a human, or bookings since cancelled.
+describe('successLine — the confirmation, and what it refuses to confirm', () => {
+  const booked = () => record({}, complete());
+  const alreadyThere = () => record(
+    { key: 2, contactKey: 'c9' },
+    complete({
+      contact: { contact_key: 'c9', state: 'matched' },
+      pass: { state: 'covering', expiration_date: null, detail: null },
+      bookings: [booking({ state: 'already booked', booking_id: null, bookingId: null })],
+    }),
+  );
+
+  test('a run where every student ended booked is confirmed, and says how many', () => {
+    const line = successLine('complete', [booked(), booked()]);
+    expect(line).toContain('2 students');
+    expect(line).toMatch(/booked/);
+  });
+
+  test('a student already booked before this run still counts as done', () => {
+    // Nothing is left for a human: they are in the sessions, which is what the
+    // operator came to achieve.
+    expect(successLine('complete', [booked(), alreadyThere()])).toBeTruthy();
+  });
+
+  test('a halt is never confirmed — students were never reached', () => {
+    expect(successLine('halted', [booked()])).toBe('');
+  });
+
+  test('a stranded student is never confirmed — a contact and a pass are left behind', () => {
+    const stranded = record({ key: 2 }, complete({ outcome: 'abandoned', ok: false, stranded: true }));
+    expect(successLine('complete', [booked(), stranded])).toBe('');
+  });
+
+  test('a refused student is never confirmed — that student got nothing', () => {
+    // settledRun() deliberately calls this run settled: re-running reproduces
+    // the refusal exactly, so the already-run gate should close. Being settled
+    // and having worked are two different questions, and this asks the second.
+    const refused = record({ key: 2 }, complete({ outcome: 'refused', ok: false, bookings: [] }));
+    expect(settledRun('complete', [booked(), refused])).toBe(true);
+    expect(successLine('complete', [booked(), refused])).toBe('');
+  });
+
+  test('a student whose pass needs a human is never confirmed', () => {
+    const needsHuman = record({ key: 2 }, complete({ outcome: 'needs-confirmation', ok: false, bookings: [] }));
+    expect(successLine('complete', [booked(), needsHuman])).toBe('');
+  });
+
+  test('bookings cancelled since take the confirmation back down', () => {
+    // The bookings this line would be confirming are gone. Left up, it is the
+    // sentence an operator would read to check whether the cancel worked.
+    const cancelled = { ...booked(), cancel: { cancelled: 2, cancelledIds: ['b1', 'b2'], failed: [], stillBooked: [], verified: true } };
+    expect(successLine('complete', [cancelled])).toBe('');
+  });
+
+  test('an empty run confirms nothing', () => {
+    expect(successLine('complete', [])).toBe('');
+  });
+
+  test('a row that booked nothing at all confirms nothing', () => {
+    // `display()` calls a `complete` row `already booked` whenever it booked
+    // nothing, and that includes a row with no bookings of any kind. There is
+    // no student in that state to point at today; the guard is here because
+    // the sentence it would print — "the student is booked" — is one nothing
+    // else on the page would contradict.
+    const nothing = record({}, complete({ bookings: [] }));
+    expect(nothing.state).toBe('already booked');
+    expect(successLine('complete', [nothing])).toBe('');
   });
 });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -2204,3 +2204,219 @@ describe('the cancel reports its progress (#112)', () => {
     expect(line).toMatch(/role="status"[^>]*x-text="cancelProgress"/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// The result step confirms, and the reset starts the next school (#113)
+// ---------------------------------------------------------------------------
+// UAT of #74: the most prominent control on a finished run was "Cancel bookings
+// from this run", with no comparably prominent confirmation that the import had
+// worked and no way to move on to the next school. Two things this must not get
+// wrong — a confirmation over a run that did not work, and a reset that takes
+// the operator's only record of permanent writes away with it.
+describe('the result step’s confirmation and reset (#113)', () => {
+  test('a clean run is confirmed, and the confirmation names the students', async () => {
+    const app = await upToApply(component());
+    expect(app.runState).toBe('complete');
+    expect(app.successLine()).toContain('6 students');
+  });
+
+  test('a halted run is not confirmed — the banner reads from the outcome, not the ending', async () => {
+    const app = await upToPreview(component({
+      student: () => ({ status: 200, body: { ...STUDENT_OK, reason: 'throttled' } }),
+    }));
+    app.askApply();
+    await app.apply();
+    expect(app.runState).toBe('halted');
+    expect(app.successLine()).toBe('');
+  });
+
+  test('the reset clears the school, the list, the resolutions, the sessions and the table', async () => {
+    const app = await upToApply(component());
+    expect(app.stepIndex).toBe(5);
+
+    app.askReset();
+    expect(app.resetConfirming).toBe(true);
+    app.startAnotherImport();
+
+    expect(app.resetConfirming).toBe(false);
+    expect(app.tag).toBe('');
+    expect(app.rawPaste).toBe('');
+    expect(app.countValue).toBe('');
+    expect(app.declaredFor).toBeNull();
+    expect(app.parsed).toBeNull();
+    expect(app.reviewed).toBeNull();
+    expect(app.resolutions).toEqual({});
+    expect(app.picked).toEqual([]);
+    expect(app.selection.ready).toBe(false);
+    expect(app.matches).toEqual({});
+    expect(app.checkState).toBe('idle');
+    expect(app.preview).toBeNull();
+    expect(app.runRecords).toEqual([]);
+    expect(app.runState).toBe('idle');
+    // Back to the first step, and the strip goes with it: a step the operator
+    // can click forward into is a step holding the last school's answers.
+    expect(app.stepIndex).toBe(0);
+    expect(app.maxStepReached).toBe(0);
+  });
+
+  test('the reset keeps the record — the run is offered back, not destroyed', async () => {
+    // Contacts and School Passes cannot be deleted, so the stored run is the
+    // only record that they were made (D10). Clearing the screen must not be
+    // the thing that loses it.
+    const app = await upToApply(component());
+    app.startAnotherImport();
+    expect(app.restored, 'the finished run is offered again').toBeTruthy();
+    expect(app.restored.records).toHaveLength(6);
+    expect(app.__stored.get('uj-school-booking-run')).toBeTruthy();
+  });
+
+  test('the reset is not a way back into an import that has already run', async () => {
+    // #111's gate is what stops a second Apply on an unchanged list. The reset
+    // is the way to start a *different* import, not the way to re-enable Apply
+    // on a finished one, so what this browser has already run survives it.
+    const app = await upToApply(component());
+    app.startAnotherImport();
+    await upToPreview(app);
+    expect(app.preview.blockers.some((b) => b.kind === 'already-run')).toBe(true);
+  });
+
+  test('nothing resets mid-run', async () => {
+    // The engine is writing into `runRecords` from a loop this cannot stop.
+    const app = await upToApply(component());
+    app.running = true;
+    app.askReset();
+    expect(app.resetConfirming).toBe(false);
+    app.startAnotherImport();
+    expect(app.runRecords).toHaveLength(6);
+    expect(app.stepIndex).toBe(5);
+
+    app.running = false;
+    app.cancelState = 'running';
+    app.startAnotherImport();
+    expect(app.runRecords).toHaveLength(6);
+  });
+
+  test('the two confirms on this step are never open together', async () => {
+    // "Cancel 12 bookings?" and "Clear this and start another school?" on one
+    // screen, each with its own Yes, is a question the operator cannot answer.
+    const app = await upToApply(component());
+    app.askCancel();
+    expect(app.cancelConfirming).toBe(true);
+    app.askReset();
+    expect(app.cancelConfirming).toBe(false);
+    expect(app.resetConfirming).toBe(true);
+    app.askCancel();
+    expect(app.resetConfirming).toBe(false);
+    expect(app.cancelConfirming).toBe(true);
+  });
+
+  test('standing the reset down leaves everything where it was', async () => {
+    const app = await upToApply(component());
+    app.askReset();
+    app.standDownReset();
+    expect(app.resetConfirming).toBe(false);
+    expect(app.runRecords).toHaveLength(6);
+  });
+
+  test('step 1 offers the reset only when there is something to clear', async () => {
+    const app = component();
+    await settled(app);
+    expect(app.holdingAnImport()).toBe(false);
+    app.tag = 'newman';
+    expect(app.holdingAnImport()).toBe(true);
+    app.startAnotherImport();
+    expect(app.holdingAnImport()).toBe(false);
+  });
+});
+
+// The banner and the two reset controls are markup, and this repo has no DOM
+// test infrastructure and is not gaining any (#78). What they have to be is
+// bound to the rules rather than to a literal — a property of the page's text,
+// which is what these read. Same reasoning as `alpine-bindings.test.js`.
+describe('the confirmation and the reset are on the page, and bound (#113)', () => {
+  const summary = (() => {
+    const at = html.indexOf('x-text="resultLine()"');
+    expect(at, 'the result summary is not in the page').toBeGreaterThan(-1);
+    const open = html.lastIndexOf('<div class="rounded-xl', at);
+    return html.slice(open, html.indexOf('</section>', at));
+  })();
+
+  test('the confirmation’s words and its tone both come from successLine()', () => {
+    // A green panel with a literal "Import complete" in it would be a banner
+    // the outcome rules cannot switch off — the one failure mode this feature
+    // has. Both the text and the colour are asked for.
+    expect(summary).toContain('x-text="successLine()"');
+    expect(summary).toMatch(/:class="successLine\(\)[\s\S]*emerald[\s\S]*amber/);
+  });
+
+  test('D11’s summary is still shown either way', () => {
+    // The confirmation leads; it does not replace. The sentence the preview
+    // showed, in past tense, is the only way to check that what happened is
+    // what was agreed to.
+    expect(summary).toContain('x-text="resultLine()"');
+    expect(summary).toContain('x-text="strandedWarning()"');
+  });
+
+  test('the result step offers the reset, behind its confirm', () => {
+    expect(summary).toContain('@click="askReset()"');
+    expect(summary).toContain('@click="startAnotherImport()"');
+    expect(summary).toContain('@click="standDownReset()"');
+  });
+
+  test('step 1 carries the same control, and only when there is something to clear', () => {
+    const step = html.slice(html.indexOf('Which school is this?'), html.indexOf('x-text="schoolsNote()"'));
+    expect(step).toContain('x-show="holdingAnImport()"');
+    expect(step).toContain('@click="askReset()"');
+    expect(step).toContain('@click="startAnotherImport()"');
+  });
+
+  test('the cancel control is demoted and nothing else — #113 must not weaken it', () => {
+    // The only reversible thing this tool does. Its label is still the count
+    // the interlock allows, its confirm is still in front of it, and the
+    // permanence sentence is still beside it rather than in a footnote.
+    const panel = html.slice(html.indexOf('>Taking it back<'), html.indexOf('Back to the preview'));
+    expect(panel).toContain('@click="askCancel()"');
+    expect(panel).toContain('@click="cancelRun()"');
+    expect(panel).toContain('@click="standDownCancel()"');
+    expect(panel).toMatch(/x-text="`Cancel \$\{cancellableCount\(\)\}/);
+    expect(panel).toContain('the API has no delete for either');
+    // Still visible without opening anything: demoted is not hidden.
+    expect(panel).not.toMatch(/<details|x-show="showCancel/);
+  });
+});
+
+// The reset restates ~45 of the component literal's initial values, and nothing
+// in the language links the two copies. The risk is not today's code — it is a
+// field added to the literal in six months and not added here, which leaves one
+// school's answer on the page for the next school's import with no symptom
+// until it matters. This is the link: a reset page must be a fresh page.
+describe('the reset leaves nothing of the last import behind (#113)', () => {
+  test('every field matches a page that has never had an import on it', async () => {
+    const fresh = component();
+    await settled(fresh);
+
+    const app = await upToApply(component());
+    app.startAnotherImport();
+
+    // The three it keeps on purpose, each for a reason in the method's header:
+    // the record of permanent writes, what this browser has already run, and a
+    // read of Clubworx that is not an answer of the operator's.
+    const kept = new Set(['restored', 'lastRun', 'schools', 'schoolsState']);
+    // Re-seeded by `openDatePicker` on every open, from the date boxes or from
+    // today — never carried across an import, whatever they hold now.
+    const seeded = new Set(['dpYear', 'dpMonth']);
+
+    for (const key of Object.keys(fresh)) {
+      if (key.startsWith('__') || typeof fresh[key] === 'function') continue;
+      if (kept.has(key) || seeded.has(key)) continue;
+      expect(app[key], `\`${key}\` survived the reset — add it to startAnotherImport()`)
+        .toEqual(fresh[key]);
+    }
+
+    // And the keepers are actually kept, so the exemption list cannot quietly
+    // become the way a field escapes the check above.
+    expect(app.restored, 'the stored run is offered back').toBeTruthy();
+    expect(app.lastRun?.fingerprint, '#111 still knows what this browser ran').toBeTruthy();
+    expect(app.schools).toEqual(fresh.schools);
+  });
+});


### PR DESCRIPTION
Closes #113.

UAT of #74: the most prominent control on a finished run was **"Cancel bookings from this run"** — no comparably prominent confirmation that the import had worked, and no way to move on to the next school.

## What changed

**The result step leads with the confirmation.** One panel, not two — D11's summary sentence stays exactly where it was, with the tone and the heading following the outcome, and a primary **Start another import** beside it.

**`successLine()` (outcome.js) decides whether there is a confirmation at all**, and is deliberately stricter than `settledRun()`. Every row must read `booked` or `already booked`, so a halt on D7's breaker or a throttle, a stranded student, a refusal and a `needs you` row each keep the banner away; `cancelled > 0` takes it back down. `settledRun()` calls a run with a refused student *settled* — correctly, since re-running reproduces that refusal exactly — but that student got nothing, and the two questions are not the same one. It returns a string in the same shape as `strandedWarning()`, so the markup shows the banner *on the text* and no template condition can disagree with the rule.

**D12's cancel is demoted and nothing else.** Same label, same count, same interlock, same confirm, same permanence sentence beside it, still visible rather than behind a disclosure. Only its weight changed — a markup guard test asserts each of those bindings survives.

**`startAnotherImport()` is one control rendered twice** — the result step, and step 1, where an operator who walked back is looking at the last school's answers and choosing a new school clears none of them. It clears the school, the paste, the declaration, the resolutions, the sessions, the check, the preview and the result table, and winds the step strip back. It keeps three things on purpose: the stored run (D10 — re-read, so it returns as the offer at the top of the page), `lastRun` (#111 still blocks an identical re-paste — this starts a *different* import, it does not re-open a finished one) and `schools`. It refuses while the run or the cancel is in flight, and it asks first.

**#111's blocker text now names this control** instead of saying "reload the page", which was only honest while the control did not exist. It names both places it appears: after a reset the result step is empty and its copy is hidden, so "on the result step" alone would have been a dead pointer.

## Two things review caught

- **The reset restates ~45 of the component literal's initial values** and nothing in the language links the two copies. A test does: a reset page must equal a fresh one field by field, with only the deliberate keepers exempt. A field added to the literal later and forgotten here now fails a test rather than leaking one school's answer into the next school's import.
- **D10 is one `localStorage` key, and the next run overwrites it** — which this issue turns from an edge case into the designed flow. The confirm says so rather than promising the record is safe: offered back *until the next import replaces it*, copy or download first. Filed as a §15 gap.

## Verification

- 24 new tests: 9 pure (`successLine`'s refusals), 15 component and markup guards.
- `school-booking` 506 → 514. All suites green: clubworx 665, worker 83, payments-proxy 9, vouchers 217.
- Module `?v=` bumped 4 → 5 across the page and sibling imports.
- Design spec: §12 **D16**, plus a §15 gap. `CLAUDE.md` updated.

Not merged — `main` is production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C28H3jB8vjJUdSHG11KsJn