### PR TITLE
Voucher hub: delete the dead QR script and its leftovers (#139)

### DIFF
--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -79,7 +79,6 @@
     window.scanInput = scanInput;
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
   <style>
     [x-cloak] { display: none !important; }
     :root {
@@ -3559,7 +3558,6 @@
       notesLoading: false,
       notesError: '',
 
-      qrDataUrl: '',
 
       // Resend email modal
       resendOpen: false,
@@ -4245,14 +4243,6 @@
         } finally {
           this.detailLoading = false;
         }
-        if (this.voucher) this.$nextTick(() => this.renderQr());
-      },
-
-      renderQr() {
-        if (!this.voucher || typeof QRCode === 'undefined') return;
-        QRCode.toDataURL(this.voucher.voucher_id, { width: 164, margin: 1 }, (err, url) => {
-          if (!err) this.qrDataUrl = url;
-        });
       },
 
       // After a redeem/undo, keep the search results list (which the staff member

--- a/vouchers/test/third-party-scripts.test.js
+++ b/vouchers/test/third-party-scripts.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Every script the voucher pages load from someone else's server, pinned as a
+// list. The point is not the list — it is that adding to it has to be a
+// deliberate edit here, with a human checking the URL actually resolves.
+//
+// This exists because of #139. The hub loaded
+// cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js, which 404s: that
+// version of the package ships no build/ directory at all. Nothing broke
+// loudly — the script simply never arrived, and the dead code behind it
+// (renderQr, qrDataUrl) had already lost its markup in 9b28f87 two months
+// earlier, so there was nothing on screen to notice was missing.
+//
+// These tests do NOT fetch anything. A test that hits the network fails on a
+// flaky connection and passes on a warm cache, which is the opposite of what
+// this needs to be.
+
+const PAGES = ['index.html', 'stats.html', 'unsubscribes.html'];
+
+// url -> why it is here. Checked live on 2026-08-25.
+const ALLOWED = {
+  'https://cdn.tailwindcss.com': 'Tailwind Play CDN — the pages have no build step',
+  'https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js': 'Alpine, the component runtime',
+  'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js': 'Chart.js, stats page only',
+};
+
+function externalUrls(file) {
+  const html = readFileSync(new URL('../' + file, import.meta.url), 'utf8');
+  return [...html.matchAll(/<(?:script|link)\b[^>]*?(?:src|href)="(https?:\/\/[^"]+)"/g)].map((m) => m[1]);
+}
+
+describe('third-party scripts', () => {
+  for (const page of PAGES) {
+    test(`${page} loads nothing unexpected`, () => {
+      for (const url of externalUrls(page)) {
+        expect(ALLOWED[url], `${page} loads an unlisted third-party URL: ${url}`).toBeDefined();
+      }
+    });
+  }
+
+  // The specific corpse from #139. Named so a copy-paste of the old tag from
+  // git history, or from another repo, fails rather than silently 404ing.
+  test('the dead qrcode CDN pin is gone for good', () => {
+    for (const page of PAGES) {
+      const html = readFileSync(new URL('../' + page, import.meta.url), 'utf8');
+      expect(html).not.toContain('qrcode@1.5.3');
+      expect(html).not.toContain('build/qrcode.min.js');
+    }
+  });
+
+  // A version-pinned CDN path is the failure mode #139 was: the package still
+  // exists, the version still exists, and the FILE does not. Keeping the list
+  // small is the only real defence, so this fails loudly if it grows.
+  test('the list stays short enough to check by hand', () => {
+    expect(Object.keys(ALLOWED)).toHaveLength(3);
+  });
+});
+
+describe('the detail-view QR is gone, not half-gone', () => {
+  // 9b28f87 removed the QR section from the detail view on purpose but left the
+  // state, the method, the $nextTick that called it and the script tag behind.
+  // Dead code that looks like a feature is what made #139 read as a broken QR
+  // rather than as leftovers.
+  const hub = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+  test('no leftovers of the removed QR remain', () => {
+    for (const corpse of ['qrDataUrl', 'renderQr', 'QRCode']) {
+      expect(hub).not.toContain(corpse);
+    }
+  });
+});


### PR DESCRIPTION
Closes #139.

The hub loaded `cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js`, which **404s** — that version of the package ships no `build/` directory at all, and `1.4.4` was the last one carrying `build/qrcode.min.js`. The *unpinned* URL works (it resolves to 1.5.1 and jsDelivr minifies on the fly), which is almost certainly why the line looked correct when it was written.

**But the QR was not broken — it was already gone.** `9b28f87` (2026-06-19, *"refactor: remove QR section, move Actions+History to right column on voucher detail"*) deleted the QR section from the detail view on purpose, taking `<img :src="qrDataUrl">` with it, and left behind:

- `qrDataUrl: ''` state
- `renderQr()`
- the `$nextTick(() => this.renderQr())` in `openVoucher()`
- the `<script>` tag

Nothing has bound `qrDataUrl` for two months. So fixing the version pin — which is what #139 originally proposed, and I wrote that issue — would have restored a working script for code that cannot render anything. **All four leftovers are deleted instead.** The issue is corrected in a comment.

If a QR on the staff detail view is wanted again, that is a feature request against a decision already taken, not this bug.

## The new test

`test/third-party-scripts.test.js` pins the complete list of scripts the three voucher pages load from someone else's server:

| URL | Why |
|---|---|
| `cdn.tailwindcss.com` | Tailwind Play CDN — the pages have no build step |
| `cdn.jsdelivr.net/npm/alpinejs@3.x.x/…` | Alpine, the component runtime |
| `cdn.jsdelivr.net/npm/chart.js@4.4.1/…` | Chart.js, stats page only |

Adding to that list now has to be a deliberate edit, with a human checking the URL resolves. It **fetches nothing** — a test that hits the network fails on a flaky connection and passes on a warm cache, which is the opposite of what this needs. All three were checked live while writing it, along with the "also worth checking" item from the issue: no other page carries a dead pin.

A version-pinned CDN path is the exact failure mode here — the package exists, the version exists, and the *file* does not. Keeping the list short is the only real defence, so the test fails if it grows past three.

## Verification

- **317 tests, 316 pass.** The one failure, `version.test.js > falls back to dev outside a git repository`, fails identically on a clean `main` and predates this branch.
- **Mutation-tested.** Putting the dead `qrcode@1.5.3` tag back → 2 failures. Adding an unlisted CDN script → 1 failure.
- **Driven in a headless browser** against a stubbed API: only Tailwind and Alpine load, zero JS errors, the detail view opens cleanly now that the `$nextTick(renderQr)` is gone, and scanning still works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph1X5172RRVMrbH2CAYfk
