### PR TITLE
docs(school-booking): the lead time is an operator override, not a law (#142)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -734,30 +734,38 @@ keep.
 
 The **one-day minimum** between booking and a School Session starting,
 server-enforced and knowable client-side from the event start. A selected event
-inside it stops the run before any write — **unless the operator overrides it for
-that session**.
-
-The minimum is a *lift-able* Clubworx booking restriction, not a property of
-time: a manager can remove it on the specific conflicted class, run the bookings,
-and put it back. So a too-soon session can be kept by an operator who confirms
-they have done that. The override is **per session**, never for a whole run; the
-session stays visible as overridden rather than disappearing; and it applies only
-to the lead time — an unreadable start time or an already-started session is
-still a hard-stop. See [ADR 0007](docs/adr/0007-lead-time-is-an-operator-override.md).
-
-The rule is enforced **twice, independently** — the picker blocks, and the write
-chain re-checks per student as a backstop. An override therefore travels to the
-Worker as the **explicit list of acknowledged event ids**, so everything nobody
-acknowledged is still refused. Never a run-wide flag: a session that crosses into
-the lead time between selection and the write must still be caught.
+inside it hard-stops the run before any write.
 
 Staff must never meet Clubworx's own message here — *"Sorry! This class is now
 closed for bookings."* — which names no cause and reads like a capacity problem.
 
-*Avoid*: treating a lifted restriction as spent once the run ends. The lasting
-damage in this whole area is a **class left open to public booking** because
-nobody put the restriction back, which is why the run reminds and why the
-reminder is in the run record.
+The rule is enforced **twice, independently**: session selection raises the
+blocker, and the write chain re-checks per student as a backstop before any
+write. Neither is the whole rule, and the minimum itself is defined once and
+re-exported to the write chain.
+
+> **Becoming an operator override — decided 2026-08-25, not yet built**
+> ([ADR 0007](docs/adr/0007-lead-time-is-an-operator-override.md),
+> [#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#146](https://github.com/urbanjungleirc/staff-site/issues/146)).
+> Until those land, the hard-stop above is the whole truth of what the tool does.
+>
+> The minimum is a *lift-able* Clubworx booking restriction, not a property of
+> time: a manager can remove it on the specific conflicted class, run the
+> bookings, and put it back. So a too-soon session will be keepable by an
+> operator who confirms they have done that — **per session**, never for a whole
+> run, with the session staying visible as overridden rather than disappearing,
+> and only for the lead time. An unreadable start time or an already-started
+> session stays a hard-stop either way.
+>
+> Because the rule is enforced twice, an override travels to the Worker as the
+> **explicit list of acknowledged event ids**, so everything nobody acknowledged
+> is still refused. Never a run-wide flag: a session that crosses into the lead
+> time between selection and the write must still be caught.
+>
+> *Avoid*, once it is built: treating a lifted restriction as spent when the run
+> ends. The lasting damage in this whole area is a **class left open to public
+> booking** because nobody put the restriction back, which is why the run will
+> remind and why the reminder belongs in the run record.
 
 ### Unknown refusal
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -734,10 +734,30 @@ keep.
 
 The **one-day minimum** between booking and a School Session starting,
 server-enforced and knowable client-side from the event start. A selected event
-inside it hard-stops the run before any write.
+inside it stops the run before any write — **unless the operator overrides it for
+that session**.
+
+The minimum is a *lift-able* Clubworx booking restriction, not a property of
+time: a manager can remove it on the specific conflicted class, run the bookings,
+and put it back. So a too-soon session can be kept by an operator who confirms
+they have done that. The override is **per session**, never for a whole run; the
+session stays visible as overridden rather than disappearing; and it applies only
+to the lead time — an unreadable start time or an already-started session is
+still a hard-stop. See [ADR 0007](docs/adr/0007-lead-time-is-an-operator-override.md).
+
+The rule is enforced **twice, independently** — the picker blocks, and the write
+chain re-checks per student as a backstop. An override therefore travels to the
+Worker as the **explicit list of acknowledged event ids**, so everything nobody
+acknowledged is still refused. Never a run-wide flag: a session that crosses into
+the lead time between selection and the write must still be caught.
 
 Staff must never meet Clubworx's own message here — *"Sorry! This class is now
 closed for bookings."* — which names no cause and reads like a capacity problem.
+
+*Avoid*: treating a lifted restriction as spent once the run ends. The lasting
+damage in this whole area is a **class left open to public booking** because
+nobody put the restriction back, which is why the run reminds and why the
+reminder is in the run record.
 
 ### Unknown refusal
 

--- a/docs/adr/0007-lead-time-is-an-operator-override.md
+++ b/docs/adr/0007-lead-time-is-an-operator-override.md
@@ -1,0 +1,153 @@
+# ADR 0007 — the lead time is an operator override, not a law
+
+- **Status**: Accepted — pending implementation ([#143](https://github.com/urbanjungleirc/staff-site/issues/143), [#144](https://github.com/urbanjungleirc/staff-site/issues/144), [#145](https://github.com/urbanjungleirc/staff-site/issues/145), [#146](https://github.com/urbanjungleirc/staff-site/issues/146))
+- **Date**: 2026-08-25
+- **Context**: school group booking ([#138](https://github.com/urbanjungleirc/staff-site/issues/138)); design spec [`2026-08-19-school-group-booking-design.md`](../superpowers/specs/2026-08-19-school-group-booking-design.md) §11, D9
+
+> Reverses the hard-stop half of D9. The other half of D9 — that the tool never
+> drops a too-soon session by itself, and that staff never meet Clubworx's own
+> message — stands unchanged and is load-bearing here.
+
+## Context
+
+A School Group Booking run refuses any selected School Session starting inside
+the **lead time**, the one-day minimum between booking and a session starting.
+The session-selection step raises a `block`-severity blocker and offers one
+answer: remove the session. There is no way to keep it.
+
+That was asked for, and its default is right. Clubworx enforces the minimum
+server-side and refuses with *"Sorry! This class is now closed for bookings."* —
+a message that names no cause and reads like a capacity problem. Meeting it
+sixty times, once per student, would also trip the run halt on the third
+consecutive failure and leave the run half-written.
+
+What the design did not record is that **the restriction is lift-able**. It is a
+per-class booking restriction in Clubworx, and a manager can remove it on the
+specific conflicted class, run the bookings, and put it back. The tool was
+modelling a gym policy that a human can suspend as though it were a property of
+time.
+
+The cost of that is not theoretical. A school sends its list on the morning of a
+session often enough to matter, and today the front desk answers it by booking
+sixty students by hand in Clubworx — the exact work this tool exists to remove.
+
+**The rule is enforced twice, independently.** The picker raises the blocker, and
+the Worker's write chain re-checks the lead time per student as a backstop before
+any write, refusing with its own lead-time reason and naming the offending event
+ids. The two are deliberately separate: D14 keeps the Worker from re-validating
+the event list, so the backstop is a guard at the point of writing rather than a
+second source of truth. Any override that reaches only the picker produces a run
+in which every student is refused. This is the fact that makes the change
+architectural rather than cosmetic, and it is why it earns an ADR.
+
+## Decision
+
+**A too-soon session can be kept, per session, by an operator who states that
+they have lifted its Clubworx restriction.**
+
+Three things make that safe, and none of them is optional.
+
+**The choice is per session, and it is a confirmation.** Each too-soon session
+keeps its own blocker and its existing removal, and gains a second answer beside
+it. Taking that answer raises a confirmation naming the specific session and
+stating the condition plainly: the booking restriction on this class must be
+lifted in Clubworx before the run starts, or every booking for it will fail.
+There is no control that acknowledges them all at once — that is the silent
+adjustment with a button on it that D9 rejected, wearing a different hat.
+
+**The contract between the page and the Worker is a list of acknowledged event
+ids, never a flag.** The page sends the exact ids the operator acknowledged, and
+the Worker narrows its refusal to too-soon sessions that are *not* on that list.
+Everything unacknowledged is still refused, with the same reason and the same
+naming of ids as today.
+
+**The run reminds staff to put the restriction back**, naming every session whose
+restriction was lifted, and that reminder is written into the JSON run record as
+well as onto the result screen.
+
+An acknowledged session's refusal drops from `block` to `warn`. It is **not**
+removed from the blocker list: a session that disappears once acknowledged is
+invisible and unexplained, which is the shape D9 exists to prevent.
+
+**Only the lead-time refusal is overridable.** An unreadable start time means the
+rule could not be checked at all, so "we cannot check this" must never become
+"you may override this". An already-started session is not a restriction the gym
+can lift. Both stay hard-stops.
+
+**The minimum itself does not move.** It stays defined once, with the events, and
+re-exported to the write chain. This decision narrows *who the rule is applied
+to*; it never re-derives what the rule is, and it does not make the number
+configurable.
+
+**The tool never changes a Clubworx restriction itself.** It does not lift one
+before the run and does not restore one after it. It states the condition and
+reminds; a person acts.
+
+## Consequences
+
+**The silent damage moves.** Before this, the worst case was a refused run —
+loud, immediate, self-correcting. After it, the worst case is **a restriction
+left lifted after the run**: a class open to public booking for as long as nobody
+notices. That is the risk this whole decision is shaped around, and it is why the
+reminder is sourced from the *selection* rather than from the run's results. A
+run that halts on its third consecutive failure produces no results for the
+acknowledged session at all, which is precisely when a restriction is most likely
+to have been left open; a reminder derived from results would go missing exactly
+when it matters most.
+
+**The backstop stays live for everything nobody acknowledged.** Naming ids rather
+than setting a flag is what buys this, and the case is real: a sixty-student list
+started at 23:40 can have a session cross into the lead time between selection
+and the write. Under a flag that session books silently. Under ids it is still
+refused, because nobody took responsibility for it.
+
+**An override taken without actually lifting the restriction fails loudly.** The
+bookings come back as ordinary refusals and the third consecutive one halts the
+run. That is an acceptable failure mode — it is visible, it stops early, and
+nothing permanent is written for the refused rows. It does mean the confirmation
+copy naming the consequence matters more than the mechanics do.
+
+**The Worker gains an input, not an opinion.** D14 still holds: the write chain
+does not re-validate the event list, and its lead-time gate remains a guard at
+the point of writing. It now knows which sessions a human vouched for. It still
+decides nothing about them.
+
+**The picker and the write chain must not be able to disagree.** They already
+share one definition of the rule; they now also share one list of exceptions. The
+sequencing follows from that — the Worker's gate is narrowed **before** the page
+can offer an override, so there is never a build in which a screen promises
+something the write chain would refuse.
+
+**§11's hard-stop table is now wrong about one of its rows**, and the domain
+vocabulary's *Lead time* entry with it. Both are amended alongside this ADR. Left
+stale, the next reader treats the override as a bug and removes it — which is the
+specific failure this document exists to prevent.
+
+**Nothing here changes the run halt.** Three consecutive failures still stop a
+run.
+
+## Alternatives considered
+
+- **A single "allow too-soon" flag on the run.** Rejected. It switches the
+  Worker's backstop off wholesale rather than narrowing it, so it also covers
+  sessions the operator never saw and sessions that crossed into the lead time
+  after selection. It is simpler by exactly the amount of safety it removes, and
+  the tell is that no test can distinguish "narrowed" from "switched off" under
+  it.
+- **Lift the restriction in Clubworx automatically, and restore it after.** Not
+  adopted, and not merely unbuilt: it removes the human judgement the
+  confirmation exists to capture, and it would leave the tool holding a
+  gym-policy control it has no way to restore reliably if the run dies mid-flight
+  or the tab closes. No API surface for it is assumed here either way.
+- **Drop the too-soon session automatically and run the rest.** Already rejected
+  as D9 and still rejected. A silent adjustment is worse than a refusal, and it
+  is worse again now that keeping the session is a real option.
+- **One override for the whole run.** Rejected for the same reason as the flag,
+  one layer up: acknowledging a Tuesday session should not acknowledge a Thursday
+  one the operator never looked at.
+- **Source the restore reminder from the run's results.** Rejected — see the
+  first consequence. The results are empty in the case that most needs the
+  reminder.
+- **Shorten or make the minimum configurable.** Out of scope and undesirable. The
+  number is Clubworx's, it is right, and a per-run knob would turn a deliberate
+  exception into a default nobody reads.

--- a/docs/adr/0007-lead-time-is-an-operator-override.md
+++ b/docs/adr/0007-lead-time-is-an-operator-override.md
@@ -8,6 +8,11 @@
 > drops a too-soon session by itself, and that staff never meet Clubworx's own
 > message — stands unchanged and is load-bearing here.
 
+> Companion: [ADR 0005](0005-school-pass-runs-26-weeks.md), the other hard-stop
+> in this run's pre-write gate. Both are about a Clubworx rule the tool cannot
+> see directly; 0005 changed the rule in Clubworx to fit the work, and this one
+> lets an operator suspend it for a session. Neither encodes the rule in code.
+
 ## Context
 
 A School Group Booking run refuses any selected School Session starting inside
@@ -31,14 +36,15 @@ The cost of that is not theoretical. A school sends its list on the morning of a
 session often enough to matter, and today the front desk answers it by booking
 sixty students by hand in Clubworx — the exact work this tool exists to remove.
 
-**The rule is enforced twice, independently.** The picker raises the blocker, and
-the Worker's write chain re-checks the lead time per student as a backstop before
-any write, refusing with its own lead-time reason and naming the offending event
-ids. The two are deliberately separate: D14 keeps the Worker from re-validating
-the event list, so the backstop is a guard at the point of writing rather than a
-second source of truth. Any override that reaches only the picker produces a run
-in which every student is refused. This is the fact that makes the change
-architectural rather than cosmetic, and it is why it earns an ADR.
+**The rule is enforced twice, independently.** Session selection raises the
+blocker, and the Worker's write chain re-checks the lead time per student as a
+backstop before any write, refusing with its own lead-time reason and naming the
+offending event ids. The two are deliberately separate: D14 keeps the Worker from
+re-validating the event list, so the backstop is a guard at the point of writing
+rather than a second source of truth. Any override reaching only session
+selection produces a run in which every student is refused. This is the fact that
+makes the change architectural rather than cosmetic, and it is why it earns an
+ADR.
 
 ## Decision
 
@@ -112,11 +118,11 @@ does not re-validate the event list, and its lead-time gate remains a guard at
 the point of writing. It now knows which sessions a human vouched for. It still
 decides nothing about them.
 
-**The picker and the write chain must not be able to disagree.** They already
-share one definition of the rule; they now also share one list of exceptions. The
-sequencing follows from that — the Worker's gate is narrowed **before** the page
-can offer an override, so there is never a build in which a screen promises
-something the write chain would refuse.
+**Session selection and the write chain must not be able to disagree.** They
+already share one definition of the rule; they now also share one list of
+exceptions. The sequencing follows from that — the Worker's gate is narrowed
+**before** the page can offer an override, so there is never a build in which a
+screen promises something the write chain would refuse.
 
 **§11's hard-stop table is now wrong about one of its rows**, and the domain
 vocabulary's *Lead time* entry with it. Both are amended alongside this ADR. Left

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -935,7 +935,7 @@ staleness. Nothing else is re-validated.
 | Condition | Ruling |
 |---|---|
 | School Pass plan unresolved, or the name ambiguous | **Hard-stop the run** |
-| Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* — **overridable per session since 2026-08-25, [ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md)** |
+| Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* — **to become overridable per session; decided 2026-08-25, not yet built ([ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md))** |
 | No events selected, or zero parseable rows | **Hard-stop** |
 | Any unresolved gate — unparseable row, count mismatch, unconfirmed age | **Hard-stop** (§9) |
 | The last selected session falls outside `today + membership_duration` | **Hard-stop the run** (§3, ADR 0005) |
@@ -947,14 +947,17 @@ adjustment. Staff must never meet Clubworx's own message here — *"Sorry! This
 class is now closed for bookings."* — which names no cause and reads like a
 capacity problem.
 
-> **Amended 2026-08-25, after the spec was written.** The hard-stop half of D9 is
-> reversed: a too-soon session can be **kept, per session**, by an operator who
-> confirms they have lifted that class's Clubworx booking restriction — it is a
-> lift-able restriction, not a property of time, and refusing the work outright
-> sent the front desk back to booking sixty students by hand. The rest of D9 is
-> untouched and is what keeps the override honest: the tool still never drops a
-> session by itself, the session stays visible as overridden rather than
-> vanishing, and staff still never meet Clubworx's own message.
+> **Amended 2026-08-25, after the spec was written — decided, not yet built**
+> ([#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#146](https://github.com/urbanjungleirc/staff-site/issues/146) are open;
+> the table row above still describes what the tool does today). The hard-stop
+> half of D9 is reversed: a too-soon session becomes **keepable, per session**, by
+> an operator who confirms they have lifted that class's Clubworx booking
+> restriction — it is a lift-able restriction, not a property of time, and
+> refusing the work outright sent the front desk back to booking sixty students
+> by hand. The rest of D9 is untouched and is what keeps the override honest: the
+> tool still never drops a session by itself, the session stays visible as
+> overridden rather than vanishing, and staff still never meet Clubworx's own
+> message.
 >
 > Two things this table cannot show. The rule is enforced **twice** — here and
 > again in the write chain per student — so an override travels to the Worker as

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -935,7 +935,7 @@ staleness. Nothing else is re-validated.
 | Condition | Ruling |
 |---|---|
 | School Pass plan unresolved, or the name ambiguous | **Hard-stop the run** |
-| Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* |
+| Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* — **overridable per session since 2026-08-25, [ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md)** |
 | No events selected, or zero parseable rows | **Hard-stop** |
 | Any unresolved gate — unparseable row, count mismatch, unconfirmed age | **Hard-stop** (§9) |
 | The last selected session falls outside `today + membership_duration` | **Hard-stop the run** (§3, ADR 0005) |
@@ -946,6 +946,23 @@ staleness. Nothing else is re-validated.
 adjustment. Staff must never meet Clubworx's own message here — *"Sorry! This
 class is now closed for bookings."* — which names no cause and reads like a
 capacity problem.
+
+> **Amended 2026-08-25, after the spec was written.** The hard-stop half of D9 is
+> reversed: a too-soon session can be **kept, per session**, by an operator who
+> confirms they have lifted that class's Clubworx booking restriction — it is a
+> lift-able restriction, not a property of time, and refusing the work outright
+> sent the front desk back to booking sixty students by hand. The rest of D9 is
+> untouched and is what keeps the override honest: the tool still never drops a
+> session by itself, the session stays visible as overridden rather than
+> vanishing, and staff still never meet Clubworx's own message.
+>
+> Two things this table cannot show. The rule is enforced **twice** — here and
+> again in the write chain per student — so an override travels to the Worker as
+> the explicit list of acknowledged event ids, never a run-wide flag. And the run
+> must remind staff to **put the restriction back**; a class left open to public
+> booking is the only damage in this area that stays silent.
+>
+> [ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md), [#138](https://github.com/urbanjungleirc/staff-site/issues/138).
 
 ### Retry policy
 


### PR DESCRIPTION
Closes #142.

The first ticket of #138. Documentation only — no source or test files change.

## What this records

The one-day **lead time** between booking and a School Session starting was
written down as an absolute hard-stop in two places. It is not: the Clubworx
booking restriction behind it is **lift-able per class**, so a manager can remove
it on the conflicted class, run the bookings, and put it back. Refusing the work
outright sent the front desk back to booking sixty students by hand.

**ADR 0007** reverses the hard-stop half of D9 and records the three conditions
that make the override safe rather than reckless — it is per session and taken as
an explicit confirmation; it crosses to the write chain as a **list of
acknowledged event ids, never a run-wide flag**; and the run reminds staff to
restore the restriction afterwards. It also records the limits: the minimum
itself does not move, only the lead-time refusal is overridable, and the tool
never changes a Clubworx restriction itself.

The finding that made this architectural rather than cosmetic: **the rule is
enforced twice, independently** — session selection raises the blocker, and the
write chain re-checks per student as a backstop. An override reaching only the
page produces a run in which every student is refused and the third consecutive
failure halts it.

`CONTEXT.md`'s Lead time entry and the design spec's §11 table and D9 are amended
to match.

## Decided, not shipped

Nothing is built. #143–#146 are open, and every amended document says so
explicitly — the hard-stop remains the plain statement of what the tool does
today, with the override in a clearly marked pending block. Both code-review axes
caught an earlier draft asserting the override as current fact; that is fixed in
the second commit.

## Verification

- school-booking 514/514, Worker 665/665 (untouched by a docs change; run to confirm)
- All relative links resolve on disk
- Reviewed on both axes — Standards and Spec — with findings applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBEEQhSPQ8MUygKPf4wEHX
