### PR TITLE
Voucher hub: a suppressed voucher is not unsent

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -128,6 +128,9 @@ checkbox and the column all read *physical*.
 A voucher that was due to reach someone by email and hasn't — the counterpart
 to a physical one, which is never unsent because no email was ever due.
 
+A **suppressed** voucher is not unsent either. Nobody is waiting for it: the
+member opted out, so the send was a decision not to email, not a failure to.
+
 Defined canonically in the **vouchers** repo, `docs/CONTEXT.md`, because it is a
 state of the voucher record rather than of this page. The hub renders it in
 three places (the create result, the detail view, the search list) and asks

--- a/vouchers/test/unsent-voucher.test.js
+++ b/vouchers/test/unsent-voucher.test.js
@@ -30,6 +30,21 @@ describe('isUnsent', () => {
     expect(isUnsent({ is_physical: true, customer_email: null, email_sent: false })).toBe(false);
   });
 
+  // Found live: the only two rows in the whole book that matched the original
+  // predicate were both suppressed, so the badge's entire real-world output was
+  // rows it should never have flagged. Suppressed is a decision, not a failure.
+  test('a suppressed voucher is never unsent — nobody is waiting for it', () => {
+    expect(isUnsent(emailed({ email_sent: false, send_state: 'suppressed' }))).toBe(false);
+  });
+
+  // The states that ARE failures still flag, or the badge stops meaning
+  // anything.
+  test('a permanent or transient failure still flags', () => {
+    expect(isUnsent(emailed({ email_sent: false, send_state: 'permanent' }))).toBe(true);
+    expect(isUnsent(emailed({ email_sent: false, send_state: 'transient' }))).toBe(true);
+    expect(isUnsent(emailed({ email_sent: false, send_state: null }))).toBe(true);
+  });
+
   test('an emailed voucher with no address on file is not unsent', () => {
     // There is nothing to resend to, and the detail view already says so.
     expect(isUnsent(emailed({ customer_email: null, email_sent: false }))).toBe(false);

--- a/vouchers/unsent-voucher.js
+++ b/vouchers/unsent-voucher.js
@@ -26,6 +26,16 @@ export function isUnsent(voucher) {
   // would just compete.
   if (!voucher.customer_email) return false;
 
+  // Suppressed is a DECISION, not a failure: the member opted out, or
+  // Clubworx's own unsubscribe flag is set, so the send was deliberately never
+  // attempted. Migration 021 is explicit that the voucher is still valid.
+  //
+  // This exclusion is the load-bearing one. Flagging a suppressed voucher does
+  // not merely mislabel it — it puts "Not sent" in front of a staff member
+  // beside a Resend button, and emailing someone who has unsubscribed is the
+  // one outcome this whole feature must not cause.
+  if (voucher.send_state === 'suppressed') return false;
+
   return !voucher.email_sent;
 }
 


### PR DESCRIPTION
Follow-up to #134, found by checking the badge against production rather than trusting it.

## What was wrong

Of **1,783 vouchers, exactly two** matched `isUnsent()`:

```
UJ-YVZ6-H98L   auto   send_state: suppressed
UJ-RVNB-KZZ6   auto   send_state: suppressed
```

Both suppressed. So the badge's entire real-world output was rows it should never have flagged.

`isUnsent()` didn't consider `send_state` at all. **Suppressed is a decision, not a failure** — the member opted out, or Clubworx's own unsubscribe flag is set, so the send was deliberately never attempted. Migration 021 says it plainly: *"Not a failure; the voucher is still valid."*

This isn't a cosmetic mislabel. It puts **"Not sent"** in front of a staff member directly beside a **Resend Email** button, and emailing someone who has unsubscribed is the one outcome this feature must not cause.

## The fix

`isUnsent()` returns false when `send_state === 'suppressed'`. `'permanent'`, `'transient'` and `null` still flag, or the badge stops meaning anything.

Glossary updated in both repos — canonical entry in urbanjungleirc/vouchers `docs/CONTEXT.md`, cross-reference here.

## Tests

`cd vouchers && npx vitest run` → 243 passing (the single failure is the pre-existing `version.test.js` environment issue, unrelated). Mutation-checked: dropping the exclusion fails the new test.

## Also worth recording

I told Jiri that vouchers resent before today would light up the badge, because `resendVoucherEmail` never patched `email_sent`. Wrong: **1,447 of 1,449** emailed vouchers have `email_sent: true`. A resend almost always happens on a voucher whose original send already succeeded, so the missing patch only ever mattered when the *first* send failed. There is no historical residue to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014L2Pv9ie5gFJwaKkcPyrMd