### PR TITLE
Voucher hub: a scanned voucher opens the redeem form (#136)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -252,6 +252,55 @@ plain checkout has no `version.json` at all, so anything reading it must treat
 missing and `dev` alike as "no version" — that is the normal state during local
 development, not a fault.
 
+## Voucher scanning
+
+Terms for the front-desk scanner (Zebra DS2208) and the codes it feeds into the
+voucher hub. See [ADR 0006](docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md).
+
+### Scan
+
+A voucher code arriving at the hub as **keystrokes with nothing focused** —
+what the counter scanner produces. The scanner is a USB keyboard as far as the
+browser is concerned; it types the code and presses Enter. There is no device,
+no permission prompt and no camera anywhere in this.
+
+A scan is therefore a *shape*, not an event: the hub cannot ask whether a
+scanner exists, only whether what just arrived looks like a voucher code.
+
+*Avoid*: "scanning the QR" as a description of the mechanism — the QR is what
+the customer holds up, not what the hub sees. *Avoid*: "camera scan", which
+described an earlier unreachable screen, now deleted.
+
+### Scannable code
+
+A code the hub will accept from a scan: **`UJ-XXXX-XXXX` only**, uppercased and
+trimmed first.
+
+Legacy UUID vouchers migrated from the GAS system are deliberately **not**
+scannable. Their emails never carried a QR, so there is nothing to point a
+scanner at; they are found through the search box like any other text.
+
+The format itself is decided in the **vouchers** repo — see its
+[ADR 0004](https://github.com/urbanjungleirc/vouchers/blob/main/docs/adr/0004-human-readable-voucher-codes.md).
+`scan-input.js` restates it as a regex on purpose, so that a stray scan is
+rejected on the page rather than by a round-trip.
+
+### Redeemable
+
+Status `active`. Nothing more — one test, not two.
+
+The word earns a definition because **a partially redeemed voucher is still
+redeemable**: it keeps status `active` for as long as it has balance, and the
+"Partially redeemed" badge is a separate, purely informational thing. Staff read
+that badge as a terminal state and it is not one.
+
+A scan of a redeemable voucher opens the redeem form. Anything else — expired,
+cancelled, no balance left — lands on the detail view under a banner naming the
+reason, coloured amber, rose and sky respectively.
+
+*Avoid*: "unused". An unsent voucher is unused and fully redeemable; a partially
+redeemed one is used and still redeemable.
+
 ## Clubworx pacing
 
 Terms for talking to the Clubworx API without being cut off. Measured in

--- a/docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md
+++ b/docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md
@@ -135,6 +135,14 @@ that limitation from also costing them the fast path.
 **Nothing scans outside the hub.** `stats.html` and `unsubscribes.html` have no
 listener. They have no voucher to redeem.
 
+**A scan into the search box still works, by a different road.** Suppression
+means the listener ignores it, but the characters land in the field and the
+Enter submits the form — where rule 4 recognises the code and sends it to the
+same place. So the common counter accident, scanning while the search box still
+has focus from the last lookup, behaves identically. That is a consequence of
+the two rules meeting, not a third rule, and the setup runbook says so because
+it otherwise looks like luck.
+
 ## Alternatives considered
 
 - **Keep the camera view and unify the two paths.** Rejected once it turned out

--- a/docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md
+++ b/docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md
@@ -10,9 +10,17 @@
 The hub already contained a scanning surface: a `view === 'scan'` screen driving
 the device camera through `html5-qrcode`, loaded from unpkg, with a manual
 `UJ-XXXX-XXXX` box beside it. **It was unreachable.** `goScan()` had no caller
-anywhere in the repo — no nav entry, no button. So the camera scanner was never
-a working alternative that we chose against; it was dead code that happened to
-describe an approach.
+anywhere in the repo. The header did carry a Scan button, but it was
+`<button disabled>` with no click handler and the tooltip "Scan coming later" —
+a placeholder for the feature, not a route to the view behind it. So the camera
+scanner was never a working alternative that we chose against; it was dead code
+that happened to describe an approach.
+
+That placeholder is deleted too, and **not replaced**. Scanning is ambient: it
+works on every screen, so there is nothing to navigate to and nothing to switch
+on. A button would imply the opposite — that you have to press something first.
+The cost is discoverability, which now rests on the setup runbook and on telling
+staff once; the alternative was a control that lies about how the feature works.
 
 The counter needs the opposite of a camera: a customer holds up a phone, and a
 staff member wants the voucher on screen and the redeem form open, without

--- a/docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md
+++ b/docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md
@@ -1,0 +1,160 @@
+# ADR 0006 — voucher scanning is a global keyboard wedge, not a camera
+
+- **Status**: Accepted — designed 2026-08-25, hardware verified 2026-08-25, not yet implemented
+- **Date**: 2026-08-25
+- **Hardware**: Zebra DS2208, corded USB, at the front desk
+- **Companion**: vouchers [ADR 0004](https://github.com/urbanjungleirc/vouchers/blob/main/docs/adr/0004-human-readable-voucher-codes.md) — the code format this depends on
+
+## Context
+
+The hub already contained a scanning surface: a `view === 'scan'` screen driving
+the device camera through `html5-qrcode`, loaded from unpkg, with a manual
+`UJ-XXXX-XXXX` box beside it. **It was unreachable.** `goScan()` had no caller
+anywhere in the repo — no nav entry, no button. So the camera scanner was never
+a working alternative that we chose against; it was dead code that happened to
+describe an approach.
+
+The counter needs the opposite of a camera: a customer holds up a phone, and a
+staff member wants the voucher on screen and the redeem form open, without
+touching anything. A corded imager does that; a webcam pointed across a desk
+does not.
+
+A DS2208 in its default mode is a **USB HID keyboard**. It does not present an
+API — it types. That single fact drives everything below: the design problem is
+not "how do we read the scanner", it is "what do we do with keystrokes that
+arrive from nowhere".
+
+## Decision
+
+**Scanning is a document-level keystroke listener on the voucher hub, gated on
+the shape of the voucher code.** The camera view, its manual box and the unpkg
+script are deleted.
+
+Four rules make it up.
+
+**1. The scanner's contract is "characters, then Enter" — nothing more.** The
+scanner is programmed with the Enter suffix and otherwise left at defaults. The
+app trims and uppercases whatever arrives before testing it, so a till with Caps
+Lock on, or a replacement unit programmed by someone else, still works. Nothing
+in the app depends on the scanner's symbology settings, prefix, or inter-character
+timing.
+
+**2. A buffer is a scan when it is Enter-terminated and matches `UJ-XXXX-XXXX`.**
+Not a timing heuristic, not a magic prefix character. Shape is enough because
+the listener is suppressed whenever focus is in a text box: to false-positive, a
+person would have to type a well-formed voucher code with nothing focused.
+
+**3. Scanning is off entirely while any modal is open.** A modal is a committed
+task. The type editor guards unsaved changes behind a discard prompt, and a scan
+that jumped past it would reintroduce exactly the loss that guard exists to
+prevent. Close the modal, then scan.
+
+**4. A voucher code goes to the redeem form however it arrived.** A scan and a
+valid code typed into the search box that matches exactly one voucher reach the
+same destination. Physical voucher cards carry no QR — only a printed code — so
+typing is the counter path for a whole class of vouchers, and giving it a
+different destination would mean two rules for the same thing.
+
+The destination itself:
+
+| Voucher state | Where the scan lands |
+|---|---|
+| `active` (including partially redeemed) | Detail view, redeem modal open, **amount blank, focus in amount** |
+| expired | Detail view, amber banner |
+| cancelled | Detail view, rose banner |
+| no balance left | Detail view, sky banner |
+| well-formed, no such voucher | Stays put, "No voucher UJ-XXXX-XXXX" |
+| not a voucher code | Stays put, "That isn't a voucher code" |
+
+## What the scanner actually sends — measured
+
+Measured 2026-08-25 on the front-desk unit with a throwaway echo page, scanning a
+real voucher QR (`UJ-TQYH-F8PW`) off a phone screen, with the Enter suffix
+already programmed through the Zebra 123Scan settings.
+
+**A 12-character code arrives as 22 keydown events.** Every letter is preceded
+by its own discrete `ShiftLeft` keydown (`keyCode` 16); digits and hyphens are
+not. The scanner types uppercase the way a person does, rather than emitting
+pre-shifted characters.
+
+> **This is the trap.** A listener that appends `e.key` on every keydown builds
+> `ShiftUShiftJ-ShiftT…`. The buffer must accept **only single-character `e.key`
+> values** and drop everything else. Beyond that filter no shift bookkeeping is
+> needed — `e.key` is already `"U"`, not `"u"`.
+
+The rest, for the record:
+
+| | |
+|---|---|
+| Terminator | `Enter`, `keyCode` 13 — one, at the end |
+| Prefix | none |
+| Modifiers | `Shift` only, and only on letters |
+| Hyphen | `e.code` `Minus`, `keyCode` 189 — survives the Australian Windows layout intact |
+| Between characters | 0–5 ms (avg 2 ms) |
+| Whole burst | 40 ms |
+
+The timings say a burst heuristic *would* have worked — worth knowing if the
+shape test ever has to widen — but they are recorded as evidence, not relied on.
+Nothing in the app reads a clock.
+
+**Not tested: a printed email.** The glossy, backlit case passed, and imagers
+generally read matte paper more easily, so this was judged not worth blocking on.
+
+## Consequences
+
+**The redeem modal has to identify the voucher itself.** Until now it could
+assume staff had read the detail page on the way in — it showed a title and a
+balance and nothing else. A scan skips that reading, so the modal gains code,
+customer name, type and item alongside the balance. Without it, the realistic
+counter error — the right-looking voucher belonging to the wrong person —
+has nothing to catch it.
+
+**The amount is deliberately not pre-filled.** Pre-filling the full balance
+would be fewer keystrokes for the common case and would make a partial redeem
+the path you have to *notice*. A redeem is irreversible without a manager, so
+the amount stays a deliberate act.
+
+**The code format is now stated in two repos.** `scan-input.js` in staff-site
+carries a regex describing what vouchers' `voucher-codes.js` generates. That is
+a knowing duplication, not an oversight: asking the Worker to decide whether a
+keystroke burst is a voucher code would put a network round-trip in front of
+every stray scan. The regex is commented with a pointer to vouchers ADR 0004,
+which is where the format is actually decided. **If the format ever changes, this
+is the second place.**
+
+**Legacy UUID vouchers are not scannable, and that is fine.** Vouchers migrated
+from the GAS system kept their UUID codes, and those emails never carried a QR —
+there is nothing to point a scanner at. Widening the shape test to match UUIDs
+would loosen it for no reachable benefit. They stay a search-box job.
+
+**Physical cards stay a typing job.** The cards handed over in the shop carry a
+printed code and no QR, so the scanner cannot help with them at all. Printing a
+QR on the card is out of scope here, not deferred — but rule 4 is what stops
+that limitation from also costing them the fast path.
+
+**Nothing scans outside the hub.** `stats.html` and `unsubscribes.html` have no
+listener. They have no voucher to redeem.
+
+## Alternatives considered
+
+- **Keep the camera view and unify the two paths.** Rejected once it turned out
+  the view was unreachable: there is no phone or tablet workflow in production
+  to preserve, so "keeping it" meant reviving dead code and carrying a
+  third-party script from unpkg on a page behind Access.
+- **A distinctive prefix character programmed into the scanner.** Unambiguous,
+  and it would work for any code shape including UUIDs. Rejected because it
+  makes the scanner's configuration load-bearing — a factory reset leaves the
+  hub silently deaf until someone finds the programming sheet. Shape-testing
+  fails soft; a missing prefix fails silent.
+- **Burst timing (characters arriving faster than a human types).** Rejected as
+  fiddly to test and capable of misfiring on a loaded machine, for a robustness
+  gain the shape test already provides.
+- **Park focus in a hidden input so scans always land somewhere.** Rejected: any
+  click elsewhere breaks scanning until focus returns, and nothing on screen
+  would say so.
+- **Send every Enter-terminated buffer to the Worker and let it decide.** One
+  definition of the code format instead of two — but a round-trip per stray
+  scan, and a slower, less certain "that isn't a voucher code".
+- **Scan straight through an open modal.** Rejected under rule 3. A second
+  voucher handed over mid-transaction is real but rare, and the cost of getting
+  it wrong is a discarded redeem or an unsaved type edit.

--- a/docs/scanner-setup.md
+++ b/docs/scanner-setup.md
@@ -1,0 +1,97 @@
+# Front-desk scanner setup (Zebra DS2208)
+
+What the voucher hub needs from the scanner, how to check it, and what to do
+when a scan does nothing. The design behind it is
+[ADR 0006](adr/0006-voucher-scanning-is-a-keyboard-wedge.md).
+
+## What the hub actually requires
+
+Two things, and deliberately nothing else:
+
+1. **USB HID keyboard mode.** The DS2208 ships this way. The browser sees a
+   keyboard, not a device — there is no driver to install and no permission
+   prompt.
+2. **An Enter suffix.** The scanner must press Enter after typing the code.
+   That keypress is what tells the hub the code is complete.
+
+Everything else is left at the factory default on purpose. The hub trims and
+uppercases whatever arrives before testing it, so Caps Lock on the till, or a
+replacement unit somebody else programmed, does not break scanning.
+
+**Do not** disable symbologies, set a prefix, or change the keyboard country to
+"tidy things up". None of it helps — the hub rejects a non-voucher scan on the
+shape of the code — and a keyboard country that stops matching Windows turns the
+hyphens in `UJ-XXXX-XXXX` into something else, which looks exactly like the
+scanner being broken.
+
+## Setting the Enter suffix
+
+Either route works; both write to the scanner's own flash and survive being
+unplugged.
+
+- **Zebra 123Scan** (Windows) — connect the scanner, set the suffix to Enter,
+  write the configuration to the device. This is what was used on 2026-08-25.
+- **The DS2208 Product Reference Guide** — scan the programming barcode that
+  adds an Enter key (carriage return) as the suffix. Zebra publishes the guide
+  as a PDF; the barcode is in the USB / "Scan Options" section.
+
+A factory reset clears it. If the scanner is ever reset or replaced, this is the
+one setting to put back.
+
+## Checking it in thirty seconds
+
+Open Notepad and scan a voucher QR off a phone screen.
+
+You should see the code and then **the cursor drop to a new line**:
+
+```
+UJ-TQYH-F8PW
+|
+```
+
+- Code appears, cursor stays on the same line → **no Enter suffix.** Set it.
+- Nothing appears → the scanner is not in HID keyboard mode, or is not powered.
+- Code appears with the hyphens missing or replaced → keyboard country mismatch.
+- Code appears in lowercase → harmless. The hub uppercases it.
+
+Then scan into the voucher hub with nothing focused. An active voucher should
+open the redeem form with the cursor in the amount box.
+
+## What a real scan looks like
+
+Measured 2026-08-25 on the front-desk unit, scanning `UJ-TQYH-F8PW`:
+
+| | |
+|---|---|
+| Keydown events | **22**, for a 12-character code |
+| Why 22 | every letter is preceded by its own `Shift` keydown; digits and hyphens are not |
+| Terminator | `Enter` (`keyCode` 13), one, at the end |
+| Prefix | none |
+| Hyphen | arrives intact on the Australian Windows layout |
+| Whole burst | 40 ms, 0–5 ms between characters |
+
+The Shift detail is why the hub collects only single-character keys. It is
+recorded here as well as in the ADR because it is the thing that looks like a
+bug when someone re-reads the code.
+
+## When a scan does nothing
+
+Work down this list; it is ordered by how often each one is the answer.
+
+1. **A modal is open.** Scanning is switched off entirely while any dialog is
+   up, so an in-progress redeem or an unsaved type edit cannot be blown away.
+   Close it and scan again.
+2. **The cursor is in a text box.** Scanning is suppressed so a scan cannot
+   hijack someone mid-typing. Click a blank part of the page first. (Scanning
+   into the *search box* is fine — the code submits the form and lands in the
+   same place.)
+3. **No Enter suffix.** Check with Notepad, above.
+4. **It is not an emailed voucher.** Physical cards carry a printed code and no
+   QR — there is nothing to scan. Type the code into the search box instead; it
+   goes to the same place.
+5. **It is a pre-2026 voucher.** Vouchers migrated from the old Google system
+   kept long UUID codes and their emails never carried a QR. Search for them by
+   customer name or receipt.
+6. **The page says "That isn't a voucher code".** The scanner fired and the hub
+   read something that is not a `UJ-XXXX-XXXX` code — usually the wrong barcode
+   on the same page, or a product barcode.

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -72,7 +72,6 @@
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
-  <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
   <style>
     [x-cloak] { display: none !important; }
     :root {
@@ -1816,37 +1815,6 @@
             class="text-sm text-neutral-400 text-center py-4">No redemptions in this period.</div>
         </div>
       </template>
-    </div>
-
-    <!-- ── QR scan ────────────────────────────────────────────────────────── -->
-    <div x-show="view==='scan'">
-      <div class="flex items-center gap-3 mb-5">
-        <button @click="goSearch()"
-          class="flex items-center gap-1.5 text-sm text-neutral-500 hover:text-neutral-800 transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M15 19l-7-7 7-7"/>
-          </svg>
-          Back
-        </button>
-        <h2 class="text-base font-semibold text-neutral-800">Scan Voucher</h2>
-      </div>
-
-      <div class="max-w-sm mx-auto space-y-3">
-        <div class="bg-white rounded-card hub-card border border-neutral-100 p-4">
-          <div id="qr-reader" class="rounded-xl overflow-hidden w-full"></div>
-          <p class="text-xs text-neutral-400 mt-2 text-center">Point camera at the voucher QR code</p>
-        </div>
-
-        <div class="bg-white rounded-card hub-card border border-neutral-100 p-4">
-          <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-2">Or enter code manually</label>
-          <form @submit.prevent="lookupManual()" class="flex gap-2">
-            <input type="text" x-model="manualCode" placeholder="UJ-XXXX-XXXX"
-              class="flex-1 border border-neutral-200 rounded-xl px-3 py-2 text-sm font-mono uppercase focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
-            <button type="submit"
-              class="bg-uj hover:bg-uj-dark text-white px-4 py-2 rounded-xl text-sm font-semibold transition-colors">Go</button>
-          </form>
-        </div>
-      </div>
     </div>
 
       <!-- ── Voucher Types (admin) ──────────────────────────────────────── -->
@@ -3705,10 +3673,6 @@
       reportRedeemedSort: { col: 'last_redeemed_date', dir: 'desc' },
       reportRedeemedPage: 1,
 
-      // Scanner
-      scanner: null,
-      manualCode: '',
-
       // Toast
       toast: null,
       _toastTimer: null,
@@ -3776,7 +3740,6 @@
       },
 
       logout() {
-        this.stopScannerIfActive();
         localStorage.removeItem('uj_staff_secret');
         this.secret = '';
         this.results = [];
@@ -3854,7 +3817,6 @@
       // ── Export ───────────────────────────────────────────────────────────
       goExport() {
         this.view = 'export';
-        this.stopScannerIfActive();
         this.applyExportPeriod();
         if (!this.exportRegistry) this.loadExportFields();
       },
@@ -4162,7 +4124,6 @@
         // Only set origin on a fresh open; refresh calls (after redeem/undo/resend)
         // omit it so the "Back to …" target is preserved.
         if (origin) this.detailOrigin = origin;
-        this.stopScannerIfActive();
         this.view = 'detail';
         this.voucher = null;
         this.detailError = '';
@@ -4537,7 +4498,6 @@
 
       // ── Create physical ──────────────────────────────────────────────────
       async goCreate() {
-        this.stopScannerIfActive();
         this.view = 'create';
         this.createdVoucher = null;
         this.createError = '';
@@ -4777,7 +4737,6 @@
       // rather than search(): it sends the filters that are in the bar and
       // leaves the current page alone, where search() resets both.
       goSearch() {
-        this.stopScannerIfActive();
         this.view = 'search';
         this.refreshData({ force: this._searchStale });
       },
@@ -4800,7 +4759,6 @@
 
       // ── Reports ──────────────────────────────────────────────────────────
       async goReports() {
-        this.stopScannerIfActive();
         this.view = 'reports';
         await this.loadReport();
       },
@@ -5050,39 +5008,6 @@
         return Math.max(1, Math.ceil((this.report?.redeemed?.length || 0) / this.PAGE_SIZE));
       },
 
-      // ── QR scanner ───────────────────────────────────────────────────────
-      goScan() {
-        this.view = 'scan';
-        this.manualCode = '';
-        this.$nextTick(() => this.startScanner());
-      },
-
-      startScanner() {
-        if (typeof Html5Qrcode === 'undefined') return;
-        this.stopScannerIfActive();
-        this.scanner = new Html5Qrcode('qr-reader');
-        this.scanner.start(
-          { facingMode: 'environment' },
-          { fps: 10, qrbox: { width: 250, height: 250 } },
-          (text) => { this.openVoucher(text.trim()); },
-          () => {}
-        ).catch(() => {});
-      },
-
-      stopScannerIfActive() {
-        if (this.scanner) {
-          this.scanner.stop().catch(() => {});
-          this.scanner = null;
-        }
-      },
-
-      lookupManual() {
-        const code = (this.manualCode || '').trim().toUpperCase();
-        if (!code) return;
-        this.stopScannerIfActive();
-        this.openVoucher(code);
-      },
-
       // ── Helpers ──────────────────────────────────────────────────────────
       fmtDate(s) {
         if (!s) return '—';
@@ -5139,7 +5064,6 @@
 
       // ── Voucher Types (admin) ──────────────────────────────────────────
       async goVoucherTypes() {
-        this.stopScannerIfActive();
         this.view = 'voucherTypes';
         await this.loadVoucherTypes();
       },

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -953,7 +953,7 @@
       <!-- The text box is the control staff reach for every time; status and the
            date range are occasional. So the box and its button own the primary
            row, and the rest sits below under a quieter "Filter" heading. -->
-      <form @submit.prevent="search()" class="mb-5">
+      <form @submit.prevent="submitSearch()" class="mb-5">
         <div class="flex gap-2 flex-wrap mb-3">
           <input type="search" x-model="q" placeholder="Name, email, code, receipt or phone…"
             class="flex-1 min-w-[200px] border border-neutral-200 rounded-xl px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj bg-white placeholder-neutral-400" />
@@ -4153,6 +4153,29 @@
       },
 
       // ── Search ───────────────────────────────────────────────────────────
+      // A voucher code goes to the redeem form however it arrived. Physical
+      // cards carry a printed code and no QR, so typing is the counter path for
+      // a whole class of vouchers, and giving it a different destination would
+      // mean two rules for the same thing (ADR 0006, rule 4).
+      //
+      // This lives on SUBMIT and not inside search(), deliberately. search() is
+      // also called on load, by the dashboard drill-downs and by the background
+      // refresh; a jump in there would fire on paths nobody asked for. Typing a
+      // code and pressing Enter is a deliberate act, and only that jumps.
+      //
+      // A code is exact, so there is nothing to search for — the lookup either
+      // finds the voucher or reports that there is no such voucher, exactly as
+      // a scan does.
+      async submitSearch() {
+        const scan = window.scanInput;
+        const code = scan?.normaliseScanned?.(this.q) ?? '';
+        if (scan?.isScannableCode?.(code)) {
+          await this.openScannedCode(code);
+          return;
+        }
+        await this.search();
+      },
+
       async search() {
         this.searchLoading = true;
         this.searchError = '';

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -807,14 +807,14 @@
           <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M3.5 8.5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2v2.1a2.4 2.4 0 0 0 0 4.8v2.1a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2v-2.1a2.4 2.4 0 0 0 0-4.8V8.5z"/><path d="M12 9.25v5.5M9.25 12h5.5"/></svg></span>
           Create
         </button>
-        <button disabled
-          class="px-4 py-2 rounded-xl border border-white/15 bg-white/5 transition-all flex items-center gap-1.5 text-[0.9rem] font-semibold text-white/40 cursor-not-allowed" title="Scan coming later">
-          <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.9" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round"
-              d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
-          </svg>
-          Scan
-        </button>
+        <!-- There is deliberately no Scan button. Scanning is ambient — it works
+             on every screen in the hub, so there is nothing to navigate to and
+             nothing to switch on. A button would imply the opposite: that you
+             have to press something first.
+
+             What stood here until #136 was a permanently disabled placeholder
+             reading "Scan coming later". Scanning has arrived; the placeholder
+             has not become a control. -->
         </div>
         <div class="flex items-center gap-1.5 flex-wrap sm:justify-end">
         <button @click="goReports()"

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -2120,6 +2120,28 @@
         </div>
       </div>
 
+      <!-- Who and what is being redeemed. Until #136 this modal could assume
+           staff had read the detail page on the way in, and showed a title and
+           a balance and nothing else. A scan — or a code typed into the search
+           box — skips that reading entirely, so the modal has to identify the
+           voucher itself.
+
+           The realistic counter error is the right-LOOKING voucher belonging to
+           the wrong person: same type, same value, wrong customer. The balance
+           does not catch it and the code does not catch it. The name does. -->
+      <div class="bg-neutral-50 border border-neutral-200 rounded-xl px-3.5 py-3 mb-4">
+        <div class="font-mono text-sm font-semibold text-neutral-800" x-text="voucher?.voucher_id"></div>
+        <div class="text-sm text-neutral-700 mt-0.5" x-text="voucher?.customer_name || 'No name on file'"></div>
+        <div class="text-xs text-neutral-500 mt-1">
+          <span x-text="voucher?._type_name || voucher?.voucher_type_id || '—'"></span>
+          <!-- Item only when the type has one, exactly as the detail view does
+               it. A dangling separator reads as a missing value. -->
+          <template x-if="voucher?._item_name || voucher?.voucher_item_id">
+            <span> · <span x-text="voucher?._item_name || voucher?.voucher_item_id"></span></span>
+          </template>
+        </div>
+      </div>
+
       <div x-show="redeemError"
         class="bg-rose-50 border border-rose-200 text-rose-700 rounded-xl p-3 text-sm mb-4"
         x-text="redeemError"></div>

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -69,6 +69,14 @@
     // behaviour rather than throwing on every row of the search list.
     import * as unsentVoucher from './unsent-voucher.js?v=1';
     window.unsentVoucher = unsentVoucher;
+    // And once more here. A stale cached copy of this one costs scanning
+    // entirely: staffApp() takes its buffer from this module at construction,
+    // and a missing export leaves that null, so onScanKey() returns on the
+    // first line and every keystroke falls through untouched. That is the
+    // right failure — the alternative is throwing on every keypress in the
+    // hub, which would break typing as well as scanning.
+    import * as scanInput from './scan-input.js?v=1';
+    window.scanInput = scanInput;
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
@@ -757,7 +765,8 @@
   </style>
 </head>
 <body class="bg-neutral-100 text-neutral-900 min-h-screen antialiased font-sans"
-  x-data="staffApp()" x-init="init()" x-cloak>
+  x-data="staffApp()" x-init="init()" x-cloak
+  @keydown.window="onScanKey($event)">
 
   <!-- ── Header ──────────────────────────────────────────────────────────── -->
   <header class="hub-header text-white">
@@ -1137,6 +1146,36 @@
       </div>
       <div x-show="detailError && !detailLoading"
         class="bg-rose-50 border border-rose-200 text-rose-700 rounded-xl p-4 text-sm" x-text="detailError"></div>
+
+      <!-- Why a scan landed here instead of on the redeem form. A staff member
+           who scanned expecting to take payment needs the reason in front of
+           them while they explain it, so this is a banner and not a toast that
+           vanishes just as the customer asks "why?".
+
+           Three literal-class variants rather than one with a computed class:
+           the hub runs on the Tailwind Play CDN, which only generates classes
+           it can see in the markup, so a class name assembled in JavaScript
+           renders as no styling at all. The status badge below carries the
+           voucher's state; this carries the refusal. -->
+      <template x-if="scanBlock && !detailLoading && voucher">
+        <div class="mb-5">
+          <div x-show="scanBlock.reason === 'expired'"
+            class="bg-amber-50 border border-amber-200 text-amber-800 rounded-xl p-4 text-sm font-medium"
+            x-text="scanBlock.message"></div>
+          <div x-show="scanBlock.reason === 'cancelled'"
+            class="bg-rose-50 border border-rose-200 text-rose-700 rounded-xl p-4 text-sm font-medium"
+            x-text="scanBlock.message"></div>
+          <div x-show="scanBlock.reason === 'no-balance'"
+            class="bg-sky-50 border border-sky-200 text-sky-800 rounded-xl p-4 text-sm font-medium"
+            x-text="scanBlock.message"></div>
+          <!-- A status voucher_derived_status() grew that this page has not
+               learned. Amber rather than neutral: it is a refusal, and a
+               refusal in grey reads as a caption. -->
+          <div x-show="scanBlock.reason === 'unknown'"
+            class="bg-amber-50 border border-amber-200 text-amber-800 rounded-xl p-4 text-sm font-medium"
+            x-text="scanBlock.message"></div>
+        </div>
+      </template>
 
       <div x-show="voucher && !detailLoading" class="grid md:grid-cols-3 gap-4">
 
@@ -2111,7 +2150,9 @@
           <label class="block text-[0.67rem] font-semibold text-neutral-400 uppercase tracking-wider mb-1.5">
             Amount ($) <span class="text-rose-400 normal-case tracking-normal font-normal">*</span>
           </label>
-          <input type="number" step="0.01" min="0.01" :max="voucher?.balance"
+          <!-- id is how a scan puts the cursor here. The field stays blank on
+               purpose; see openScannedCode(). -->
+          <input type="number" step="0.01" min="0.01" :max="voucher?.balance" id="redeem-amount"
             x-model="redeemAmount" placeholder="0.00"
             class="w-full border border-neutral-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-uj/20 focus:border-uj" />
           <button @click="redeemAmount = String(voucher?.balance)"
@@ -3366,6 +3407,19 @@
 
   <script>
   function staffApp() {
+    // The scan buffer and the double-trigger guard live HERE, in the closure,
+    // and deliberately not on the object below. Alpine wraps its data in a
+    // reactive Proxy; a stateful helper does not want one around it, and
+    // nothing on screen renders a half-read buffer, so making it reactive
+    // would buy nothing and cost a re-render per keystroke.
+    //
+    // Built once at construction. If scan-input.js failed to load this is
+    // null, and onScanKey() returns on its first line — no scanning, no
+    // throwing.
+    const scanBuffer = window.scanInput?.createScanBuffer?.() ?? null;
+    let lastScannedCode = '';
+    let lastScannedAt = 0;
+
     // Production talks to the payments Worker through the same-origin proxy, so
     // Cloudflare Access authenticates every call and no secret is needed.
     // Localhost has no Access in front of it, so it keeps the shared-secret path.
@@ -3465,6 +3519,9 @@
       detailLoading: false,
       detailError: '',
       detailOrigin: 'search', // where the detail view was opened from: 'search' | 'reports'
+      // Why a scan did NOT open the redeem form: { reason, message } from
+      // scanOutcome(), or null. Cleared by every route into the detail view.
+      scanBlock: null,
 
       // Redeem modal
       redeemOpen: false,
@@ -4120,16 +4177,24 @@
       },
 
       // ── Detail ───────────────────────────────────────────────────────────
-      async openVoucher(code, origin) {
+      async openVoucher(code, origin, preloaded) {
         // Only set origin on a fresh open; refresh calls (after redeem/undo/resend)
         // omit it so the "Back to …" target is preserved.
         if (origin) this.detailOrigin = origin;
         this.view = 'detail';
         this.voucher = null;
         this.detailError = '';
+        // Every route into the detail view clears the scan banner, which is why
+        // openScannedCode() sets it after calling this and never before. A
+        // banner surviving into a voucher opened by hand would explain a
+        // refusal that has nothing to do with what is on screen.
+        this.scanBlock = null;
         this.detailLoading = true;
         try {
-          this.voucher = await this.api('/v1/vouchers/' + encodeURIComponent(code));
+          // A scan has already fetched the voucher to decide where to send
+          // staff. Passing it in keeps that to one request rather than two
+          // identical ones on the way to the same screen.
+          this.voucher = preloaded || await this.api('/v1/vouchers/' + encodeURIComponent(code));
         } catch (e) {
           this.detailError = e.message;
         } finally {
@@ -5006,6 +5071,109 @@
       },
       reportRedeemedTotalPages() {
         return Math.max(1, Math.ceil((this.report?.redeemed?.length || 0) / this.PAGE_SIZE));
+      },
+
+      // ── Scanning ─────────────────────────────────────────────────────────
+      // The front-desk scanner is a USB keyboard: it types the code and presses
+      // Enter. There is no device to talk to and no event saying "a scan
+      // happened" — only characters arriving with nothing focused. The rules
+      // are in scan-input.js; this is the wiring. See
+      // docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md.
+      onScanKey(e) {
+        if (!scanBuffer) return;                       // module missing — no scanning, no throwing
+        if (this.typingSomewhere(e) || this.committedTaskOpen()) {
+          // Not our keystrokes. Drop anything half-collected too, so a code
+          // begun outside a field and finished inside one cannot be stitched
+          // together into a scan nobody made.
+          scanBuffer.reset();
+          return;
+        }
+
+        const result = scanBuffer.push(e.key);
+        if (!result) return;
+
+        if (result.type === 'code') {
+          // The scanner's Enter would otherwise reach whatever is behind it.
+          e.preventDefault();
+          this.openScannedCode(result.code);
+          return;
+        }
+
+        // Enough characters to have been a real attempt, but not a voucher
+        // code. Saying nothing here is worse than saying this: a staff member
+        // who shot the wrong side of a card would see nothing happen and
+        // conclude the scanner is broken.
+        this.showToast('That isn’t a voucher code', 'error');
+      },
+
+      typingSomewhere(e) {
+        const el = e.target || document.activeElement;
+        if (!el) return false;
+        return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA'
+          || el.tagName === 'SELECT' || el.isContentEditable === true;
+      },
+
+      // Is a modal open — a task someone has committed to? A scan must not blow
+      // past one: the type editor guards unsaved changes behind a discard
+      // prompt, and jumping to another voucher would reintroduce exactly the
+      // loss that guard exists to prevent.
+      //
+      // NOT the same question as _anyModalOpen() above, which asks "is the user
+      // busy, so do not re-fetch under them" and therefore counts the combo
+      // popovers too. A popover is not a committed task and must not block a
+      // scan — that difference is half the reason this is a separate test.
+      //
+      // The other half: this one is structural, so a modal added later is
+      // covered without anyone remembering to come back here. A flag list rots
+      // silently, and the failure mode is a scan running straight through an
+      // open dialog.
+      //
+      // getClientRects(), not offsetParent: offsetParent is null for a
+      // position:fixed element whether it is shown or hidden, so it would
+      // report every modal closed.
+      committedTaskOpen() {
+        return Array.from(document.querySelectorAll('.fixed.inset-0'))
+          .some((el) => el.getClientRects().length > 0);
+      },
+
+      // Where a scanned or typed voucher code lands. One lookup: the answer
+      // decides the destination AND is what the detail view renders.
+      async openScannedCode(code) {
+        // A scanner can double-trigger on one pull. The same code twice within
+        // a moment is that, not a second customer.
+        const now = Date.now();
+        if (code === lastScannedCode && now - lastScannedAt < 1500) return;
+        lastScannedCode = code;
+        lastScannedAt = now;
+
+        let voucher;
+        try {
+          voucher = await this.api('/v1/vouchers/' + encodeURIComponent(code));
+        } catch (err) {
+          // Stay where we are. Yanking someone onto an error screen for a
+          // mis-scan costs them whatever they were doing, and the toast says
+          // everything there is to say.
+          this.showToast(
+            err?.status === 404 ? 'No voucher ' + code : (err?.message || 'Lookup failed'),
+            'error',
+          );
+          return;
+        }
+
+        const outcome = window.scanInput.scanOutcome(voucher);
+        // openVoucher clears scanBlock, so the banner is set after it, never
+        // before. Passing the voucher we already have keeps this to one request.
+        await this.openVoucher(code, 'search', voucher);
+
+        if (outcome.action === 'redeem') {
+          this.openRedeem();
+          // Focus the amount, which is deliberately left blank: a redeem cannot
+          // be undone without a manager, so the amount stays a deliberate act
+          // rather than something a staff member confirms by momentum.
+          this.$nextTick(() => document.getElementById('redeem-amount')?.focus());
+          return;
+        }
+        this.scanBlock = outcome;
       },
 
       // ── Helpers ──────────────────────────────────────────────────────────

--- a/vouchers/scan-input.js
+++ b/vouchers/scan-input.js
@@ -1,0 +1,148 @@
+// vouchers/scan-input.js
+// Turning keystrokes from the front-desk scanner into a voucher code, and a
+// voucher into a destination. Pure on purpose — no DOM, no network — so the
+// rules are unit-testable and the page holds nothing but wiring.
+//
+// The scanner (Zebra DS2208) is a USB keyboard as far as the browser is
+// concerned: it types the code and presses Enter. There is no device to talk
+// to and no event that says "a scan happened" — only characters arriving with
+// nothing focused. See docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md
+// for why it is built this way and what was rejected.
+
+// The voucher code format is DECIDED IN THE VOUCHERS REPO — its ADR 0004, and
+// randomVoucherCode() in cloudflare/payments-worker/src/voucher-codes.js. This
+// regex is a knowing second copy of that decision, not a source of truth.
+//
+// It is duplicated rather than asked for because the alternative is a network
+// round-trip in front of every stray scan, just to be told it was not a
+// voucher. IF THE FORMAT EVER CHANGES, THIS IS THE SECOND PLACE.
+//
+// Deliberately the loose form: [A-Z0-9], not the generator's reduced alphabet
+// (which omits I, O, 0 and 1 so humans do not misread them). A code that
+// somehow contains one is a code we should still look up — the tighter test
+// would turn a lookup into a silent refusal, and the Worker is the thing that
+// actually knows whether a voucher exists.
+export const VOUCHER_CODE = /^UJ-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+
+// Migrated GAS-era vouchers kept their UUID codes and are deliberately NOT
+// matched here: those emails never carried a QR, so there is nothing to point a
+// scanner at. They are found through the search box like any other text.
+export function isScannableCode(text) {
+  return VOUCHER_CODE.test(normaliseScanned(text));
+}
+
+// Everything is normalised before it is tested, so the app depends on nothing
+// about the scanner beyond "characters, then Enter". A till with Caps Lock on,
+// or a replacement unit someone else programmed, still works.
+export function normaliseScanned(text) {
+  return typeof text === 'string' ? text.trim().toUpperCase() : '';
+}
+
+// A burst shorter than this on Enter is treated as noise and passes in silence.
+// It is a heuristic against stray keypresses, not a rule about voucher codes —
+// a real code is 12 characters and a scanned barcode of any kind is longer than
+// four. Without it, every bare Enter pressed with nothing focused would tell a
+// staff member that something is not a voucher code.
+export const MIN_MEANINGFUL_LENGTH = 4;
+
+// Guards against a buffer growing without bound if someone types at a page with
+// nothing focused. The tail is kept rather than the head: if anything useful is
+// in there, it is what arrived most recently.
+export const MAX_BUFFER = 64;
+
+// Accumulates keystrokes until Enter, then reports what it has.
+//
+// Returns null while there is nothing to say, and a result object on Enter:
+//   { type: 'code', code }        a scannable voucher code
+//   { type: 'unrecognised', text } enough characters to be a real attempt, but
+//                                  not a voucher code — worth saying so
+//
+// THE TRAP THIS EXISTS TO AVOID (measured 2026-08-25, ADR 0006): a 12-character
+// code arrives as 22 keydown events, because the scanner presses Shift before
+// every letter exactly as a person would. Appending e.key on every keydown
+// builds "ShiftUShiftJ-ShiftT…". Only single-character keys are collected.
+// Nothing else about Shift needs handling — e.key is already "U", not "u".
+export function createScanBuffer() {
+  let chars = [];
+
+  return {
+    // Pass event.key, not the event: the module stays DOM-free and a test can
+    // drive it with plain strings.
+    push(key) {
+      if (typeof key !== 'string') return null;
+
+      if (key === 'Enter') {
+        const text = normaliseScanned(chars.join(''));
+        chars = [];
+        if (text.length < MIN_MEANINGFUL_LENGTH) return null;
+        return VOUCHER_CODE.test(text)
+          ? { type: 'code', code: text }
+          : { type: 'unrecognised', text };
+      }
+
+      // Escape abandons whatever has accumulated. Cheap, and it gives a staff
+      // member a way out if a half-read scan has left junk in the buffer.
+      if (key === 'Escape') {
+        chars = [];
+        return null;
+      }
+
+      // Shift, Control, Tab, ArrowLeft, F5 — every non-printable key. Dropped
+      // rather than treated as a terminator: only Enter ends a scan, so a
+      // modifier landing mid-code cannot truncate it.
+      if (key.length !== 1) return null;
+
+      chars.push(key);
+      if (chars.length > MAX_BUFFER) chars = chars.slice(-MAX_BUFFER);
+      return null;
+    },
+
+    // What has accumulated so far. For tests and debugging; the page does not
+    // render it — a half-typed buffer on screen would be noise.
+    pending() {
+      return chars.join('');
+    },
+
+    reset() {
+      chars = [];
+    },
+  };
+}
+
+// Where a scanned or typed voucher code should land.
+//
+// Returns one of:
+//   { action: 'not-found' }
+//   { action: 'redeem' }
+//   { action: 'blocked', reason, message }
+//
+// `reason` is a key rather than a colour or a class. The hub runs on the
+// Tailwind Play CDN, which cannot generate a class name computed in JavaScript,
+// so the banner's colours are literal in the markup and gated on this key.
+export function scanOutcome(voucher) {
+  if (!voucher) return { action: 'not-found' };
+
+  // ONE test, not two. A partially redeemed voucher keeps status 'active' for
+  // as long as it has balance, and is redeemable — the "Partially redeemed"
+  // badge is informational and reads more terminal than it is. This is the same
+  // gate the Redeem button already uses, deliberately.
+  if (voucher.status === 'active') return { action: 'redeem' };
+
+  return { action: 'blocked', ...blocked(voucher.status) };
+}
+
+function blocked(status) {
+  switch (status) {
+    case 'expired':
+      return { reason: 'expired', message: 'This voucher has expired — it can no longer be redeemed.' };
+    case 'cancelled':
+      return { reason: 'cancelled', message: 'This voucher was cancelled — it can no longer be redeemed.' };
+    case 'redeemed':
+      return { reason: 'no-balance', message: 'This voucher has no balance left — it is fully redeemed.' };
+    // A status the Worker's voucher_derived_status() grew and this page has not
+    // learned yet. Refuse rather than fall through to the redeem form: an
+    // unknown status is not a licence to take money off a voucher.
+    default:
+      return { reason: 'unknown', message: 'This voucher is not redeemable.' };
+  }
+}

--- a/vouchers/test/nav-menu.test.js
+++ b/vouchers/test/nav-menu.test.js
@@ -84,7 +84,10 @@ describe('the header row collapses', () => {
   });
 
   it('keeps the primary actions in the header, out of the menu', () => {
-    for (const label of ['Search & Redeem', 'Create', 'Scan']) {
+    // 'Scan' was here as a permanently disabled "Scan coming later" placeholder.
+    // #136 shipped scanning as an ambient keystroke listener that works on every
+    // screen, so there is no Scan view to navigate to and no button to press.
+    for (const label of ['Search & Redeem', 'Create']) {
       expect(navOutsideMenu()).toMatch(label);
       expect(menuPanel()).not.toMatch(label);
     }

--- a/vouchers/test/scan-input.test.js
+++ b/vouchers/test/scan-input.test.js
@@ -1,0 +1,254 @@
+import { describe, expect, test } from 'vitest';
+import {
+  VOUCHER_CODE,
+  isScannableCode,
+  normaliseScanned,
+  createScanBuffer,
+  scanOutcome,
+  MIN_MEANINGFUL_LENGTH,
+  MAX_BUFFER,
+} from '../scan-input.js';
+
+// The keystrokes a real DS2208 sends, measured 2026-08-25 against a live
+// voucher and recorded in ADR 0006. Every letter is preceded by its own
+// ShiftLeft keydown; digits and hyphens are not. Twenty-two events for twelve
+// characters. Tests drive the buffer with THIS, not with a clean string, or
+// they prove nothing about the thing that actually happens at the counter.
+function scannerKeys(code) {
+  const keys = [];
+  for (const ch of code) {
+    if (/[A-Z]/.test(ch)) keys.push('Shift');
+    keys.push(ch);
+  }
+  keys.push('Enter');
+  return keys;
+}
+
+function feed(buffer, keys) {
+  let last = null;
+  for (const k of keys) last = buffer.push(k);
+  return last;
+}
+
+describe('the shape of a scannable code', () => {
+  test('accepts a real code', () => {
+    // Both measured live: TQYH-F8PW off a phone screen, YVZ6-H98L off another.
+    expect(isScannableCode('UJ-TQYH-F8PW')).toBe(true);
+    expect(isScannableCode('UJ-YVZ6-H98L')).toBe(true);
+  });
+
+  test('normalises before testing, so casing and stray spaces do not matter', () => {
+    expect(isScannableCode('  uj-tqyh-f8pw  ')).toBe(true);
+    expect(normaliseScanned('  uj-tqyh-f8pw  ')).toBe('UJ-TQYH-F8PW');
+  });
+
+  // The app depends on nothing about the scanner beyond "characters, then
+  // Enter". A till left on Caps Lock is the case this covers.
+  test('a lowercase burst is still a code', () => {
+    expect(isScannableCode('uj-tqyh-f8pw')).toBe(true);
+  });
+
+  test('rejects the wrong shape', () => {
+    expect(isScannableCode('UJ-TQYH-F8P')).toBe(false);    // too short
+    expect(isScannableCode('UJ-TQYH-F8PWX')).toBe(false);  // too long
+    expect(isScannableCode('UJTQYHF8PW')).toBe(false);     // hyphens gone
+    expect(isScannableCode('XX-TQYH-F8PW')).toBe(false);   // not ours
+    expect(isScannableCode('9312345678903')).toBe(false);  // a product barcode
+    expect(isScannableCode('')).toBe(false);
+  });
+
+  test('rejects a legacy UUID voucher on purpose', () => {
+    // Migrated GAS-era vouchers kept UUID codes, and those emails never carried
+    // a QR — there is nothing to scan. Widening the test would loosen it for no
+    // reachable benefit. They stay a search-box job.
+    expect(isScannableCode('3f2504e0-4f89-11d3-9a0c-0305e82c3301')).toBe(false);
+  });
+
+  // The generator omits I, O, 0 and 1 so humans do not misread them, but this
+  // test is deliberately looser than the generator. A code containing one
+  // should still be looked up — the Worker knows whether a voucher exists, and
+  // a tighter regex here would turn that lookup into a silent refusal.
+  test('does not enforce the generator’s reduced alphabet', () => {
+    expect(isScannableCode('UJ-I0O1-ABCD')).toBe(true);
+  });
+
+  test('is anchored at both ends', () => {
+    expect(VOUCHER_CODE.test('XUJ-TQYH-F8PW')).toBe(false);
+    expect(VOUCHER_CODE.test('UJ-TQYH-F8PWX')).toBe(false);
+  });
+
+  test('a non-string is not a code', () => {
+    expect(isScannableCode(null)).toBe(false);
+    expect(isScannableCode(undefined)).toBe(false);
+    expect(isScannableCode(12)).toBe(false);
+  });
+});
+
+describe('the scan buffer', () => {
+  // THE test. If this passes with the Shift keydowns interleaved, the trap that
+  // ADR 0006 records is closed.
+  test('reads a code out of the keystrokes a real scanner sends', () => {
+    const buffer = createScanBuffer();
+    const keys = scannerKeys('UJ-TQYH-F8PW');
+
+    expect(keys).toHaveLength(22);   // 12 characters, 22 events
+    expect(feed(buffer, keys)).toEqual({ type: 'code', code: 'UJ-TQYH-F8PW' });
+  });
+
+  test('says nothing until Enter arrives', () => {
+    const buffer = createScanBuffer();
+    const keys = scannerKeys('UJ-TQYH-F8PW');
+    for (const k of keys.slice(0, -1)) expect(buffer.push(k)).toBeNull();
+    expect(buffer.push('Enter')).toEqual({ type: 'code', code: 'UJ-TQYH-F8PW' });
+  });
+
+  test('drops every non-printable key rather than treating it as a terminator', () => {
+    const buffer = createScanBuffer();
+    // A modifier landing mid-code must not truncate it.
+    feed(buffer, ['U', 'J', 'Shift', '-', 'Control', 'T', 'Q', 'Y', 'H', 'ArrowLeft', '-', 'F', '8', 'P', 'F5', 'W']);
+    expect(buffer.pending()).toBe('UJ-TQYH-F8PW');
+    expect(buffer.push('Enter')).toEqual({ type: 'code', code: 'UJ-TQYH-F8PW' });
+  });
+
+  test('reports something that is not a voucher code', () => {
+    const buffer = createScanBuffer();
+    expect(feed(buffer, [...'9312345678903', 'Enter']))
+      .toEqual({ type: 'unrecognised', text: '9312345678903' });
+  });
+
+  // Without this, every bare Enter pressed with nothing focused tells a staff
+  // member that something is not a voucher code.
+  test('passes a short burst over in silence', () => {
+    const buffer = createScanBuffer();
+    expect(buffer.push('Enter')).toBeNull();
+    expect(feed(buffer, ['A', 'Enter'])).toBeNull();
+    expect(feed(buffer, [...'ABC', 'Enter'])).toBeNull();
+  });
+
+  test('speaks up at exactly the meaningful length', () => {
+    const buffer = createScanBuffer();
+    const text = 'A'.repeat(MIN_MEANINGFUL_LENGTH);
+    expect(feed(buffer, [...text, 'Enter'])).toEqual({ type: 'unrecognised', text });
+  });
+
+  test('clears itself after Enter, whatever the verdict', () => {
+    const buffer = createScanBuffer();
+    feed(buffer, [...'UJ-TQYH-F8PW', 'Enter']);
+    expect(buffer.pending()).toBe('');
+
+    feed(buffer, [...'rubbish', 'Enter']);
+    expect(buffer.pending()).toBe('');
+
+    // So a second scan is read on its own, not appended to the first.
+    expect(feed(buffer, scannerKeys('UJ-YVZ6-H98L')))
+      .toEqual({ type: 'code', code: 'UJ-YVZ6-H98L' });
+  });
+
+  test('Escape abandons what has accumulated', () => {
+    const buffer = createScanBuffer();
+    feed(buffer, [...'UJ-TQYH']);
+    expect(buffer.push('Escape')).toBeNull();
+    expect(buffer.pending()).toBe('');
+  });
+
+  test('reset() empties it', () => {
+    const buffer = createScanBuffer();
+    feed(buffer, [...'UJ-TQYH']);
+    buffer.reset();
+    expect(buffer.pending()).toBe('');
+  });
+
+  test('keeps the tail when it overflows, and drops the head', () => {
+    const buffer = createScanBuffer();
+    feed(buffer, [...'X'.repeat(MAX_BUFFER)]);
+    expect(buffer.pending()).toBe('X'.repeat(MAX_BUFFER));
+
+    // Whatever arrived most recently is what survives — if anything useful is
+    // in a runaway buffer, it is what was typed last.
+    feed(buffer, [...'UJ-TQYH-F8PW']);
+    const pending = buffer.pending();
+    expect(pending).toHaveLength(MAX_BUFFER);
+    expect(pending.endsWith('UJ-TQYH-F8PW')).toBe(true);
+    expect(pending.startsWith('X'.repeat(MAX_BUFFER - 12))).toBe(true);
+    expect(pending).not.toContain('X'.repeat(MAX_BUFFER));
+  });
+
+  test('ignores a non-string key', () => {
+    const buffer = createScanBuffer();
+    expect(buffer.push(null)).toBeNull();
+    expect(buffer.push(undefined)).toBeNull();
+    expect(buffer.pending()).toBe('');
+  });
+
+  test('two buffers do not share state', () => {
+    const a = createScanBuffer();
+    const b = createScanBuffer();
+    feed(a, [...'UJ-TQYH']);
+    expect(b.pending()).toBe('');
+  });
+});
+
+describe('where a scanned voucher lands', () => {
+  test('an active voucher goes to the redeem form', () => {
+    expect(scanOutcome({ status: 'active', balance: 50 })).toEqual({ action: 'redeem' });
+  });
+
+  // The reason this is one test and not two. A partially redeemed voucher keeps
+  // status 'active' while it has balance; the "Partially redeemed" badge is
+  // informational and reads more terminal than it is.
+  test('a partially redeemed voucher is still redeemable', () => {
+    expect(scanOutcome({ status: 'active', balance: 20, value: 50, last_redeemed_amount: 30 }))
+      .toEqual({ action: 'redeem' });
+  });
+
+  // An unsent voucher is active and redeemable — a member must not lose an
+  // entitlement because an email bounced.
+  test('an unsent voucher is redeemable', () => {
+    expect(scanOutcome({ status: 'active', balance: 50, email_sent: false }))
+      .toEqual({ action: 'redeem' });
+  });
+
+  test('no voucher is not-found', () => {
+    expect(scanOutcome(null)).toEqual({ action: 'not-found' });
+    expect(scanOutcome(undefined)).toEqual({ action: 'not-found' });
+  });
+
+  test('each blocked status carries its own reason', () => {
+    expect(scanOutcome({ status: 'expired' }).reason).toBe('expired');
+    expect(scanOutcome({ status: 'cancelled' }).reason).toBe('cancelled');
+    expect(scanOutcome({ status: 'redeemed' }).reason).toBe('no-balance');
+  });
+
+  test('every blocked outcome says why, in words a customer can hear', () => {
+    for (const status of ['expired', 'cancelled', 'redeemed']) {
+      const out = scanOutcome({ status });
+      expect(out.action).toBe('blocked');
+      expect(out.message).toMatch(/redeem/i);
+      expect(out.message.length).toBeGreaterThan(20);
+    }
+  });
+
+  // An unknown status is not a licence to take money off a voucher. If the
+  // Worker's voucher_derived_status() grows a state this page has not learned,
+  // it must refuse rather than fall through.
+  test('an unrecognised status is refused, not waved through', () => {
+    const out = scanOutcome({ status: 'on_hold' });
+    expect(out.action).toBe('blocked');
+    expect(out.reason).toBe('unknown');
+  });
+
+  test('a voucher with no status at all is refused', () => {
+    expect(scanOutcome({ balance: 50 }).action).toBe('blocked');
+  });
+
+  // The reason must stay a key. The hub runs on the Tailwind Play CDN, which
+  // cannot generate a class name computed in JavaScript, so the banner colours
+  // are literal in the markup and gated on this value.
+  test('the reason is a key, not a colour or a class', () => {
+    for (const status of ['expired', 'cancelled', 'redeemed', 'whatever']) {
+      const { reason } = scanOutcome({ status });
+      expect(reason).toMatch(/^[a-z-]+$/);
+      expect(reason).not.toMatch(/amber|rose|sky|bg-|text-/);
+    }
+  });
+});

--- a/vouchers/test/scan-wiring.test.js
+++ b/vouchers/test/scan-wiring.test.js
@@ -203,6 +203,38 @@ describe('where a scan lands', () => {
   });
 });
 
+// Not scanning as such, but it exists BECAUSE of scanning: a scan reaches this
+// modal without staff having read the detail page, so the modal has to say what
+// it is about to take money off.
+describe('the redeem modal identifies the voucher', () => {
+  const modal = () => between('<div x-show="redeemOpen"', 'x-text="redeemError"');
+
+  test('it shows the code, the customer and the type', () => {
+    const html = modal();
+    expect(html).toContain('x-text="voucher?.voucher_id"');
+    expect(html).toContain("voucher?.customer_name || 'No name on file'");
+    expect(html).toContain('voucher?._type_name || voucher?.voucher_type_id');
+  });
+
+  // The balance was already there and is the one thing that does NOT identify
+  // the voucher — two vouchers of the same type carry the same balance.
+  test('the balance is still there, and is not the identity', () => {
+    expect(modal()).toContain('fmtMoney(voucher?.balance)');
+  });
+
+  test('the item shows only when the type has one', () => {
+    const html = modal();
+    expect(html).toContain('<template x-if="voucher?._item_name || voucher?.voucher_item_id">');
+  });
+
+  // The name is the assertion that matters. A voucher of the right type and
+  // value belonging to the wrong person is what this catches, and nothing else
+  // in the modal would.
+  test('a nameless voucher says so rather than rendering blank', () => {
+    expect(modal()).toContain("'No name on file'");
+  });
+});
+
 describe('the refusal banner', () => {
   const banner = () => between('<template x-if="scanBlock && !detailLoading && voucher">', '</template>');
 

--- a/vouchers/test/scan-wiring.test.js
+++ b/vouchers/test/scan-wiring.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// scan-input.js is a real module and is called directly in scan-input.test.js.
+// These read the page source instead. Be clear about what that proves: they
+// assert the markup ASKS the right question and wires the listener where it
+// should be, not that a browser dispatches anything. What they catch is the
+// listener being dropped, the suppression rules being loosened, or the camera
+// scanner coming back.
+
+const page = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+describe('the camera scanner is gone', () => {
+  // It was unreachable dead code — goScan() had no caller anywhere in the repo
+  // — and it loaded a third-party script from unpkg onto a page behind Access.
+  // Deleted in #136; ADR 0006 records why. These stop it drifting back.
+  test('no html5-qrcode script is loaded', () => {
+    expect(page).not.toContain('html5-qrcode');
+    expect(page).not.toContain('Html5Qrcode');
+  });
+
+  test('no unpkg script of any kind is loaded', () => {
+    expect(page).not.toContain('unpkg.com');
+  });
+
+  test('there is no scan view, and nothing left to route to it', () => {
+    expect(page).not.toContain("view==='scan'");
+    expect(page).not.toContain('qr-reader');
+    for (const gone of ['goScan', 'startScanner', 'stopScannerIfActive', 'lookupManual', 'manualCode']) {
+      expect(page).not.toContain(gone);
+    }
+  });
+});

--- a/vouchers/test/scan-wiring.test.js
+++ b/vouchers/test/scan-wiring.test.js
@@ -203,6 +203,50 @@ describe('where a scan lands', () => {
   });
 });
 
+// Rule 4 of ADR 0006: a voucher code goes to the redeem form however it
+// arrived. Physical cards carry a printed code and no QR, so typing is the
+// counter path for a whole class of vouchers.
+describe('a typed code lands where a scanned one does', () => {
+  const submitSearch = () => between('async submitSearch() {', '\n      },');
+
+  test('the search form submits through submitSearch()', () => {
+    expect(page).toContain('@submit.prevent="submitSearch()"');
+  });
+
+  test('a code goes to the same place a scan does, and stops there', () => {
+    const fn = submitSearch();
+    expect(fn).toContain('isScannableCode');
+
+    // The return is the load-bearing half. Without it the jump navigates to the
+    // detail view and search() then sets the view straight back to the list,
+    // so the redeem form appears and vanishes. Asserted INSIDE the branch —
+    // an indexOf comparison passes vacuously when the return is gone (-1 is
+    // less than everything), which is how this escaped the first time.
+    const branch = fn.slice(fn.indexOf('isScannableCode'), fn.indexOf('}', fn.indexOf('isScannableCode')));
+    expect(branch).toContain('await this.openScannedCode(code);');
+    expect(branch).toContain('return;');
+  });
+
+  test('anything that is not a code is still a search', () => {
+    expect(submitSearch()).toContain('await this.search();');
+  });
+
+  // search() is also called on load, by the dashboard drill-downs and by the
+  // background refresh. A jump inside it would fire on paths nobody asked for
+  // — including a return to the search view with a code still in the box,
+  // which would bounce staff straight back out of it.
+  test('search() itself never jumps', () => {
+    const fn = between('async search() {', '\n      },');
+    expect(fn).not.toContain('openScannedCode');
+    expect(fn).not.toContain('isScannableCode');
+  });
+
+  test('the load and drill-down paths still call search(), not submitSearch()', () => {
+    expect(between('showActiveVouchers() {', '\n      },')).toContain('await this.search();');
+    expect(page).not.toMatch(/this\.submitSearch\(\)/);
+  });
+});
+
 // Not scanning as such, but it exists BECAUSE of scanning: a scan reaches this
 // modal without staff having read the detail page, so the modal has to say what
 // it is about to take money off.

--- a/vouchers/test/scan-wiring.test.js
+++ b/vouchers/test/scan-wiring.test.js
@@ -10,6 +10,17 @@ import { readFileSync } from 'node:fs';
 
 const page = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
 
+function between(start, end) {
+  const from = page.indexOf(start);
+  if (from < 0) throw new Error(`could not find ${start} in index.html`);
+  const to = page.indexOf(end, from + start.length);
+  if (to < 0) throw new Error(`could not find ${end} after ${start}`);
+  return page.slice(from, to);
+}
+
+const onScanKey = () => between('onScanKey(e) {', '\n      },');
+const openScannedCode = () => between('async openScannedCode(code) {', '\n      },');
+
 describe('the camera scanner is gone', () => {
   // It was unreachable dead code — goScan() had no caller anywhere in the repo
   // — and it loaded a third-party script from unpkg onto a page behind Access.
@@ -29,5 +40,198 @@ describe('the camera scanner is gone', () => {
     for (const gone of ['goScan', 'startScanner', 'stopScannerIfActive', 'lookupManual', 'manualCode']) {
       expect(page).not.toContain(gone);
     }
+  });
+});
+
+describe('the listener is wired', () => {
+  test('the module is imported and published for the component to read', () => {
+    expect(page).toMatch(/import \* as scanInput from '\.\/scan-input\.js\?v=\d+'/);
+    expect(page).toContain('window.scanInput = scanInput;');
+  });
+
+  // Bound in the markup rather than added in init(). The page carries
+  // x-data + x-init="init()", which Alpine runs TWICE — once itself and once
+  // for the directive — so a listener attached there would double-handle every
+  // keystroke. A directive binds once per element whatever init does.
+  test('keydown is bound on the root, at window scope', () => {
+    expect(page).toContain('@keydown.window="onScanKey($event)"');
+    expect(between('x-data="staffApp()"', '>')).toContain('@keydown.window');
+  });
+
+  test('a missing module disables scanning instead of throwing', () => {
+    // Every keystroke in the hub goes through this. Throwing here would break
+    // typing, not just scanning.
+    expect(page).toMatch(/const scanBuffer = window\.scanInput\?\.createScanBuffer\?\.\(\)/);
+    expect(onScanKey()).toMatch(/^\s*if \(!scanBuffer\) return;/m);
+  });
+
+  // Alpine wraps its data in a reactive Proxy. The buffer is stateful and
+  // nothing renders it, so it lives in the closure — see the comment there.
+  test('the buffer is a closure variable, not component data', () => {
+    const data = between('function staffApp() {', 'onScanKey(e) {');
+    expect(data).toMatch(/^\s*const scanBuffer =/m);
+    expect(page).not.toMatch(/scanBuffer:/);
+    expect(page).not.toMatch(/this\.scanBuffer/);
+  });
+});
+
+describe('when a scan is ignored', () => {
+  test('typing in a field and an open modal both suppress it', () => {
+    expect(onScanKey()).toContain('if (this.typingSomewhere(e) || this.committedTaskOpen())');
+  });
+
+  // A code begun outside a field and finished inside one must not be stitched
+  // together into a scan nobody made.
+  test('a suppressed keystroke also clears what was half-collected', () => {
+    const guard = between('if (this.typingSomewhere(e) || this.committedTaskOpen())', 'return;');
+    expect(guard).toContain('scanBuffer.reset()');
+  });
+
+  // The page already had _anyModalOpen(), a flag list that asks a DIFFERENT
+  // question — "is the user busy, so do not re-fetch under them" — and counts
+  // the combo popovers. A popover must not block a scan. If these two ever
+  // collapse into one, a scan starts being swallowed by an open dropdown.
+  test('the scan guard is not the background-refresh guard', () => {
+    expect(page).toContain('_anyModalOpen()');
+    expect(onScanKey()).not.toContain('_anyModalOpen');
+    expect(between('committedTaskOpen() {', '\n      },')).not.toContain('statusOpen');
+  });
+
+  test('typing is any editable target, not just INPUT', () => {
+    const fn = between('typingSomewhere(e) {', '\n      },');
+    for (const tag of ['INPUT', 'TEXTAREA', 'SELECT']) expect(fn).toContain(tag);
+    expect(fn).toContain('isContentEditable');
+  });
+
+  // Structural detection, so a modal added later is covered without anyone
+  // remembering to come back. A list of *Open flags would silently rot — and
+  // would have to exclude the combo popovers, which are not modals.
+  test('modals are found structurally, not by listing flags', () => {
+    const fn = between('committedTaskOpen() {', '\n      },');
+    expect(fn).toContain(".querySelectorAll('.fixed.inset-0')");
+    expect(fn).not.toMatch(/Open\b.*\|\|/);
+  });
+
+  // offsetParent is null for a position:fixed element whether it is shown or
+  // hidden, so it would report every modal closed and defeat the whole guard.
+  test('visibility is tested with getClientRects, not offsetParent', () => {
+    const fn = between('committedTaskOpen() {', '\n      },');
+    expect(fn).toContain('getClientRects().length > 0');
+    expect(fn).not.toContain('offsetParent');
+  });
+
+  // The guard is only as good as its assumption that every modal is built this
+  // way. If one is ever built differently, a scan runs straight through it.
+  test('the modals the guard must catch are all .fixed.inset-0', () => {
+    for (const flag of [
+      'redeemOpen', 'notesOpen', 'resendOpen', 'undoOpen', 'cancelOpen',
+      'restoreOpen', 'deleteOpen', 'discardOpen', 'typeEditorOpen',
+    ]) {
+      const at = page.indexOf(`x-show="${flag}"`);
+      expect(at, `${flag} is not in the page`).toBeGreaterThan(-1);
+      expect(page.slice(at, at + 260), `${flag} is not a .fixed.inset-0 modal`)
+        .toContain('fixed inset-0');
+    }
+  });
+
+  test('the page has not grown a modal style the guard cannot see', () => {
+    // A rough census. It fails loudly if the modal count moves a long way from
+    // the shape this guard was written against.
+    const containers = (page.match(/class="fixed inset-0/g) || []).length;
+    expect(containers).toBeGreaterThanOrEqual(15);
+  });
+});
+
+describe('where a scan lands', () => {
+  test('a repeat of the same code within a moment is one pull, not two customers', () => {
+    const fn = openScannedCode();
+    expect(fn).toContain('lastScannedCode');
+    expect(fn).toMatch(/now - lastScannedAt < \d+/);
+  });
+
+  test('one lookup decides the destination and feeds the detail view', () => {
+    const fn = openScannedCode();
+    expect((fn.match(/this\.api\(/g) || [])).toHaveLength(1);
+    expect(fn).toContain("await this.openVoucher(code, 'search', voucher)");
+  });
+
+  // Yanking someone onto an error screen for a mis-scan costs them whatever
+  // they were doing.
+  test('a lookup that fails stays put and says so', () => {
+    const fn = openScannedCode();
+    const failure = fn.slice(fn.indexOf('} catch (err) {'), fn.indexOf('const outcome'));
+    expect(failure).toContain("'No voucher '");
+    expect(failure).toContain("'error'");
+    expect(failure).toContain('return;');
+    expect(failure).not.toContain('openVoucher');
+  });
+
+  test('404 is told apart from a real failure', () => {
+    expect(openScannedCode()).toContain('err?.status === 404');
+  });
+
+  test('an active voucher opens the redeem form with the cursor in the amount', () => {
+    const fn = openScannedCode();
+    expect(fn).toContain("if (outcome.action === 'redeem')");
+    expect(fn).toContain('this.openRedeem();');
+    expect(fn).toContain("getElementById('redeem-amount')?.focus()");
+  });
+
+  // Pre-filling the balance would make a partial redeem the path you have to
+  // notice. A redeem cannot be undone without a manager.
+  test('the scan never pre-fills the amount', () => {
+    expect(openScannedCode()).not.toContain('redeemAmount');
+    expect(between('openRedeem() {', '\n      },')).toContain("this.redeemAmount = '';");
+    expect(page).toContain('id="redeem-amount"');
+  });
+
+  test('anything else sets the banner instead', () => {
+    expect(openScannedCode()).toContain('this.scanBlock = outcome;');
+  });
+
+  // The banner must not survive into a voucher opened by hand, where it would
+  // explain a refusal that has nothing to do with what is on screen.
+  test('every route into the detail view clears the banner first', () => {
+    const fn = between('async openVoucher(code, origin, preloaded) {', '\n      },');
+    expect(fn).toContain('this.scanBlock = null;');
+    expect(fn.indexOf('this.scanBlock = null;')).toBeLessThan(fn.indexOf('this.detailLoading = true;'));
+  });
+
+  test('the preloaded voucher is used rather than fetched again', () => {
+    const fn = between('async openVoucher(code, origin, preloaded) {', '\n      },');
+    expect(fn).toContain('preloaded || await this.api(');
+  });
+});
+
+describe('the refusal banner', () => {
+  const banner = () => between('<template x-if="scanBlock && !detailLoading && voucher">', '</template>');
+
+  test('each reason has its own colour', () => {
+    const html = banner();
+    for (const [reason, tone] of [
+      ['expired', 'amber'],
+      ['cancelled', 'rose'],
+      ['no-balance', 'sky'],
+      ['unknown', 'amber'],
+    ]) {
+      expect(html).toContain(`scanBlock.reason === '${reason}'`);
+      expect(html).toMatch(new RegExp(`scanBlock\\.reason === '${reason}'[^]*?bg-${tone}-50`));
+    }
+  });
+
+  // Never grey. A refusal in neutral tones reads as a caption rather than an
+  // answer, and this is the thing a staff member reads out to a customer.
+  test('no variant is neutral', () => {
+    expect(banner()).not.toMatch(/bg-neutral-|text-neutral-/);
+  });
+
+  // The Tailwind Play CDN only generates classes it can see in the markup, so
+  // a class name assembled in JavaScript renders as no styling at all.
+  test('the colours are literal, not computed', () => {
+    expect(banner()).not.toContain(':class');
+  });
+
+  test('it renders the reason in words, from the module', () => {
+    expect(banner()).toContain('x-text="scanBlock.message"');
   });
 });

--- a/vouchers/test/scan-wiring.test.js
+++ b/vouchers/test/scan-wiring.test.js
@@ -34,6 +34,18 @@ describe('the camera scanner is gone', () => {
     expect(page).not.toContain('unpkg.com');
   });
 
+  // Scanning is ambient — every screen, no navigation, nothing to switch on. A
+  // button would imply you have to press something first, which is exactly what
+  // the old disabled "Scan coming later" placeholder trained staff to think.
+  test('there is no Scan control in the header', () => {
+    const nav = between('<nav class="flex flex-col gap-1.5 sm:items-end">', '</nav>');
+    expect(nav).not.toMatch(/>\s*Scan\s*</);
+    // The attribute, not the phrase — the comment that replaced the button
+    // quotes the old tooltip, and pinning the words would fail on the
+    // explanation rather than on the control.
+    expect(page).not.toContain('title="Scan coming later"');
+  });
+
   test('there is no scan view, and nothing left to route to it', () => {
     expect(page).not.toContain("view==='scan'");
     expect(page).not.toContain('qr-reader');

--- a/vouchers/test/search-freshness.test.js
+++ b/vouchers/test/search-freshness.test.js
@@ -76,10 +76,13 @@ describe('every route into the search view goes through goSearch()', () => {
     expect(direct).toEqual([]);
   });
 
-  test('the header nav and the scanner both call it', () => {
+  // The scan view used to be the second route in here. It was deleted in #136:
+  // it had no caller anywhere in the repo, so it was unreachable dead code, and
+  // scanning is now a global keystroke listener with no screen of its own (ADR
+  // 0006). The nav button is the only route left.
+  test('the header nav calls it', () => {
     const navButton = between('<nav class="flex flex-col gap-1.5 sm:items-end">', 'goCreate()');
     expect(navButton).toMatch(/@click="goSearch\(\)/);
-    expect(between("<div x-show=\"view==='scan'\">", '</button>')).toMatch(/goSearch\(\)/);
   });
 
   test('leaving the detail view returns through one shared path', () => {


### PR DESCRIPTION
Closes #136.

The front-desk Zebra DS2208 now reaches the voucher hub. Scan a voucher off a customer's phone and the redeem form opens on it.

**Draft on purpose: `main` is production, so merging is deploying, and the live check at the till hasn't happened yet.** Everything below was verified against a stubbed API in a real browser, not against the counter.

## What it does

| Voucher state | Where a scan lands |
|---|---|
| `active` (**including partially redeemed**) | Detail view, redeem modal open, **amount blank, focus in amount** |
| expired | Detail view, amber banner |
| cancelled | Detail view, rose banner |
| no balance left | Detail view, sky banner |
| well-formed, no such voucher | Stays put, "No voucher UJ-XXXX-XXXX" |
| not a voucher code | Stays put, "That isn't a voucher code" |

A code **typed** into the search box goes to exactly the same place. Physical cards carry a printed code and no QR, so typing is the counter path for a whole class of vouchers, and two rules for one thing is how it drifts.

## Things worth a reviewer's attention

**The scanner presses Shift before every letter.** A 12-character code arrives as 22 keydown events — measured on the real unit, not assumed. Appending `e.key` on each keydown builds `ShiftUShiftJ-ShiftT…`, so the buffer collects only single-character keys. The unit tests drive it with those 22 events rather than a clean string, which is the only way they prove anything about the counter.

**The listener is bound as a directive, not in `init()`.** The page carries `x-data` plus `x-init="init()"`, which Alpine runs twice — a listener attached there would double-handle every keystroke.

**`committedTaskOpen()` is deliberately not the existing `_anyModalOpen()`.** That one asks "is the user busy, so don't re-fetch under them" and counts the combo popovers. A popover is not a committed task and must not swallow a scan. The new one is also structural — it looks for a visible `.fixed.inset-0` rather than listing seventeen `*Open` flags — so a modal added later is covered without anyone remembering to come back. `getClientRects()` rather than `offsetParent`, which is null for a fixed element whether shown or hidden.

**The amount is not pre-filled.** Pre-filling the balance would be fewer keystrokes and would make a partial redeem the path you have to *notice*. A redeem cannot be undone without a manager.

**The code regex is a knowing second copy** of the format decided in the vouchers repo (its ADR 0004), commented as such. Asking the Worker instead would put a network round-trip in front of every stray scan.

**The camera scan view is deleted.** `goScan()` had no caller anywhere in the repo — it was unreachable dead code — so nothing staff can currently reach is lost. It also drops a third-party script loaded from unpkg onto a page behind Access.

## Verification

- **310 tests, 309 pass.** The one failure, `version.test.js > falls back to dev outside a git repository`, fails identically on a clean `main` — it predates this branch and is untouched by it.
- **29 unit tests** on `scan-input.js`, driven with the measured keystroke sequence.
- **32 source-pinning tests** on the wiring, the modal identity, the banner and the typed-code route.
- **Mutation-tested.** Six deliberate breakages — dropping the single-char filter, widening the active check, removing the modal guard, greying the banner, dropping the amount focus, removing the customer name — each killed tests. A seventh survived: removing the `return` after the typed-code jump. That test asserted with `indexOf`, which passes vacuously at `-1`. Fixed, re-run, killed.
- **Driven in a headless browser** against a stubbed API: an active voucher opens the redeem form with a blank amount and the cursor in it; expired renders exactly one amber banner and no redeem form; cancelled renders rose; a scan while a modal is open issues zero requests; typing in the search box issues zero; a double-trigger on one code is one lookup; a 404 stays put and names the code.

## Still to do at the till

Scan a real voucher off a phone, confirm the redeem form opens, and confirm an expired or cancelled voucher shows its banner. Setup and troubleshooting are in [`docs/scanner-setup.md`](docs/scanner-setup.md); the design and its rejected alternatives are in [ADR 0006](docs/adr/0006-voucher-scanning-is-a-keyboard-wedge.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph1X5172RRVMrbH2CAYfk
