### PR TITLE
Lead-time override: narrow the Worker's gate to unacknowledged sessions (#143)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -744,10 +744,13 @@ blocker, and the write chain re-checks per student as a backstop before any
 write. Neither is the whole rule, and the minimum itself is defined once and
 re-exported to the write chain.
 
-> **Becoming an operator override — decided 2026-08-25, not yet built**
+> **Becoming an operator override — decided 2026-08-25, half built**
 > ([ADR 0007](docs/adr/0007-lead-time-is-an-operator-override.md),
 > [#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#146](https://github.com/urbanjungleirc/staff-site/issues/146)).
-> Until those land, the hard-stop above is the whole truth of what the tool does.
+> The **write chain** now narrows its backstop to sessions absent from the
+> acknowledged list (#143). Nothing offers an operator a way to acknowledge one
+> yet, so the hard-stop above is still the whole truth of what *staff* can do —
+> and a request that names no acknowledgements behaves exactly as it always has.
 >
 > The minimum is a *lift-able* Clubworx booking restriction, not a property of
 > time: a manager can remove it on the specific conflicted class, run the

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -426,6 +426,12 @@ Three things it deliberately is not:
 - **Not a way past an unreadable start.** A session whose `starts_at` will not
   parse is refused as `bad-request` whether it was acknowledged or not — "we
   cannot check this" must never become "you may override this".
+- **Not a way past a session that has already started.** Only the lead time is
+  a restriction the gym can lift. There is no separate past-session gate here —
+  a started session reaches the lead-time comparison as a *negative* delta — so
+  the narrowing excludes it explicitly. Its refusal is unchanged: still
+  `lead-time`, because nothing about a request carrying no acknowledgements may
+  move.
 - **Not a change to the minimum.** `MIN_LEAD_HOURS` stays defined once, in
   `src/events.js`, and is imported here. This narrows *who the rule is applied
   to*; it never re-derives what the rule is.

--- a/cloudflare-clubworx/README.md
+++ b/cloudflare-clubworx/README.md
@@ -392,7 +392,8 @@ POST /api/clubworx/student
   "contact_key": null,              // null means "new" — this call creates them
   "membership_plan_id": 64189,      // from GET /plan
   "membership_duration": "26 weeks",// the plan's own string, raw
-  "events": [{ "event_id": 101, "starts_at": "2026-09-03T10:00:00+08:00" }]
+  "events": [{ "event_id": 101, "starts_at": "2026-09-03T10:00:00+08:00" }],
+  "lead_time_acknowledged_event_ids": []   // ADR 0007 — see below. Optional
 }
 ```
 
@@ -400,6 +401,37 @@ POST /api/clubworx/student
 matched → re-read membership → ensure School Pass → book ×N → verify
 new     → create contact WITH the pass ───────────→ book ×N → verify
 ```
+
+### The lead-time gate is narrowed, never switched off
+
+The chain re-checks the 24-hour lead time per student as a backstop before any
+write, and refuses a too-soon session with `reason: "lead-time"` naming the
+offending event ids. **`lead_time_acknowledged_event_ids` narrows who that
+refusal applies to** — the event ids an operator stated they have lifted the
+Clubworx booking restriction for ([ADR 0007](../docs/adr/0007-lead-time-is-an-operator-override.md)).
+Everything absent from the list is still refused, with the same reason and the
+same ids as before.
+
+It is a list and **never a flag**, and that is the whole safety property. A flag
+would also cover a session that crossed into the lead time between selection and
+this call — real on a sixty-student list started at 23:40 — and a session the
+operator never saw. Both book silently under a flag; under ids both are still
+refused, because nobody took responsibility for them.
+
+Three things it deliberately is not:
+
+- **Not an opinion.** D14 still holds: the route hands the list through and the
+  chain does not re-validate the event list. An id naming a session this run did
+  not select is **inert**.
+- **Not a way past an unreadable start.** A session whose `starts_at` will not
+  parse is refused as `bad-request` whether it was acknowledged or not — "we
+  cannot check this" must never become "you may override this".
+- **Not a change to the minimum.** `MIN_LEAD_HOURS` stays defined once, in
+  `src/events.js`, and is imported here. This narrows *who the rule is applied
+  to*; it never re-derives what the rule is.
+
+Ids are compared as strings on both sides, so an id that made the round trip as
+`"101"` still matches one the picker read as `101`.
 
 ### The unit is one student, and it is all-or-nothing
 
@@ -484,8 +516,9 @@ Only two things are not a `200`, and in both there is nothing to record:
 
 - **`429`** — a throttle **that wrote nothing**. §11 pauses the *whole run* on a
   throttle, because the allowance is gym-wide.
-- **`400`** — a refusal that happened before any write: a session inside the
-  24-hour lead time, a pass that will not cover the term, a malformed request.
+- **`400`** — a refusal that happened before any write: an **unacknowledged**
+  session inside the 24-hour lead time, a pass that will not cover the term, a
+  malformed request.
 
 Everything else — including an abandoned, rolled-back student, and including a
 throttle that struck *after* something permanent was written — is a `200`

--- a/cloudflare-clubworx/src/index.js
+++ b/cloudflare-clubworx/src/index.js
@@ -200,9 +200,9 @@ const readStatus = reason => (reason === 'throttled' ? 429 : REFUSALS.has(reason
  *     page needs that where it cannot be missed. Once the call HAS written or
  *     cancelled something there is a row, so it leaves as a 200 still carrying
  *     `reason: "throttled"` — the field the page actually pauses on.
- *   - **400** — a refusal before anything was attempted: a lead-time session, a
- *     pass that will not cover the term, a set spanning two students, a
- *     malformed request.
+ *   - **400** — a refusal before anything was attempted: an *unacknowledged*
+ *     lead-time session (ADR 0007), a pass that will not cover the term, a set
+ *     spanning two students, a malformed request.
  *
  * `changed` is what "nothing happened yet" means on each route, and it is the
  * only part that differs between them: on `/student` a permanent record was
@@ -460,6 +460,15 @@ export function createHandler({
         membershipPlanId: payload.membership_plan_id,
         membershipDuration: payload.membership_duration,
         events: payload.events,
+        // ADR 0007. The route hands this through and forms no opinion about
+        // it: D14 keeps the Worker from re-validating the event list, and an
+        // id here naming a session the run did not select is inert in the
+        // gate. Defaulted to an empty list rather than passed as `undefined`,
+        // so a body without the field means "nobody acknowledged anything"
+        // everywhere it is read.
+        leadTimeAcknowledgedEventIds: Array.isArray(payload.lead_time_acknowledged_event_ids)
+          ? payload.lead_time_acknowledged_event_ids
+          : [],
       });
 
       // A result is not an error, even when the student was abandoned — the

--- a/cloudflare-clubworx/src/student.js
+++ b/cloudflare-clubworx/src/student.js
@@ -68,7 +68,9 @@
  * **It does not re-validate the event list.** D14 is explicit that only the
  * membership is re-read. The lead-time and pass-coverage gates below run
  * against the dates the page sends; they are a backstop at the point of writing,
- * not a second source of truth.
+ * not a second source of truth. ADR 0007 gives the lead-time gate one more
+ * input — the event ids an operator acknowledged — and no more authority: it
+ * narrows who the refusal applies to, and decides nothing about them.
  *
  * **It does not run the circuit breaker.** D7 halts a *run* after 3 consecutive
  * failures, and a run is many students across many calls — the page's job. This
@@ -99,6 +101,10 @@ import { isRetryable, upstreamMessage, upstreamReason } from './upstream.js';
  * (D9). Two copies would drift, and the drift shows up as a run refused at its
  * last step for a session the page had shown as selectable — with nothing on
  * either screen to say why the two disagreed.
+ *
+ * ADR 0007 makes that sharing load-bearing twice over: the two halves now share
+ * one list of exceptions as well as one definition of the rule, and they must
+ * not be able to disagree about either.
  */
 export { MIN_LEAD_HOURS };
 
@@ -360,6 +366,26 @@ const startOf = event => {
 };
 
 /**
+ * The acknowledged event ids, as a set that can be asked about an event id.
+ *
+ * Compared as strings on both sides. A Clubworx event id arrives as a number
+ * from the picker's read and as whatever JSON carried it on the way back in,
+ * and an acknowledgement that silently stops matching because one side is
+ * `101` and the other `"101"` fails in the direction that books nothing and
+ * explains nothing — the operator is told the session they just vouched for is
+ * refused.
+ *
+ * @param {unknown} ids
+ * @returns {Set<string>}
+ */
+const acknowledgedSet = ids =>
+  new Set(
+    (Array.isArray(ids) ? ids : [])
+      .filter(id => id !== null && id !== undefined)
+      .map(id => String(id)),
+  );
+
+/**
  * Run the whole chain for one student.
  *
  * @param {object} opts
@@ -369,6 +395,9 @@ const startOf = event => {
  * @param {string|number} opts.membershipPlanId The School Pass plan, resolved by `GET /plan`.
  * @param {string} opts.membershipDuration The plan's `membership_duration`, raw.
  * @param {Array<{event_id: any, starts_at: string, spaces_available?: number}>} opts.events
+ * @param {Array<any>} [opts.leadTimeAcknowledgedEventIds] The event ids the operator
+ *   has stated they lifted the Clubworx booking restriction for (ADR 0007). A list,
+ *   never a flag: everything absent from it is still refused by the gate below.
  * @param {string} [opts.now] The instant of the run. Injected so tests are not clock-dependent.
  * @param {(ms: number) => Promise<void>} [opts.sleep]
  */
@@ -379,6 +408,7 @@ export async function runStudentChain({
   membershipPlanId,
   membershipDuration,
   events = [],
+  leadTimeAcknowledgedEventIds = [],
   now = new Date().toISOString(),
   sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
 }) {
@@ -443,7 +473,17 @@ export async function runStudentChain({
     });
   }
 
-  const tooSoon = events.filter((_, i) => starts[i] - startedAt < MIN_LEAD_HOURS * MS_PER_HOUR);
+  // ADR 0007 — the gate is NARROWED to the sessions nobody acknowledged, never
+  // switched off. A single "allow too-soon" flag was rejected because it would
+  // also cover a session that crossed into the lead time between selection and
+  // this call, and a session the operator never saw. Both are real on a
+  // sixty-student list started late in the evening, and under a flag both book
+  // silently. The acknowledgement is read here and nowhere else: the rule
+  // itself still lives once, in `events.js`, and is imported above.
+  const acknowledged = acknowledgedSet(leadTimeAcknowledgedEventIds);
+  const tooSoon = events.filter(
+    (e, i) => starts[i] - startedAt < MIN_LEAD_HOURS * MS_PER_HOUR && !acknowledged.has(String(e.event_id)),
+  );
   if (tooSoon.length > 0) {
     // D9 — dropping the event automatically was rejected as a silent
     // adjustment. Staff must never meet Clubworx's own message here.

--- a/cloudflare-clubworx/src/student.js
+++ b/cloudflare-clubworx/src/student.js
@@ -375,6 +375,14 @@ const startOf = event => {
  * explains nothing — the operator is told the session they just vouched for is
  * refused.
  *
+ * Anything that is not a list becomes an empty one rather than throwing. The
+ * route already coerces a malformed body field, so this is the second guard
+ * on a value that decides whether a permanent write happens — and the chain is
+ * exported and called directly, by the tests here and by anything later. The
+ * failure it forecloses is the one this file's header warns about: a value
+ * guessed past is the one that writes. Empty is the fail-closed answer, since
+ * an empty set excuses nothing.
+ *
  * @param {unknown} ids
  * @returns {Set<string>}
  */
@@ -480,9 +488,23 @@ export async function runStudentChain({
   // sixty-student list started late in the evening, and under a flag both book
   // silently. The acknowledgement is read here and nowhere else: the rule
   // itself still lives once, in `events.js`, and is imported above.
+  //
+  // **Only a session that has not started yet can be excused.** ADR 0007 keeps
+  // an already-started session a hard-stop — it is not a restriction the gym
+  // can lift, so no confirmation can buy it. This gate has no separate
+  // past-session check (the page's `sessionRefusal()` does): a started session
+  // arrives here as a NEGATIVE delta and is caught by the same comparison. So
+  // the exclusion has to be written down here, or the same late-evening list
+  // the ids exist to protect books a session that is already under way.
+  //
+  // Note what this deliberately does NOT do: it does not give a started
+  // session its own reason. Nothing about a request carrying no
+  // acknowledgements may move, and today such a session refuses as
+  // `lead-time`.
   const acknowledged = acknowledgedSet(leadTimeAcknowledgedEventIds);
+  const excused = (event, at) => at > startedAt && acknowledged.has(String(event.event_id));
   const tooSoon = events.filter(
-    (e, i) => starts[i] - startedAt < MIN_LEAD_HOURS * MS_PER_HOUR && !acknowledged.has(String(e.event_id)),
+    (e, i) => starts[i] - startedAt < MIN_LEAD_HOURS * MS_PER_HOUR && !excused(e, starts[i]),
   );
   if (tooSoon.length > 0) {
     // D9 — dropping the event automatically was rejected as a silent

--- a/cloudflare-clubworx/test/student.test.js
+++ b/cloudflare-clubworx/test/student.test.js
@@ -166,6 +166,36 @@ describe('refusals before any permanent write', () => {
     expect(out.outcome).toBe('complete');
   });
 
+  it('still refuses a session that has already started, acknowledged or not', async () => {
+    // ADR 0007: only the lead-time refusal is overridable. An already-started
+    // session is not a restriction the gym can lift, so no confirmation can
+    // buy it. The Worker has no separate past-session gate — a started session
+    // reaches the lead-time filter as a NEGATIVE delta — so the narrowing has
+    // to exclude it explicitly or acknowledging one books it.
+    const client = makeClient({});
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: '2026-08-19T02:00:00Z' }], // a day ago
+      leadTimeAcknowledgedEventIds: [101],
+    });
+
+    expect(out).toMatchObject({ outcome: 'refused', reason: 'lead-time', written: false });
+    expect(out.leadTimeEventIds).toEqual([101]);
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('treats a session starting exactly now as started, not as overridable', async () => {
+    // The boundary belongs on the refusing side: at the instant it starts there
+    // is nothing left to book.
+    const client = makeClient({});
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: NOW }],
+      leadTimeAcknowledgedEventIds: [101],
+    });
+
+    expect(out).toMatchObject({ outcome: 'refused', reason: 'lead-time' });
+    expect(out.leadTimeEventIds).toEqual([101]);
+  });
+
   it('still refuses a session whose start cannot be read, acknowledged or not', async () => {
     // "We cannot check this" must never become "you may override this".
     const client = makeClient({});

--- a/cloudflare-clubworx/test/student.test.js
+++ b/cloudflare-clubworx/test/student.test.js
@@ -101,6 +101,95 @@ describe('refusals before any permanent write', () => {
     expect(client.calls).toHaveLength(0);
   });
 
+  // -------------------------------------------------------------------------
+  // ADR 0007 — the lead time is an operator override, not a law. The gate is
+  // NARROWED to sessions nobody acknowledged; it is never switched off. Every
+  // test below has to stay able to tell those two apart.
+  // -------------------------------------------------------------------------
+
+  it('books a too-soon session the operator acknowledged', async () => {
+    const client = makeClient({
+      'POST members': ok({ contact_key: 'ck-new' }),
+      'GET members': ok([contactRow()]),
+      'POST bookings': ok({ booking_id: 'b1' }),
+      'GET bookings': ok([{ booking_id: 'b1', event_id: 101 }]),
+    });
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: '2026-08-20T12:00:00Z' }],
+      leadTimeAcknowledgedEventIds: [101],
+    });
+
+    expect(out.outcome).toBe('complete');
+  });
+
+  it('names only the unacknowledged session when two are too soon and one is acknowledged', async () => {
+    // The whole point of ids over a flag: acknowledging Tuesday must not
+    // acknowledge Thursday.
+    const client = makeClient({});
+    const out = await run(client, {
+      events: [
+        { event_id: 101, starts_at: '2026-08-20T12:00:00Z' },
+        { event_id: 102, starts_at: '2026-08-20T14:00:00Z' },
+      ],
+      leadTimeAcknowledgedEventIds: [101],
+    });
+
+    expect(out).toMatchObject({ outcome: 'refused', reason: 'lead-time', written: false });
+    expect(out.leadTimeEventIds).toEqual([102]);
+    expect(out.message).toContain('1 selected session(s)');
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('ignores an acknowledgement naming a session this run did not select', async () => {
+    const client = makeClient({});
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: '2026-08-20T12:00:00Z' }],
+      leadTimeAcknowledgedEventIds: [999],
+    });
+
+    expect(out).toMatchObject({ outcome: 'refused', reason: 'lead-time' });
+    expect(out.leadTimeEventIds).toEqual([101]);
+  });
+
+  it('matches an acknowledged id whatever it was carried as, so a string id from JSON still counts', async () => {
+    const client = makeClient({
+      'POST members': ok({ contact_key: 'ck-new' }),
+      'GET members': ok([contactRow()]),
+      'POST bookings': ok({ booking_id: 'b1' }),
+      'GET bookings': ok([{ booking_id: 'b1', event_id: 101 }]),
+    });
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: '2026-08-20T12:00:00Z' }],
+      leadTimeAcknowledgedEventIds: ['101'],
+    });
+
+    expect(out.outcome).toBe('complete');
+  });
+
+  it('still refuses a session whose start cannot be read, acknowledged or not', async () => {
+    // "We cannot check this" must never become "you may override this".
+    const client = makeClient({});
+    const out = await run(client, {
+      events: [{ event_id: 101, starts_at: 'not a date' }],
+      leadTimeAcknowledgedEventIds: [101],
+    });
+
+    expect(out).toMatchObject({ outcome: 'refused', reason: 'bad-request', written: false });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('refuses an unacknowledged too-soon session exactly as before when acknowledgements are absent', async () => {
+    // The no-acknowledgement path is today's path, and it must not have moved.
+    const client = makeClient({});
+    const events = [{ event_id: 101, starts_at: '2026-08-20T12:00:00Z' }];
+    const before = await run(client, { events });
+    const after = await run(client, { events, leadTimeAcknowledgedEventIds: [] });
+
+    expect(after).toEqual(before);
+    expect(before.leadTimeEventIds).toEqual([101]);
+    expect(client.calls).toHaveLength(0);
+  });
+
   it('stops when the last session falls outside the plan duration', async () => {
     // A 26-week pass granted 2026-08-20 covers to 2027-02-17. A session in March
     // is past that, and every booking would still be written on a day the pass

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -569,7 +569,7 @@ describe('POST /student', () => {
     const h = handlerWith(accepts(OPERATOR), {
       runStudent: async args => {
         seen = args;
-        return (await completes()()) ;
+        return await completes()();
       },
     });
 

--- a/cloudflare-clubworx/test/worker.test.js
+++ b/cloudflare-clubworx/test/worker.test.js
@@ -562,6 +562,41 @@ describe('POST /student', () => {
     expect(await res.json()).toMatchObject({ outcome: 'complete', requests: 4 });
   });
 
+  it('hands the acknowledged event ids to the write chain (ADR 0007)', async () => {
+    // A page-only override refuses every student and halts the run on the
+    // third, so the ids reaching the chain is the whole feature, not plumbing.
+    let seen = null;
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: async args => {
+        seen = args;
+        return (await completes()()) ;
+      },
+    });
+
+    await h.call(
+      '/api/clubworx/student',
+      post({ ...BODY, lead_time_acknowledged_event_ids: [101, 102] }),
+    );
+
+    expect(seen.leadTimeAcknowledgedEventIds).toEqual([101, 102]);
+  });
+
+  it('sends an empty acknowledgement list when the body carries none', async () => {
+    // Today's body has no such field, and it must keep meaning "nobody
+    // acknowledged anything" rather than arriving as undefined.
+    let seen = null;
+    const h = handlerWith(accepts(OPERATOR), {
+      runStudent: async args => {
+        seen = args;
+        return await completes()();
+      },
+    });
+
+    await h.call('/api/clubworx/student', post());
+
+    expect(seen.leadTimeAcknowledgedEventIds).toEqual([]);
+  });
+
   it('passes the page a 400 for a refusal that happened before any write', async () => {
     const h = handlerWith(accepts(OPERATOR), {
       runStudent: completes({ ok: false, outcome: 'refused', reason: 'lead-time', written: false }),


### PR DESCRIPTION
Closes #143. First of the four tickets under #138, and the one the others are sequenced behind: the Worker's gate is narrowed **before** any page can offer an override, so there is never a build in which a screen promises something the write chain would refuse.

Implements [ADR 0007](https://github.com/urbanjungleirc/staff-site/blob/main/docs/adr/0007-lead-time-is-an-operator-override.md).

## What changed

`POST /student` takes `lead_time_acknowledged_event_ids` alongside the session list. The write chain's lead-time backstop refuses only too-soon sessions **absent** from that list; everything unacknowledged is still refused, with the same reason and the same naming of ids as today.

A list, never a flag. A flag switches the backstop off wholesale, so it would also cover a session that crossed into the lead time after selection — real on a sixty-student list started at 23:40 — and a session the operator never saw. The ADR names the tell: no test can distinguish "narrowed" from "switched off" under a flag. Two here do.

**No page changes.** Verifiable entirely at the Worker boundary.

## The defect code review caught

The second commit fixes a real hole in the first. ADR 0007 keeps an already-started session a hard-stop — not a restriction the gym can lift — but this Worker has **no separate past-session gate**. The page's `sessionRefusal()` has one; here a started session arrives as a *negative* delta and is caught by the same lead-time comparison. Narrowing that comparison by acknowledged id therefore exempted it, and the exposed case is precisely the one the ids exist to protect: cross the lead time late enough and the session has already begun.

An acknowledgement now excuses only a session that has not started yet, with the boundary on the refusing side. It deliberately keeps the `lead-time` reason rather than getting its own — the criterion that a request carrying no acknowledgements behaves identically to today outranks the tidier vocabulary.

## Deliberately unchanged

- An unreadable start time is still `bad-request`, acknowledged or not. "We cannot check this" must never become "you may override this".
- `MIN_LEAD_HOURS` stays defined once, in `events.js`. This narrows *who the rule is applied to*; it never re-derives what the rule is.
- The route forms no opinion (D14) — an id naming a session the run did not select is inert.

## Verification

- Worker suite 675/675, page suite 514/514.
- Mutation-checked twice, as the ticket asks: switching the gate off rather than narrowing it fails 2 tests; dropping the past-session exclusion fails 2 more.
- All nine acceptance criteria walked item by item.

## Not in this PR

The Worker needs a manual `npx wrangler deploy` — merging publishes Pages only. Nothing staff-visible changes until #144 gives operators a way to acknowledge anything, and a request naming no acknowledgements behaves exactly as it always has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBEEQhSPQ8MUygKPf4wEHX