### PR TITLE
Lead-time override: acknowledge a too-soon session and book it end-to-end (#144)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,30 @@ school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #10
                           equals a fresh one field by field — the reset restates
                           the component literal's initial values and nothing in
                           the language links the two copies.
+                          ADR 0007 (#144) added `leadTimeAcknowledgements` — the
+                          per-session log of too-soon sessions an operator has
+                          stated they lifted the Clubworx restriction for — and
+                          `leadTimeConfirm`, the one session waiting on its
+                          confirmation. Both are cleared by the reset: a
+                          statement about the last import's sessions is not a
+                          statement about this one's.
+                          askLeadTimeOverride() only OPENS that confirmation;
+                          confirmLeadTimeOverride() is the only thing that
+                          writes to the log. keepAcknowledgementsForPicked() is
+                          the rule that keeps it honest — an acknowledgement
+                          lasts exactly as long as its tick, so un-ticking (by
+                          checkbox, by the blocker's removal, or by a re-search
+                          that drops the session) withdraws it and ticking the
+                          session again asks the question again. The
+                          confirmation is rendered in BOTH blocker lists,
+                          because both dispatch through answerSelection() and a
+                          confirmation on only one of them is a chip that
+                          silently does nothing on the other.
 school-booking/events.js - what a SELECTION of sessions is: the same-name,
                           same-location pre-tick (no recurrence field exists,
-                          so any automatic rule is a guess), the lead-time and
-                          past-session hard-stops with D9's one-click removal,
-                          and the spaces warning that never blocks.
+                          so any automatic rule is a guess), the past-session
+                          and unreadable-start hard-stops with D9's one-click
+                          removal, and the spaces warning that never blocks.
                           sessionRefusal() is the ONE place deciding what is
                           wrong with a session and how serious — the blocker
                           list and the picker's row styling both ask it. Do not
@@ -165,6 +184,20 @@ school-booking/events.js - what a SELECTION of sessions is: the same-name,
                           room" in with "too close to the start", and only the
                           second refuses a booking, so reading it alone paints
                           a warnable session as a refused one.
+                          The lead time is NO LONGER a hard-stop: ADR 0007 made
+                          it an operator override, so a too-soon session keeps
+                          its removal and gains a second answer — acknowledge
+                          that its Clubworx booking restriction has been lifted
+                          by hand, and it drops to `warn` and stays listed. It
+                          is the ONLY overridable refusal; an unreadable start
+                          means the rule could not be checked at all, and an
+                          already-started session is not a restriction the gym
+                          can lift. acknowledgeLeadTime() is the decision log,
+                          keyed by event id and per session throughout — there
+                          is no control that clears them all. The report
+                          derives `acknowledgedEventIds` from the sessions
+                          actually ticked and loaded, and that list (never a
+                          flag) is what narrows the Worker's own backstop.
                           The paste-an-id fallback resolves HERE, against the
                           window already on screen — GET /events/:id answers 404
                           for every id, real or invented (#97), so a message
@@ -215,6 +248,14 @@ school-booking/run.js   - step 6's engine: Apply's per-student loop, D8's retry
                           and not the status: once a call has written something
                           the Worker answers 200 carrying `reason: "throttled"`,
                           because the body is then the only record of the write.
+                          runList() carries ADR 0007's acknowledged sessions as
+                          `lead_time_acknowledged_event_ids`, per student,
+                          because the gate they narrow is a per-student backstop
+                          in the write chain. OMITTED from the payload entirely
+                          when there are none, so a run nobody overrode is the
+                          run this route already took. The ids come off the
+                          SELECTION, never the log, so a statement about a
+                          session no longer ticked cannot reach the Worker.
 school-booking/outcome.js - what one `POST /student` answer means, and what a
                           run of them adds up to. Two exports are safety rules
                           rather than presentation: isFailure() feeds the

--- a/school-booking.html
+++ b/school-booking.html
@@ -68,14 +68,14 @@
      or missing module into a visible refusal rather than a page whose gates
      quietly do nothing. -->
 <script type="module">
-  import * as parser from './school-booking/parse.js?v=5';
-  import * as steps from './school-booking/steps.js?v=5';
-  import * as identity from './school-booking/identity.js?v=5';
-  import * as events from './school-booking/events.js?v=5';
-  import * as preview from './school-booking/preview.js?v=5';
-  import * as calendar from './school-booking/calendar.js?v=5';
-  import * as outcome from './school-booking/outcome.js?v=5';
-  import * as run from './school-booking/run.js?v=5';
+  import * as parser from './school-booking/parse.js?v=6';
+  import * as steps from './school-booking/steps.js?v=6';
+  import * as identity from './school-booking/identity.js?v=6';
+  import * as events from './school-booking/events.js?v=6';
+  import * as preview from './school-booking/preview.js?v=6';
+  import * as calendar from './school-booking/calendar.js?v=6';
+  import * as outcome from './school-booking/outcome.js?v=6';
+  import * as run from './school-booking/run.js?v=6';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
   window.schoolBookingIdentity = identity;
@@ -1153,6 +1153,21 @@
                   <button type="button" class="chip" @click="answerSelection(action)" x-text="action.label"></button>
                 </template>
               </div>
+
+              <!-- ADR 0007. Attached to the blocker it is about, so the session
+                   being kept is the one on screen beside the sentence. It is a
+                   confirmation and not a formality: the restriction has to be
+                   lifted by hand in Clubworx, and the cost of clicking past
+                   this is sixty refusals and a halted run. -->
+              <div class="mt-2 rounded-lg bg-white border border-neutral-300 px-3 py-2"
+                   x-show="leadTimeConfirm === blocker.eventId" x-cloak>
+                <div class="text-[0.78rem] text-neutral-700" x-text="leadTimeConfirmLine()"></div>
+                <div class="flex gap-2 mt-2">
+                  <button type="button" class="chip border-solid border-uj text-uj"
+                          @click="confirmLeadTimeOverride()">Yes — the restriction is lifted</button>
+                  <button type="button" class="chip" @click="cancelLeadTimeOverride()">Cancel</button>
+                </div>
+              </div>
             </div>
           </template>
         </div>
@@ -1216,6 +1231,20 @@
                     <template x-for="action in blocker.actions" :key="action.key">
                       <button type="button" class="chip" @click="answerSelection(action)" x-text="action.label"></button>
                     </template>
+                  </div>
+
+                  <!-- The same confirmation as step 4's. Both lists dispatch
+                       through `answerSelection`, so a confirmation on only one
+                       of them is an action that silently does nothing on the
+                       other. -->
+                  <div class="mt-2 rounded-lg bg-white border border-neutral-300 px-3 py-2"
+                       x-show="leadTimeConfirm === blocker.eventId" x-cloak>
+                    <div class="text-[0.78rem] text-neutral-700" x-text="leadTimeConfirmLine()"></div>
+                    <div class="flex gap-2 mt-2">
+                      <button type="button" class="chip border-solid border-uj text-uj"
+                              @click="confirmLeadTimeOverride()">Yes — the restriction is lifted</button>
+                      <button type="button" class="chip" @click="cancelLeadTimeOverride()">Cancel</button>
+                    </div>
                   </div>
                 </div>
               </template>
@@ -1691,7 +1720,15 @@ function schoolBooking() {
     // on every render of step 4, including the first, and an Alpine expression
     // that throws leaves its `:disabled` unapplied — which would *enable* the
     // forward button on the one render where nothing has been checked.
-    selection: { events: [], blockers: [], ready: false, sessions: 0, students: 0, bookings: 0, firstSession: null, lastSession: null },
+    selection: { events: [], blockers: [], ready: false, acknowledgedEventIds: [], sessions: 0, students: 0, bookings: 0, firstSession: null, lastSession: null },
+
+    // ADR 0007 — the sessions an operator has stated they lifted the Clubworx
+    // booking restriction for, keyed by event id, and the one waiting on its
+    // confirmation. One at a time and never a set: the choice is per session
+    // throughout, and a control that acknowledged them all would be the silent
+    // adjustment with a button on it.
+    leadTimeAcknowledgements: {},
+    leadTimeConfirm: null,
 
     // The check between 4 and 5
     // The plan name, not its id: an id is a number nobody can check against the
@@ -2344,6 +2381,11 @@ function schoolBooking() {
         // group ends up booked into a session nobody chose.
         const present = new Set(this.events.map((e) => String(e.event_id)));
         this.picked = this.picked.filter((id) => present.has(String(id)));
+        // ADR 0007's statements go with the ticks they are about: an
+        // acknowledgement about a session nobody can see is one nobody can take
+        // back, and a session searched up again later must arrive refusing
+        // rather than pre-forgiven.
+        this.keepAcknowledgementsForPicked();
       } catch (error) {
         this.events = [];
         this.eventsTotal = 0;
@@ -2376,7 +2418,23 @@ function schoolBooking() {
     togglePick(id) {
       const key = String(id);
       this.picked = this.isPicked(key) ? this.picked.filter((p) => p !== key) : [...this.picked, key];
+      this.keepAcknowledgementsForPicked();
       this.refreshSelection();
+    },
+
+    // ADR 0007. An acknowledgement is a statement about a session **in this
+    // run**, so it lasts exactly as long as the tick does. Un-ticking drops it,
+    // and ticking the session again asks the question again — otherwise a
+    // session could come back pre-forgiven by a confirmation nobody re-took,
+    // which is the one thing a confirmation is for. Strict is the safe
+    // direction here: the damage this feature is shaped around is a restriction
+    // left lifted, never a question asked twice.
+    keepAcknowledgementsForPicked() {
+      const ticked = new Set(this.picked.map(String));
+      this.leadTimeAcknowledgements = Object.fromEntries(
+        Object.entries(this.leadTimeAcknowledgements).filter(([id]) => ticked.has(id)),
+      );
+      if (!ticked.has(String(this.leadTimeConfirm))) this.leadTimeConfirm = null;
     },
 
     // §8's one-click series. The rule is same name, same location, ahead of the
@@ -2385,6 +2443,7 @@ function schoolBooking() {
     // "pick this first" is a statement about which session is first.
     pickSeries(id) {
       this.picked = window.schoolBookingEvents.preTicked(this.events, id);
+      this.keepAcknowledgementsForPicked();
       this.refreshSelection();
     },
 
@@ -2452,7 +2511,7 @@ function schoolBooking() {
     // being painted the same red as a lead-time hard-stop, with no reason
     // beside it, against §11's "warn, never block".
     eventLane(event) {
-      const refusal = window.schoolBookingEvents.sessionRefusal(event);
+      const refusal = this.refusalFor(event);
       if (refusal?.severity === 'block') return 'lane-bad';
       if (refusal) return 'lane-need';
       return this.isPicked(event.event_id) ? 'lane-ok' : 'lane';
@@ -2462,13 +2521,11 @@ function schoolBooking() {
     // own refusal — "Sorry! This class is now closed for bookings." — names
     // none of them and reads like a capacity problem (D9).
     eventWarning(event) {
-      return window.schoolBookingEvents.sessionRefusal(event)?.message ?? '';
+      return this.refusalFor(event)?.message ?? '';
     },
 
     eventWarningTone(event) {
-      return window.schoolBookingEvents.sessionRefusal(event)?.severity === 'block'
-        ? 'text-rose-700'
-        : 'text-amber-700';
+      return this.refusalFor(event)?.severity === 'block' ? 'text-rose-700' : 'text-amber-700';
     },
 
     refreshSelection() {
@@ -2481,6 +2538,12 @@ function schoolBooking() {
         // edit the dates without pressing Search, and a series checked against
         // dates nobody loaded would clear the warning by typing.
         windowTo: this.loadedTo,
+        // ADR 0007. The report ignores an entry naming a session that is not
+        // ticked or not in the window, so nothing has to be pruned for
+        // correctness — `loadEvents` prunes it anyway, so that a session
+        // dropped and later searched up again comes back refusing rather than
+        // forgiven by a decision nobody re-took.
+        acknowledged: this.leadTimeAcknowledgements,
       });
     },
 
@@ -2489,11 +2552,81 @@ function schoolBooking() {
         || 'No sessions picked yet.';
     },
 
-    // The one-click removal D9 asks for. Removing is the only thing a blocker
-    // here can do, and the page dispatches on `answers` exactly as step 3 does,
-    // so a blocker kind added in the module cannot arrive without its control.
+    // D9's one-click removal, and ADR 0007's second answer beside it. The page
+    // dispatches on `answers` exactly as step 3 does, so a blocker kind added
+    // in the module cannot arrive without its control — and the dispatcher
+    // still knows no blocker kinds.
     answerSelection(action) {
       if (action.answers === 'remove') this.togglePick(action.value);
+      else if (action.answers === 'acknowledge-lead-time') this.askLeadTimeOverride(action.value);
+      else if (action.answers === 'unacknowledge-lead-time') this.takeBackLeadTimeOverride(action.value);
+    },
+
+    // --- ADR 0007, the lead-time override ---------------------------------
+    // Asking is not taking, and the name says so: nothing about the selection
+    // moves here. The answer opens a confirmation, and the confirmation is the
+    // whole safeguard — somebody has to go and lift a restriction in Clubworx
+    // by hand, and the failure mode of not doing it is sixty refusals and a
+    // halted run. Only `confirmLeadTimeOverride` writes to the log.
+    askLeadTimeOverride(eventId) {
+      this.leadTimeConfirm = String(eventId);
+    },
+
+    cancelLeadTimeOverride() {
+      this.leadTimeConfirm = null;
+    },
+
+    confirmLeadTimeOverride() {
+      const eventId = this.leadTimeConfirm;
+      if (!eventId) return;
+      this.leadTimeAcknowledgements = window.schoolBookingEvents
+        .acknowledgeLeadTime(this.leadTimeAcknowledgements, eventId, { kind: 'lifted' });
+      this.leadTimeConfirm = null;
+      this.afterAcknowledgement();
+    },
+
+    takeBackLeadTimeOverride(eventId) {
+      // No confirmation on the way back. Taking one back restores the refusal,
+      // and nothing that only ever makes the tool stricter needs a gate.
+      this.leadTimeAcknowledgements = window.schoolBookingEvents
+        .acknowledgeLeadTime(this.leadTimeAcknowledgements, eventId, null);
+      // Only if it was this session's question. A confirmation open on one
+      // session is not answered by a decision taken about another.
+      if (this.leadTimeConfirm === String(eventId)) this.leadTimeConfirm = null;
+      this.afterAcknowledgement();
+    },
+
+    isLeadTimeAcknowledged(eventId) {
+      return window.schoolBookingEvents.leadTimeAcknowledged(this.leadTimeAcknowledgements, eventId);
+    },
+
+    // The one place the page asks what is wrong with a session, so the three
+    // row-styling helpers below cannot drift apart over whether an
+    // acknowledgement counts.
+    refusalFor(event) {
+      return window.schoolBookingEvents
+        .sessionRefusal(event, this.isLeadTimeAcknowledged(event?.event_id));
+    },
+
+    // The selection always, and the preview when there is one to keep honest:
+    // its blockers are the selection's, carried verbatim, so a decision taken
+    // on either screen has to reach both.
+    afterAcknowledgement() {
+      this.refreshSelection();
+      if (this.preview) this.refreshPreview();
+    },
+
+    // The session, and the condition, in the plainest words available. The
+    // consequence is concrete on purpose — the mechanics of this feature are
+    // simple and the copy is the part that actually prevents the damage.
+    leadTimeConfirmLine() {
+      const id = this.leadTimeConfirm;
+      if (!id) return '';
+      const event = this.events.find((e) => String(e.event_id) === String(id));
+      const label = event ? window.schoolBookingEvents.sessionLabel(event) : 'This session';
+      return `${label} — the booking restriction on this class must be lifted in Clubworx before `
+        + 'the run starts, or every booking for it will fail. The failures arrive as ordinary '
+        + 'refusals, and the third one in a row halts the run. Lift it first, then run.';
     },
 
     // The dates are seeded and the read waits. A term-wide window is ~900
@@ -2719,6 +2852,10 @@ function schoolBooking() {
         preview: this.preview,
         rows: this.reviewed?.rows ?? [],
         email: this.marker(),
+        // ADR 0007. Read off the selection rather than the log, so a statement
+        // about a session that is no longer ticked — or no longer in the loaded
+        // window — never reaches the write chain.
+        acknowledgedEventIds: this.selection.acknowledgedEventIds ?? [],
       });
       if (students.length === 0) return;
 
@@ -3127,7 +3264,12 @@ function schoolBooking() {
       this.pastedIdOk = false;
       this.pastedIdEvent = null;
       this.picked = [];
-      this.selection = { events: [], blockers: [], ready: false, sessions: 0, students: 0, bookings: 0, firstSession: null, lastSession: null };
+      this.selection = { events: [], blockers: [], ready: false, acknowledgedEventIds: [], sessions: 0, students: 0, bookings: 0, firstSession: null, lastSession: null };
+      // A statement about the last import's sessions is not a statement about
+      // this one's, and this is the one field where carrying it over would
+      // silently pre-forgive a session nobody has looked at yet.
+      this.leadTimeAcknowledgements = {};
+      this.leadTimeConfirm = null;
 
       this.plan = null;
       this.matches = {};

--- a/school-booking/events.js
+++ b/school-booking/events.js
@@ -231,13 +231,20 @@ export function sessionLabel(event) {
  * so §11 makes it "warn, never block". Reading `bookable` alone paints a
  * warnable session as a refused one.
  *
+ * @param {object} event
+ * @param {boolean} [acknowledged] Whether an operator has stated they lifted
+ *   this session's Clubworx booking restriction (ADR 0007). Only the lead time
+ *   moves under it — see the branch.
  * @returns {{kind: string, severity: 'block'|'warn', message: string}|null}
  *   null when there is nothing wrong with the session.
  */
-export function sessionRefusal(event) {
+export function sessionRefusal(event, acknowledged = false) {
   const lead = event?.lead ?? {};
 
   if (lead.unreadable === true) {
+    // ADR 0007 stops here deliberately: an unreadable start time means the rule
+    // could not be checked at all, and "we cannot check this" must never become
+    // "you may override this".
     return {
       kind: 'unreadable-session',
       severity: 'block',
@@ -246,10 +253,23 @@ export function sessionRefusal(event) {
   }
 
   if (lead.past === true) {
+    // Not overridable either — an already-started session is not a restriction
+    // the gym can lift.
     return { kind: 'past-session', severity: 'block', message: 'Already started.' };
   }
 
   if (lead.withinLeadTime === true) {
+    // The one refusal an operator can answer for (ADR 0007). It drops to a
+    // warning and stays on screen: a session that disappears once acknowledged
+    // is invisible and unexplained, which is the shape D9 exists to prevent.
+    if (acknowledged) {
+      return {
+        kind: 'lead-time',
+        severity: 'warn',
+        message: 'Starts within the lead time. Its Clubworx booking restriction must be lifted '
+          + 'before the run starts, or every booking for it will fail.',
+      };
+    }
     return {
       kind: 'lead-time',
       severity: 'block',
@@ -260,8 +280,18 @@ export function sessionRefusal(event) {
     };
   }
 
-  // Ranked below the lead time on purpose: a session that is both too soon and
-  // full is refused for the reason that actually refuses it.
+  return capacityRefusal(event);
+}
+
+/**
+ * What Clubworx says about the room — a warning, never a hard-stop (§11).
+ *
+ * Split out from `sessionRefusal` because it is ranked *below* the lead time
+ * there and an acknowledged session has to reach it anyway: the lead time
+ * outranks the room because only one of them refuses the run, so once it stops
+ * refusing, the room is the thing left worth saying.
+ */
+function capacityRefusal(event) {
   if (event?.event_full === true || event?.spaces_available === 0) {
     return {
       kind: 'full',
@@ -269,7 +299,6 @@ export function sessionRefusal(event) {
       message: 'Clubworx reports no spaces — a number that has been wrong in both directions.',
     };
   }
-
   return null;
 }
 
@@ -280,12 +309,109 @@ const REFUSAL_TITLES = {
   full: 'Clubworx reports no spaces on a session',
 };
 
+// The acknowledged lead time is the same blocker saying a different thing, so
+// it is the same key with a different headline rather than a second kind.
+const ACKNOWLEDGED_LEAD_TIME_TITLE = 'A session starts too soon — its restriction is being lifted by hand';
+
 const removal = (event) => ({
   key: `remove:${event.event_id}`,
   label: 'Remove this session',
   answers: 'remove',
   value: String(event.event_id),
 });
+
+// ADR 0007's second answer, offered only beside the lead time and only while it
+// still refuses. The page raises a confirmation on it; nothing here takes it.
+const acknowledgement = (event) => ({
+  key: `ack:${event.event_id}`,
+  label: 'Keep it and book anyway',
+  answers: 'acknowledge-lead-time',
+  value: String(event.event_id),
+});
+
+const takeBack = (event) => ({
+  key: `unack:${event.event_id}`,
+  label: 'Take that back',
+  answers: 'unacknowledge-lead-time',
+  value: String(event.event_id),
+});
+
+/**
+ * What a session's blocker offers, in one place.
+ *
+ * D9's removal answers a session that **refuses the run**; offering it beside a
+ * warning turns "worth a look" into "click here to make this go away", which is
+ * why a warning carries no removal anywhere here. An acknowledged session is
+ * the same rule seen from the other side: it no longer refuses, so it offers
+ * the way back and nothing else.
+ */
+function answersFor(event, refusal, overridden) {
+  // An acknowledged session KEEPS its removal — ADR 0007: "Each too-soon
+  // session keeps its own blocker and its existing removal, and gains a second
+  // answer beside it." It is the one warning here that carries one, and it has
+  // earned the exception by having been a block a click ago: the removal was
+  // already on offer, so leaving it is not a new invitation to silence a
+  // warning. Un-ticking drops the acknowledgement with it (see the page), so
+  // this cannot leave a statement behind about a session nobody is booking.
+  if (overridden) return [removal(event), takeBack(event)];
+  if (refusal.severity !== 'block') return [];
+  // Only the lead time is answerable. An unreadable start means the rule could
+  // not be checked at all, and an already-started session is not a restriction
+  // the gym can lift — both get the removal alone.
+  return refusal.kind === 'lead-time'
+    ? [removal(event), acknowledgement(event)]
+    : [removal(event)];
+}
+
+/** One session's blocker, in the shape step 4 and step 5 both render. */
+const sessionBlocker = (event, refusal, { title, actions = [] } = {}) => ({
+  key: `${refusal.kind}:${event.event_id}`,
+  kind: refusal.kind,
+  // Named so a surface can attach something to the session itself — the
+  // confirmation ADR 0007 raises is rendered against this.
+  eventId: String(event.event_id),
+  severity: refusal.severity,
+  title: title ?? REFUSAL_TITLES[refusal.kind],
+  detail: `${sessionLabel(event)} — ${refusal.message}`,
+  actions,
+});
+
+// ---------------------------------------------------------------------------
+// The acknowledgement log — ADR 0007
+// ---------------------------------------------------------------------------
+
+/**
+ * Record — or take back — one operator's statement that they have lifted a
+ * session's Clubworx booking restriction.
+ *
+ * The same shape as step 3's resolution log and step 5's match-decision log,
+ * and for the same reason: a new object comes back rather than the original
+ * mutated, because Alpine re-renders from the returned value and an undo that
+ * mutates in place is an undo nobody can see.
+ *
+ * Simpler than step 3's, like step 5's: there is no gate here asking *did staff
+ * work these sessions*, so taking one back leaves nothing behind. An
+ * un-acknowledged session is exactly a session nobody acknowledged.
+ *
+ * Keyed by event id **as a string**, so a numeric Clubworx id and one pasted
+ * off a screen are the same key — the same comparison the Worker's own gate
+ * makes on the far end of this list.
+ *
+ * @param {object} acknowledgements the current log
+ * @param {string|number} eventId the session acknowledged
+ * @param {{kind: 'lifted'}|null} action or null to take it back
+ */
+export function acknowledgeLeadTime(acknowledgements, eventId, action) {
+  const next = { ...(acknowledgements ?? {}) };
+  if (action === null || action === undefined) delete next[String(eventId)];
+  else next[String(eventId)] = action;
+  return next;
+}
+
+/** Has this session been acknowledged? */
+export function leadTimeAcknowledged(acknowledgements, eventId) {
+  return Boolean((acknowledgements ?? {})[String(eventId)]);
+}
 
 /**
  * Everything step 4 blocks on, and the two numbers step 5 needs from it.
@@ -301,10 +427,17 @@ const removal = (event) => ({
  * @param {number} opts.studentCount Students the run would book.
  * @param {boolean} [opts.truncated] Whether the Worker said it could not read the window to the end.
  * @param {string} [opts.windowTo] The last day loaded, so a series running past it can be named.
+ * @param {object} [opts.acknowledged] The ADR 0007 log, keyed by event id. An
+ *   entry naming a session that is not ticked, not in the window, or not too
+ *   soon is inert — the report is derived from the sessions actually on screen,
+ *   so re-searching the dates cannot resurrect a stale acknowledgement.
  */
-export function selectionReport({ events, selected, studentCount = 0, truncated = false, windowTo = '' } = {}) {
+export function selectionReport({
+  events, selected, studentCount = 0, truncated = false, windowTo = '', acknowledged = {},
+} = {}) {
   const picked = selectedEvents(events, selected);
   const blockers = [];
+  const acknowledgedEventIds = [];
 
   if (picked.length === 0) {
     blockers.push({
@@ -333,23 +466,34 @@ export function selectionReport({ events, selected, studentCount = 0, truncated 
     // removal when it is a `block`: D9's one-click fix answers a session that
     // refuses the run, and offering it beside a warning turns "worth a look"
     // into "click here to make this go away".
-    const refusal = sessionRefusal(event);
+    //
+    // An acknowledgement only counts once the session has actually reached this
+    // loop: it has to be ticked, in the loaded window, and still too soon. That
+    // is what makes a stale entry inert rather than a thing to prune.
+    const lifted = leadTimeAcknowledged(acknowledged, event.event_id);
+    const refusal = sessionRefusal(event, lifted);
+    const overridden = lifted && refusal?.kind === 'lead-time';
+    if (overridden) acknowledgedEventIds.push(String(event.event_id));
+
     if (refusal) {
-      blockers.push({
-        key: `${refusal.kind}:${event.event_id}`,
-        kind: refusal.kind,
-        severity: refusal.severity,
-        title: REFUSAL_TITLES[refusal.kind],
-        detail: `${sessionLabel(event)} — ${refusal.message}`,
-        actions: refusal.severity === 'block' ? [removal(event)] : [],
-      });
+      blockers.push(sessionBlocker(event, refusal, {
+        title: overridden ? ACKNOWLEDGED_LEAD_TIME_TITLE : REFUSAL_TITLES[refusal.kind],
+        actions: answersFor(event, refusal, overridden),
+      }));
     }
+
+    // Once the lead time stops refusing, the room is the thing left worth
+    // saying — and `sessionRefusal` never reached it, because the lead time
+    // outranks it there.
+    const capacity = overridden ? capacityRefusal(event) : null;
+    if (capacity) blockers.push(sessionBlocker(event, capacity));
 
     // Room is a second question from "is it full", and both are warnings.
     // A null is not a zero — it is Clubworx declining to say, passed through
     // untouched by the Worker for exactly this reason.
     const spaces = event.spaces_available;
-    if (refusal?.kind !== 'full' && typeof spaces === 'number' && studentCount > 0 && spaces < studentCount) {
+    const reportedFull = refusal?.kind === 'full' || capacity?.kind === 'full';
+    if (!reportedFull && typeof spaces === 'number' && studentCount > 0 && spaces < studentCount) {
       blockers.push({
         key: `spaces:${event.event_id}`,
         kind: 'spaces',
@@ -391,7 +535,14 @@ export function selectionReport({ events, selected, studentCount = 0, truncated 
   return {
     events: picked,
     blockers,
+    // Unchanged, and deliberately: readiness has always been the absence of any
+    // block, so an acknowledged session un-darkens Apply by dropping to a warn
+    // rather than by any new gate being wired (ADR 0007).
     ready: !blockers.some((b) => b.severity === 'block'),
+    // The list the run carries to the Worker, in timetable order. Ids, never a
+    // flag — a flag would also excuse a session that crossed into the lead time
+    // after selection, and one the operator never saw.
+    acknowledgedEventIds,
     sessions: picked.length,
     students: studentCount,
     bookings: picked.length * studentCount,

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -24,7 +24,7 @@
 // already has a contact comes back as `new`, and a second permanent contact is
 // written for them. Nothing throws: both spellings are individually valid, and
 // contacts cannot be deleted.
-import { compareForm } from './parse.js?v=5';
+import { compareForm } from './parse.js?v=6';
 
 // ---------------------------------------------------------------------------
 // Match states (P2b)

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -39,7 +39,7 @@
 // written something the Worker answers 200 and carries `reason: "throttled"`,
 // because the body is then the only record of what was written.
 
-import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=5';
+import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=6';
 
 /** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
 export const RETRY_BACKOFF_MS = 20_000;
@@ -272,10 +272,17 @@ export function runStore(storage, key) {
  * @param {object} opts.preview `buildPreview`'s result
  * @param {object[]} opts.rows step 3's rows, which carry the **write form** of the name
  * @param {string} opts.email the school marker
+ * @param {string[]} [opts.acknowledgedEventIds] the sessions an operator stated
+ *   they have lifted the Clubworx booking restriction for (ADR 0007). Sent per
+ *   student, because the gate they narrow is a per-student backstop in the
+ *   write chain. Omitted from the payload entirely when there are none, so a
+ *   run nobody overrode is the run this route already took.
  */
-export function runList({ preview, rows, email } = {}) {
+export function runList({ preview, rows, email, acknowledgedEventIds = [] } = {}) {
   const plan = preview?.plan ?? null;
   if (!plan?.membership_plan_id || !email) return [];
+
+  const acknowledged = (Array.isArray(acknowledgedEventIds) ? acknowledgedEventIds : []).map(String);
 
   const source = new Map((rows ?? []).map((r) => [r.key, r]));
   const events = (preview?.sessions ?? []).map((e) => ({
@@ -309,6 +316,7 @@ export function runList({ preview, rows, email } = {}) {
           membership_plan_id: plan.membership_plan_id,
           membership_duration: plan.membership_duration ?? '',
           events,
+          ...(acknowledged.length > 0 ? { lead_time_acknowledged_event_ids: acknowledged } : {}),
         },
       };
     });

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -43,7 +43,7 @@
 //
 // Bump this in lockstep with school-booking.html. alpine-bindings.test.js
 // fails if the two ever disagree.
-import { compareForm, readDate, writeForm } from './parse.js?v=5';
+import { compareForm, readDate, writeForm } from './parse.js?v=6';
 
 const DOMAIN = 'urbanjungleirc.com';
 

--- a/school-booking/test/events.test.js
+++ b/school-booking/test/events.test.js
@@ -8,7 +8,9 @@
 
 import { describe, expect, test } from 'vitest';
 import {
+  acknowledgeLeadTime,
   defaultWindow,
+  leadTimeAcknowledged,
   sessionRefusal,
   preTicked,
   resolvePastedId,
@@ -205,9 +207,12 @@ describe('selectionReport', () => {
     const blocker = report.blockers.find((b) => b.kind === 'lead-time');
     expect(blocker.severity).toBe('block');
     // D9: the fix is offered, never taken. A session dropped on the page's own
-    // initiative is the silent adjustment the whole design refuses.
+    // initiative is the silent adjustment the whole design refuses. ADR 0007
+    // adds a second answer beside it — keeping the session — and neither is
+    // taken by the page itself.
     expect(blocker.actions).toEqual([
       { key: 'remove:c', label: 'Remove this session', answers: 'remove', value: 'c' },
+      { key: 'ack:c', label: 'Keep it and book anyway', answers: 'acknowledge-lead-time', value: 'c' },
     ]);
     expect(blocker.detail).toMatch(/24 hours/);
   });
@@ -280,6 +285,267 @@ describe('selectionReport', () => {
     const warning = report.blockers.find((b) => b.kind === 'truncated');
     expect(warning.severity).toBe('warn');
     expect(report.ready).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADR 0007 — the lead time is an operator override, not a law
+// ---------------------------------------------------------------------------
+
+describe('acknowledgeLeadTime — the per-session decision log', () => {
+  test('an acknowledgement is recorded against the event id', () => {
+    expect(acknowledgeLeadTime({}, 'c', { kind: 'lifted' })).toEqual({ c: { kind: 'lifted' } });
+  });
+
+  test('a new object comes back, so an undo is observable', () => {
+    // Alpine re-renders from the returned value. The same object mutated in
+    // place leaves the screen showing the decision that was just taken back.
+    const before = {};
+    const after = acknowledgeLeadTime(before, 'c', { kind: 'lifted' });
+    expect(before).toEqual({});
+    expect(after).not.toBe(before);
+  });
+
+  test('taking one back leaves nothing behind', () => {
+    // Unlike step 3's log there is no gate here asking *did staff work this* —
+    // so an un-acknowledged session is exactly a session nobody acknowledged.
+    const log = acknowledgeLeadTime({}, 'c', { kind: 'lifted' });
+    expect(acknowledgeLeadTime(log, 'c', null)).toEqual({});
+  });
+
+  test('ids are keyed as strings, so a numeric id and a pasted one agree', () => {
+    const log = acknowledgeLeadTime({}, 101, { kind: 'lifted' });
+    expect(leadTimeAcknowledged(log, '101')).toBe(true);
+    expect(leadTimeAcknowledged(log, 101)).toBe(true);
+    expect(leadTimeAcknowledged(log, '102')).toBe(false);
+  });
+
+  test('an empty log acknowledges nothing', () => {
+    expect(leadTimeAcknowledged(undefined, 'c')).toBe(false);
+  });
+});
+
+describe('selectionReport — an acknowledged session is kept, not hidden', () => {
+  const ok = event({ event_id: 'a' });
+  const soon = (id, over = {}) => event({
+    event_id: id,
+    event_start_at: '2026-08-21T18:00:00+08:00',
+    bookable: false,
+    lead: { hoursAhead: 4, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+    ...over,
+  });
+  const lifted = (...ids) => Object.fromEntries(ids.map((id) => [String(id), { kind: 'lifted' }]));
+
+  test('an acknowledged session warns instead of blocking, and names the lifted restriction', () => {
+    const report = selectionReport({
+      events: [ok, soon('c')],
+      selected: ['a', 'c'],
+      studentCount: 6,
+      acknowledged: lifted('c'),
+    });
+    const blocker = report.blockers.find((b) => b.kind === 'lead-time');
+    expect(blocker.severity).toBe('warn');
+    expect(blocker.detail).toMatch(/restriction/i);
+    expect(blocker.detail).toMatch(/Clubworx/);
+  });
+
+  test('it stays in the list — a session that vanishes is invisible and unexplained', () => {
+    // The shape D9 rejects, wearing a different hat.
+    const report = selectionReport({
+      events: [soon('c')],
+      selected: ['c'],
+      studentCount: 6,
+      acknowledged: lifted('c'),
+    });
+    expect(report.blockers.filter((b) => b.kind === 'lead-time')).toHaveLength(1);
+  });
+
+  test('it keeps its removal and gains the way back', () => {
+    // ADR 0007: "Each too-soon session keeps its own blocker and its existing
+    // removal, and gains a second answer beside it." The only warning here that
+    // carries a removal, and it earned the exception by having been a block one
+    // click ago — the removal was already on offer.
+    const report = selectionReport({
+      events: [soon('c')],
+      selected: ['c'],
+      studentCount: 6,
+      acknowledged: lifted('c'),
+    });
+    const blocker = report.blockers.find((b) => b.kind === 'lead-time');
+    expect(blocker.actions).toEqual([
+      { key: 'remove:c', label: 'Remove this session', answers: 'remove', value: 'c' },
+      { key: 'unack:c', label: 'Take that back', answers: 'unacknowledge-lead-time', value: 'c' },
+    ]);
+  });
+
+  test('acknowledging every too-soon session flips the selection to ready', () => {
+    const report = selectionReport({
+      events: [soon('c'), soon('d')],
+      selected: ['c', 'd'],
+      studentCount: 6,
+      acknowledged: lifted('c', 'd'),
+    });
+    expect(report.ready).toBe(true);
+  });
+
+  test('acknowledging some of several does not', () => {
+    // Readiness is still derived from the absence of any block. Nothing new is
+    // gated; the remaining session simply still blocks.
+    const report = selectionReport({
+      events: [soon('c'), soon('d')],
+      selected: ['c', 'd'],
+      studentCount: 6,
+      acknowledged: lifted('c'),
+    });
+    expect(report.ready).toBe(false);
+    expect(report.blockers.filter((b) => b.severity === 'block')).toHaveLength(1);
+  });
+
+  test('taking an acknowledgement back restores the block', () => {
+    const log = acknowledgeLeadTime(acknowledgeLeadTime({}, 'c', { kind: 'lifted' }), 'c', null);
+    const report = selectionReport({
+      events: [soon('c')], selected: ['c'], studentCount: 6, acknowledged: log,
+    });
+    expect(report.ready).toBe(false);
+    expect(report.blockers.find((b) => b.kind === 'lead-time').severity).toBe('block');
+  });
+
+  test('an acknowledgement naming an event outside the loaded window changes nothing', () => {
+    // Re-searching the dates must not resurrect a stale one, and an id nobody
+    // can see on screen is one nobody took responsibility for.
+    const report = selectionReport({
+      events: [soon('c')],
+      selected: ['c'],
+      studentCount: 6,
+      acknowledged: lifted('gone'),
+    });
+    expect(report.ready).toBe(false);
+    expect(report.acknowledgedEventIds).toEqual([]);
+  });
+
+  test('an acknowledgement on a session nobody ticked is inert', () => {
+    const report = selectionReport({
+      events: [ok, soon('c')],
+      selected: ['a'],
+      studentCount: 6,
+      acknowledged: lifted('c'),
+    });
+    expect(report.acknowledgedEventIds).toEqual([]);
+    expect(report.ready).toBe(true);
+  });
+
+  test('an acknowledgement on a session that is not too soon is inert', () => {
+    const report = selectionReport({
+      events: [ok], selected: ['a'], studentCount: 6, acknowledged: lifted('a'),
+    });
+    expect(report.acknowledgedEventIds).toEqual([]);
+    expect(report.blockers).toEqual([]);
+  });
+
+  test('an unreadable start time is NOT overridable', () => {
+    // "We cannot check this" must never become "you may override this".
+    const broken = event({
+      event_id: 'f',
+      event_start_at: 'whenever',
+      bookable: false,
+      lead: { hoursAhead: null, past: null, withinLeadTime: null, minLeadHours: 24, unreadable: true },
+    });
+    const report = selectionReport({
+      events: [broken], selected: ['f'], studentCount: 6, acknowledged: lifted('f'),
+    });
+    const blocker = report.blockers.find((b) => b.kind === 'unreadable-session');
+    expect(blocker.severity).toBe('block');
+    expect(blocker.actions.map((a) => a.answers)).toEqual(['remove']);
+    expect(report.ready).toBe(false);
+    expect(report.acknowledgedEventIds).toEqual([]);
+  });
+
+  test('an already-started session is NOT overridable', () => {
+    // Not a restriction the gym can lift.
+    const past = event({
+      event_id: 'e',
+      event_start_at: '2026-08-01T09:00:00+08:00',
+      bookable: false,
+      lead: { hoursAhead: -480, past: true, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+    });
+    const report = selectionReport({
+      events: [past], selected: ['e'], studentCount: 6, acknowledged: lifted('e'),
+    });
+    const blocker = report.blockers.find((b) => b.kind === 'past-session');
+    expect(blocker.severity).toBe('block');
+    expect(blocker.actions.map((a) => a.answers)).toEqual(['remove']);
+    expect(report.ready).toBe(false);
+    expect(report.acknowledgedEventIds).toEqual([]);
+  });
+
+  test('too soon AND full still reports the lead time first, and keeps the capacity warning once acknowledged', () => {
+    // The lead time outranks the room because only one of them refuses. Once
+    // it stops refusing, the room is the thing left worth saying.
+    // Clubworx declines to say how many spaces are left, so `full` is the only
+    // thing carrying the room — the case where suppressing it would lose it.
+    const both = soon('c', { event_full: true, spaces_available: null });
+
+    const blocked = selectionReport({ events: [both], selected: ['c'], studentCount: 6 });
+    expect(blocked.blockers[0]).toMatchObject({ kind: 'lead-time', severity: 'block' });
+
+    const report = selectionReport({
+      events: [both], selected: ['c'], studentCount: 6, acknowledged: lifted('c'),
+    });
+    expect(report.blockers.map((b) => b.kind)).toEqual(['lead-time', 'full']);
+    expect(report.blockers.every((b) => b.severity === 'warn')).toBe(true);
+    expect(report.ready).toBe(true);
+  });
+
+  test('the room is never said twice, acknowledged or not', () => {
+    // A count of zero raises `spaces` on its own today, and `full` would say
+    // the same thing beside it — the two-banners-one-message fault #71 fixed.
+    const both = soon('c', { event_full: true, spaces_available: 0 });
+
+    const blocked = selectionReport({ events: [both], selected: ['c'], studentCount: 6 });
+    expect(blocked.blockers.map((b) => b.kind)).toEqual(['lead-time', 'spaces']);
+
+    const report = selectionReport({
+      events: [both], selected: ['c'], studentCount: 6, acknowledged: lifted('c'),
+    });
+    expect(report.blockers.map((b) => b.kind)).toEqual(['lead-time', 'full']);
+  });
+
+  test('the acknowledged ids travel with the report, in timetable order', () => {
+    const report = selectionReport({
+      events: [soon('d', { event_start_at: '2026-08-21T19:00:00+08:00' }), soon('c')],
+      selected: ['c', 'd'],
+      studentCount: 6,
+      acknowledged: lifted('c', 'd'),
+    });
+    expect(report.acknowledgedEventIds).toEqual(['c', 'd']);
+  });
+
+  test('a selection with no acknowledgements reports none', () => {
+    const report = selectionReport({ events: [ok], selected: ['a'], studentCount: 6 });
+    expect(report.acknowledgedEventIds).toEqual([]);
+  });
+});
+
+describe('sessionRefusal — an acknowledged session says so on the row too', () => {
+  const soon = event({
+    event_id: 'c',
+    bookable: false,
+    lead: { hoursAhead: 4, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+  });
+
+  test('acknowledged, it drops to a warning and names the lifted restriction', () => {
+    // The picker's row styling asks this too, so the row and the blocker can
+    // never disagree about whether the run can proceed — §16's fault shape.
+    expect(sessionRefusal(soon, true)).toEqual({
+      kind: 'lead-time',
+      severity: 'warn',
+      message: expect.stringMatching(/restriction/i),
+    });
+  });
+
+  test('unacknowledged, nothing moves', () => {
+    expect(sessionRefusal(soon).severity).toBe('block');
+    expect(sessionRefusal(soon, false).severity).toBe('block');
   });
 });
 

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -74,6 +74,16 @@ const EVENTS = [
   },
 ];
 
+// A Newman session that starts inside the lead time, ahead of the two above so
+// `pickSeries` ticks all three. ADR 0007's whole subject.
+const SOON = {
+  event_id: 'e0', event_name: 'School Session — Newman', event_start_at: '2026-08-22T09:00:00+08:00',
+  event_end_at: '2026-08-22T10:30:00+08:00', location_id: 'loc-1', location_name: 'Urban Jungle',
+  free_class: false, event_full: false, spaces_available: 30,
+  lead: { hoursAhead: 4, past: false, withinLeadTime: true, minLeadHours: 24, unreadable: false },
+  bookable: false,
+};
+
 const PLAN = {
   ok: true,
   plan: {
@@ -1317,6 +1327,248 @@ describe('step 4 says each thing once', () => {
     app.pickSeries('e1');
     expect(app.selection.sessions).toBe(2);
     expect(app.sessionsLine()).toBe('2 sessions × 6 students = 12 bookings.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADR 0007 / #144 — a too-soon session an operator keeps
+// ---------------------------------------------------------------------------
+
+const withSoon = async (opts = {}) => {
+  const app = await withEvents(component({ eventList: [SOON, ...EVENTS], ...opts }));
+  app.pickSeries('e0'); // e0, e1, e2 — the whole Newman series
+  return app;
+};
+
+const leadTimeBlocker = (app) => app.selection.blockers.find((b) => b.kind === 'lead-time');
+
+describe('the lead-time override (ADR 0007, #144)', () => {
+  test('a too-soon session still blocks, and now offers keeping it beside removing it', async () => {
+    const app = await withSoon();
+    expect(app.picked).toEqual(['e0', 'e1', 'e2']);
+    expect(app.selection.ready).toBe(false);
+
+    const blocker = leadTimeBlocker(app);
+    expect(blocker.severity).toBe('block');
+    expect(blocker.actions.map((a) => a.answers)).toEqual(['remove', 'acknowledge-lead-time']);
+  });
+
+  test('taking the second answer raises a confirmation rather than acting on it', async () => {
+    // It is a confirmation, not a formality to click past: the whole safety of
+    // this feature is a human agreeing to go and lift a restriction by hand.
+    const app = await withSoon();
+    app.answerSelection(leadTimeBlocker(app).actions[1]);
+
+    expect(app.leadTimeConfirm).toBe('e0');
+    expect(app.selection.ready).toBe(false);
+    expect(leadTimeBlocker(app).severity).toBe('block');
+  });
+
+  test('the confirmation names the session and what happens if the restriction is not lifted', async () => {
+    const app = await withSoon();
+    app.answerSelection(leadTimeBlocker(app).actions[1]);
+
+    const line = app.leadTimeConfirmLine();
+    expect(line).toContain('School Session — Newman');
+    expect(line).toContain('2026-08-22');
+    expect(line).toMatch(/restriction/i);
+    expect(line).toMatch(/Clubworx/);
+    // The consequence, concretely: refusals, and the third in a row stops it.
+    expect(line).toMatch(/every booking/i);
+    expect(line).toMatch(/halt|stop/i);
+  });
+
+  test('cancelling leaves the session refusing, and nothing acknowledged', async () => {
+    const app = await withSoon();
+    app.answerSelection(leadTimeBlocker(app).actions[1]);
+    app.cancelLeadTimeOverride();
+
+    expect(app.leadTimeConfirm).toBe(null);
+    expect(app.selection.ready).toBe(false);
+    expect(app.selection.acknowledgedEventIds).toEqual([]);
+  });
+
+  test('confirming drops it to a warning, keeps it on screen, and un-darkens Apply', async () => {
+    const app = await withSoon();
+    app.answerSelection(leadTimeBlocker(app).actions[1]);
+    app.confirmLeadTimeOverride();
+
+    expect(app.leadTimeConfirm).toBe(null);
+    const blocker = leadTimeBlocker(app);
+    // Still listed. A session that vanishes once acknowledged is invisible and
+    // unexplained — the shape D9 already rejected.
+    expect(blocker).toBeTruthy();
+    expect(blocker.severity).toBe('warn');
+    expect(blocker.detail).toMatch(/restriction/i);
+    expect(app.selection.ready).toBe(true);
+    expect(app.selection.acknowledgedEventIds).toEqual(['e0']);
+  });
+
+  test('the picker row agrees with the blocker about severity', async () => {
+    // §16's fault shape: two surfaces contradicting each other about whether a
+    // run can proceed. The row asks the same module the report does.
+    const app = await withSoon();
+    const soon = app.events.find((e) => e.event_id === 'e0');
+    expect(app.eventLane(soon)).toBe('lane-bad');
+    expect(app.eventWarningTone(soon)).toBe('text-rose-700');
+
+    app.answerSelection(leadTimeBlocker(app).actions[1]);
+    app.confirmLeadTimeOverride();
+
+    expect(app.eventLane(soon)).toBe('lane-need');
+    expect(app.eventWarningTone(soon)).toBe('text-amber-700');
+    expect(app.eventWarning(soon)).toMatch(/restriction/i);
+  });
+
+  test('an acknowledgement can be taken back, and the block comes back with it', async () => {
+    const app = await withSoon();
+    app.answerSelection(leadTimeBlocker(app).actions[1]);
+    app.confirmLeadTimeOverride();
+    expect(app.selection.ready).toBe(true);
+
+    // Still two answers, the removal first — an acknowledged session keeps it.
+    const answers = leadTimeBlocker(app).actions;
+    expect(answers.map((a) => a.answers)).toEqual(['remove', 'unacknowledge-lead-time']);
+
+    app.answerSelection(answers[1]);
+    expect(leadTimeBlocker(app).severity).toBe('block');
+    expect(app.selection.ready).toBe(false);
+    expect(app.selection.acknowledgedEventIds).toEqual([]);
+  });
+
+  test('acknowledging one of two too-soon sessions does not open the door', async () => {
+    const second = { ...SOON, event_id: 'e0b', event_start_at: '2026-08-22T13:00:00+08:00' };
+    const app = await withEvents(component({ eventList: [SOON, second, ...EVENTS] }));
+    app.pickSeries('e0');
+    expect(app.picked).toEqual(['e0', 'e0b', 'e1', 'e2']);
+
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    expect(app.selection.ready).toBe(false);
+    expect(app.selection.acknowledgedEventIds).toEqual(['e0']);
+
+    // Per session, throughout. There is no control that clears them all.
+    app.askLeadTimeOverride('e0b');
+    app.confirmLeadTimeOverride();
+    expect(app.selection.ready).toBe(true);
+    expect(app.selection.acknowledgedEventIds).toEqual(['e0', 'e0b']);
+  });
+
+  test('un-ticking an acknowledged session withdraws it, and ticking it again asks again', async () => {
+    // The statement is about a session in this run. A session that comes back
+    // pre-forgiven by a confirmation nobody re-took is the one thing the
+    // confirmation exists to prevent.
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    app.togglePick('e0');
+
+    expect(app.picked).toEqual(['e1', 'e2']);
+    expect(app.selection.acknowledgedEventIds).toEqual([]);
+
+    app.togglePick('e0');
+    expect(app.picked).toContain('e0');
+    expect(leadTimeBlocker(app).severity).toBe('block');
+    expect(app.selection.ready).toBe(false);
+  });
+
+  test('removing an acknowledged session from its own blocker withdraws the statement too', async () => {
+    // The removal and the checkbox are the same act, so they cannot leave the
+    // log in two different states.
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+
+    app.answerSelection(leadTimeBlocker(app).actions[0]); // Remove this session
+    expect(app.picked).toEqual(['e1', 'e2']);
+    expect(app.leadTimeAcknowledgements).toEqual({});
+    expect(app.selection.ready).toBe(true);
+  });
+
+  test('a re-search cannot resurrect an acknowledgement for a session it dropped', async () => {
+    // The tick is already dropped when a window no longer holds the session
+    // (loadEvents), and the statement about it goes with it. Otherwise the
+    // session comes back ticked-and-forgiven by a decision nobody re-took.
+    const list = [SOON, ...EVENTS];
+    const app = await withEvents(component({ eventList: list }));
+    app.pickSeries('e0');
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    expect(app.selection.ready).toBe(true);
+
+    list.shift(); // a narrower window, without the too-soon session
+    await app.loadEvents();
+    expect(app.picked).toEqual(['e1', 'e2']);
+
+    list.unshift(SOON); // and back again
+    await app.loadEvents();
+    app.pickSeries('e0');
+    expect(leadTimeBlocker(app).severity).toBe('block');
+    expect(app.selection.ready).toBe(false);
+  });
+
+  test('an unreadable or already-started session is never overridable', async () => {
+    const broken = {
+      ...SOON, event_id: 'x1', event_name: 'School Session — Harlow', event_start_at: 'whenever',
+      lead: { hoursAhead: null, past: null, withinLeadTime: null, minLeadHours: 24, unreadable: true },
+    };
+    const past = {
+      ...SOON, event_id: 'x2', event_name: 'School Session — Harlow', event_start_at: '2026-08-01T09:00:00+08:00',
+      lead: { hoursAhead: -480, past: true, withinLeadTime: false, minLeadHours: 24, unreadable: false },
+    };
+    const app = await withEvents(component({ eventList: [broken, past, ...EVENTS] }));
+    app.picked = ['x1', 'x2'];
+    app.refreshSelection();
+
+    for (const kind of ['unreadable-session', 'past-session']) {
+      const blocker = app.selection.blockers.find((b) => b.kind === kind);
+      expect(blocker.severity).toBe('block');
+      expect(blocker.actions.map((a) => a.answers)).toEqual(['remove']);
+    }
+    expect(app.selection.ready).toBe(false);
+  });
+});
+
+describe('the override reaches the wire (#144)', () => {
+  test('every student carries the acknowledged ids', async () => {
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+    app.askApply();
+    await app.apply();
+
+    expect(app.__writes).toHaveLength(6);
+    for (const write of app.__writes) {
+      expect(write.body.lead_time_acknowledged_event_ids).toEqual(['e0']);
+      // Narrowed, never switched off: the other two sessions are not on it.
+      expect(write.body.events.map((e) => e.event_id)).toEqual(['e0', 'e1', 'e2']);
+    }
+  });
+
+  test('a run nobody overrode sends no acknowledgement key at all', async () => {
+    const app = await upToApply(component());
+    expect(app.__writes).toHaveLength(6);
+    for (const write of app.__writes) {
+      expect(write.body).not.toHaveProperty('lead_time_acknowledged_event_ids');
+    }
+  });
+});
+
+describe('the override confirmation is on the page, and bound (#144)', () => {
+  test('the blocker list renders it against the session it is about', () => {
+    // Both blocker lists dispatch through `answerSelection`, so a confirmation
+    // rendered on only one of them is an action that silently does nothing on
+    // the other.
+    const lists = html.split('@click="answerSelection(action)"').length - 1;
+    expect(lists).toBe(2);
+    expect(html.split('leadTimeConfirm === blocker.eventId').length - 1).toBe(lists);
+  });
+
+  test('the confirmation offers both ways out', () => {
+    expect(html).toContain('confirmLeadTimeOverride()');
+    expect(html).toContain('cancelLeadTimeOverride()');
+    expect(html).toContain('leadTimeConfirmLine()');
   });
 });
 

--- a/school-booking/test/run.test.js
+++ b/school-booking/test/run.test.js
@@ -417,6 +417,29 @@ describe('runList — turning the preview into calls', () => {
     ]);
   });
 
+  test('a run with no acknowledgements sends the payload it sends today', () => {
+    // ADR 0007's key appears only when a human vouched for something. Absent is
+    // the honest encoding of "nobody acknowledged anything", and it keeps a
+    // no-override run byte-identical to the one before this feature existed.
+    const [ada] = runList({ preview, rows, email: 'noreply+x@urbanjungleirc.com' });
+    expect(ada.payload).not.toHaveProperty('lead_time_acknowledged_event_ids');
+
+    const none = runList({ preview, rows, email: 'noreply+x@urbanjungleirc.com', acknowledgedEventIds: [] });
+    expect(none[0].payload).not.toHaveProperty('lead_time_acknowledged_event_ids');
+  });
+
+  test('the acknowledged event ids travel with every student', () => {
+    // Per student, because the gate they narrow is a per-student backstop in
+    // the write chain — one call per student is the whole shape of this run.
+    const list = runList({
+      preview, rows, email: 'noreply+x@urbanjungleirc.com', acknowledgedEventIds: ['e1'],
+    });
+    expect(list).toHaveLength(2);
+    for (const student of list) {
+      expect(student.payload.lead_time_acknowledged_event_ids).toEqual(['e1']);
+    }
+  });
+
   test('a preview with no resolved plan produces no calls at all', () => {
     const list = runList({ preview: { ...preview, plan: null }, rows, email: 'noreply+x@urbanjungleirc.com' });
     expect(list).toEqual([]);


### PR DESCRIPTION
Closes #144. ADR 0007's tracer bullet, page-side. The Worker half shipped in #143, so the write chain already refuses only *unacknowledged* sessions — this is the screen that produces the acknowledgements.

## What changed

A too-soon session keeps its **Remove this session** answer and gains a second one beside it: keep it, and state that its Clubworx booking restriction has been lifted by hand. Taking that answer raises a confirmation naming the session and the consequence — every booking for it fails as an ordinary refusal, and the third in a row halts the run.

An acknowledged session drops from `block` to `warn` and **stays in the blocker list**, keeping its removal and gaining the way back. Readiness is still the absence of any block, so Apply un-darkens on its own and no new gate is wired.

The acknowledgements are a decision log keyed by event id — the same shape as step 3's resolutions and step 5's match decisions. An acknowledgement lasts exactly as long as its tick: un-ticking withdraws it, whether by checkbox, by the blocker's own removal, or by a re-search that drops the session, so a session can never come back pre-forgiven by a confirmation nobody re-took.

Only the lead time is overridable. An unreadable start means the rule could not be checked at all; an already-started session is not a restriction the gym can lift. Both stay hard-stops, asserted explicitly.

The acknowledged ids travel to the write chain as `lead_time_acknowledged_event_ids` — read off the selection rather than the log, a list per student, never a flag, and omitted entirely when there are none, so a run nobody overrode is byte-identical to the one this route already took.

## Review

Both axes of `/code-review` ran and their findings are applied.

**Standards** caught a page method shadowing the module's while doing something different (`acknowledgeLeadTime` → `askLeadTimeOverride`), a `fullRefusal` whose docstring contradicted its name (`capacityRefusal`), a duplicated blocker literal and a three-deep ternary (extracted to `sessionBlocker` / `answersFor`), and a bug where taking back one session's acknowledgement closed another session's open confirmation.

**Spec** caught a real deviation: the acknowledged blocker had *lost* its removal, against ADR 0007's "keeps its own blocker and its existing removal". Corrected — and since that opened a hole where removing an acknowledged session left the statement behind, acknowledgements are now dropped on un-tick by every path.

## Testing

554 tests in `school-booking/`, ~45 of them new and mapping onto the issue's acceptance criteria. A mutation check (broadening the acknowledged-id derivation) fails 7 of them, so the suite genuinely distinguishes *narrowed* from *switched off* — the tell ADR 0007 names for the rejected flag design.

The one repo-wide failure, `vouchers/test/version.test.js`, is pre-existing and unrelated; it fails identically on a clean `main`.

## Not covered here

- **The live end-to-end criterion.** "Acknowledge a too-soon session whose restriction has been lifted in Clubworx, run it, and the bookings land" needs a real gym run. The contract matches #143 end to end, but nobody has exercised it against production.
- **The confirmation also renders in step 5's preview blocker list.** #144 scopes the override to session selection, but `preview.js` already carried selection blockers *with their actions* verbatim, so the chip would be dead there otherwise. Adjacent to #145's territory — a conscious accept.
- #145 (the aggregate lifted-sessions sentence) and #146 (the restore reminder and run record) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBEEQhSPQ8MUygKPf4wEHX