### PR TITLE
Lead-time override: name the lifted sessions on the confirmation step (#145)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,19 @@ school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #10
                           confirmation. Both are cleared by the reset: a
                           statement about the last import's sessions is not a
                           statement about this one's.
+                          afterSelectionChange() rebuilds the selection AND
+                          the preview, and EVERY change to the selection goes
+                          through it — the acknowledgement handlers, togglePick,
+                          pickSeries and loadEvents. That is the whole of #145's
+                          "reflected without a reload", and it also fixed a
+                          preview left describing the old run after a tick
+                          changed (step 5's blocker list offers "Remove this
+                          session", so this was reachable from the preview
+                          itself). Rebuilt, never discarded: discardPreview() is
+                          for a step-3 edit, where the STUDENTS changed and the
+                          Clubworx check is genuinely void. A tick change costs
+                          nothing to rebuild and must not re-spend the
+                          allowance.
                           askLeadTimeOverride() only OPENS that confirmation;
                           confirmLeadTimeOverride() is the only thing that
                           writes to the log. keepAcknowledgementsForPicked() is
@@ -229,6 +242,17 @@ school-booking/preview.js - step 5: the STUDENT/DOB/READ/CLUBWORX/OUTCOME table,
                           Apply" rather than "pass already active". An absent
                           answer is `pending`, never `new` — `new` writes a
                           contact Clubworx cannot delete.
+                          liftedRestrictionsLine() is #145's second run-level
+                          fact, beside the permanence line and never inside it:
+                          the sessions this run will book with their Clubworx
+                          restriction lifted by hand (ADR 0007), named with
+                          events.js's sessionLabel() — the same label the picker
+                          and the blocker use, which is the only reason this
+                          module imports events.js. It is SILENT when nothing
+                          was acknowledged; a line that is always present is one
+                          that stops being read. It does not replace the
+                          session's own warning, which arrives here from
+                          selection carried verbatim, actions included.
                           runFingerprint() is #111's already-run gate, and it
                           SUPERSEDES §12 D13, which decided the opposite — read
                           the note there before touching it. Its own header says

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -734,7 +734,8 @@ keep.
 
 The **one-day minimum** between booking and a School Session starting,
 server-enforced and knowable client-side from the event start. A selected event
-inside it hard-stops the run before any write.
+inside it hard-stops the run before any write **unless an operator states they
+have lifted its Clubworx booking restriction** (ADR 0007) — see below.
 
 Staff must never meet Clubworx's own message here — *"Sorry! This class is now
 closed for bookings."* — which names no cause and reads like a capacity problem.
@@ -744,31 +745,33 @@ blocker, and the write chain re-checks per student as a backstop before any
 write. Neither is the whole rule, and the minimum itself is defined once and
 re-exported to the write chain.
 
-> **Becoming an operator override — decided 2026-08-25, half built**
+> **An operator override — decided 2026-08-25, built except the reminder**
 > ([ADR 0007](docs/adr/0007-lead-time-is-an-operator-override.md),
 > [#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#146](https://github.com/urbanjungleirc/staff-site/issues/146)).
-> The **write chain** now narrows its backstop to sessions absent from the
-> acknowledged list (#143). Nothing offers an operator a way to acknowledge one
-> yet, so the hard-stop above is still the whole truth of what *staff* can do —
-> and a request that names no acknowledgements behaves exactly as it always has.
+> The **write chain** narrows its backstop to sessions absent from the
+> acknowledged list (#143), the **session picker** offers the override and takes
+> the confirmation (#144), and the **confirmation step** names every session
+> carrying a lifted restriction above the preview table and again where the run
+> is started (#145). Still open: #146, the post-run reminder to put the
+> restriction back.
 >
 > The minimum is a *lift-able* Clubworx booking restriction, not a property of
 > time: a manager can remove it on the specific conflicted class, run the
-> bookings, and put it back. So a too-soon session will be keepable by an
-> operator who confirms they have done that — **per session**, never for a whole
-> run, with the session staying visible as overridden rather than disappearing,
-> and only for the lead time. An unreadable start time or an already-started
-> session stays a hard-stop either way.
+> bookings, and put it back. So a too-soon session is keepable by an operator
+> who confirms they have done that — **per session**, never for a whole run,
+> with the session staying visible as overridden rather than disappearing, and
+> only for the lead time. An unreadable start time or an already-started session
+> stays a hard-stop either way.
 >
 > Because the rule is enforced twice, an override travels to the Worker as the
 > **explicit list of acknowledged event ids**, so everything nobody acknowledged
 > is still refused. Never a run-wide flag: a session that crosses into the lead
 > time between selection and the write must still be caught.
 >
-> *Avoid*, once it is built: treating a lifted restriction as spent when the run
-> ends. The lasting damage in this whole area is a **class left open to public
-> booking** because nobody put the restriction back, which is why the run will
-> remind and why the reminder belongs in the run record.
+> *Avoid*: treating a lifted restriction as spent when the run ends. The lasting
+> damage in this whole area is a **class left open to public booking** because
+> nobody put the restriction back, which is why the run must remind (#146) and
+> why the reminder belongs in the run record.
 
 ### Unknown refusal
 

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -935,7 +935,7 @@ staleness. Nothing else is re-validated.
 | Condition | Ruling |
 |---|---|
 | School Pass plan unresolved, or the name ambiguous | **Hard-stop the run** |
-| Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* — **to become overridable per session; decided 2026-08-25, not yet built ([ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md))** |
+| Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* — **overridable per session since 2026-08-25: an operator who states they have lifted the class's Clubworx booking restriction keeps it, and it drops to a warning ([ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md), [#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#145](https://github.com/urbanjungleirc/staff-site/issues/145))** |
 | No events selected, or zero parseable rows | **Hard-stop** |
 | Any unresolved gate — unparseable row, count mismatch, unconfirmed age | **Hard-stop** (§9) |
 | The last selected session falls outside `today + membership_duration` | **Hard-stop the run** (§3, ADR 0005) |
@@ -947,9 +947,10 @@ adjustment. Staff must never meet Clubworx's own message here — *"Sorry! This
 class is now closed for bookings."* — which names no cause and reads like a
 capacity problem.
 
-> **Amended 2026-08-25, after the spec was written — decided, not yet built**
-> ([#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#146](https://github.com/urbanjungleirc/staff-site/issues/146) are open;
-> the table row above still describes what the tool does today). The hard-stop
+> **Amended 2026-08-25, after the spec was written — built except the reminder**
+> ([#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#145](https://github.com/urbanjungleirc/staff-site/issues/145)
+> shipped; [#146](https://github.com/urbanjungleirc/staff-site/issues/146), the post-run
+> reminder, is still open). The hard-stop
 > half of D9 is reversed: a too-soon session becomes **keepable, per session**, by
 > an operator who confirms they have lifted that class's Clubworx booking
 > restriction — it is a lift-able restriction, not a property of time, and

--- a/school-booking.html
+++ b/school-booking.html
@@ -68,14 +68,14 @@
      or missing module into a visible refusal rather than a page whose gates
      quietly do nothing. -->
 <script type="module">
-  import * as parser from './school-booking/parse.js?v=6';
-  import * as steps from './school-booking/steps.js?v=6';
-  import * as identity from './school-booking/identity.js?v=6';
-  import * as events from './school-booking/events.js?v=6';
-  import * as preview from './school-booking/preview.js?v=6';
-  import * as calendar from './school-booking/calendar.js?v=6';
-  import * as outcome from './school-booking/outcome.js?v=6';
-  import * as run from './school-booking/run.js?v=6';
+  import * as parser from './school-booking/parse.js?v=7';
+  import * as steps from './school-booking/steps.js?v=7';
+  import * as identity from './school-booking/identity.js?v=7';
+  import * as events from './school-booking/events.js?v=7';
+  import * as preview from './school-booking/preview.js?v=7';
+  import * as calendar from './school-booking/calendar.js?v=7';
+  import * as outcome from './school-booking/outcome.js?v=7';
+  import * as run from './school-booking/run.js?v=7';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
   window.schoolBookingIdentity = identity;
@@ -1221,6 +1221,26 @@
               <div class="font-semibold" x-text="permanenceLine()"></div>
             </div>
 
+            <!-- #145, ADR 0007. Beside the permanence line rather than inside
+                 it: the two are different facts, and the permanence box goes
+                 away when nothing is bookable while a lifted restriction is
+                 still a thing somebody has to put back. Its own x-show, so it
+                 is absent — not empty — when nothing was acknowledged.
+
+                 The acknowledged session's own warning is in the blocker list
+                 below, carried over from selection. This is the aggregate the
+                 operator approves the run against, which is what the per-session
+                 confirmation two steps ago could not be. -->
+            <div class="rounded-xl px-3.5 py-3 text-sm mb-3 bg-amber-50 border border-amber-300 border-l-4 border-l-amber-500 text-amber-900"
+                 x-show="liftedRestrictionsLine()" x-cloak>
+              <!-- A heading and a lighter sentence, where the permanence box is
+                   one bold line. Same amber — the severity is the same — but a
+                   different shape, so two stacked panels do not read as one
+                   sentence split in half. -->
+              <div class="font-semibold">Booking restrictions lifted by hand</div>
+              <div class="mt-1" x-text="liftedRestrictionsLine()"></div>
+            </div>
+
             <div class="space-y-2 mb-3">
               <template x-for="blocker in preview.blockers" :key="blocker.key">
                 <div class="rounded-xl px-3.5 py-2.5 text-sm"
@@ -1341,6 +1361,11 @@
               <div class="font-semibold">Before this starts</div>
               <div class="mt-1" x-text="runCost()"></div>
               <div class="mt-1" x-text="permanenceLine()"></div>
+              <!-- The same sentence again, because this is the click that
+                   starts the run and the restriction has to be off in Clubworx
+                   by then. Absent when nothing was acknowledged. -->
+              <div class="mt-1" x-show="liftedRestrictionsLine()" x-cloak
+                   x-text="liftedRestrictionsLine()"></div>
               <div class="text-xs mt-1 opacity-90">
                 Leave this tab open. Every student is written one at a time, and closing the page
                 mid-run loses the record of what was created.
@@ -2395,7 +2420,9 @@ function schoolBooking() {
         this.loadedFrom = '';
         this.loadedTo = '';
       }
-      this.refreshSelection();
+      // A narrower window drops ticks and the acknowledgements with them, so
+      // this changes the selection as surely as a click does.
+      this.afterSelectionChange();
     },
 
     eventsNote() {
@@ -2419,7 +2446,7 @@ function schoolBooking() {
       const key = String(id);
       this.picked = this.isPicked(key) ? this.picked.filter((p) => p !== key) : [...this.picked, key];
       this.keepAcknowledgementsForPicked();
-      this.refreshSelection();
+      this.afterSelectionChange();
     },
 
     // ADR 0007. An acknowledgement is a statement about a session **in this
@@ -2444,7 +2471,7 @@ function schoolBooking() {
     pickSeries(id) {
       this.picked = window.schoolBookingEvents.preTicked(this.events, id);
       this.keepAcknowledgementsForPicked();
-      this.refreshSelection();
+      this.afterSelectionChange();
     },
 
     // Resolved, then confirmed — never selected outright. §8: the paste is a
@@ -2582,7 +2609,7 @@ function schoolBooking() {
       this.leadTimeAcknowledgements = window.schoolBookingEvents
         .acknowledgeLeadTime(this.leadTimeAcknowledgements, eventId, { kind: 'lifted' });
       this.leadTimeConfirm = null;
-      this.afterAcknowledgement();
+      this.afterSelectionChange();
     },
 
     takeBackLeadTimeOverride(eventId) {
@@ -2593,7 +2620,7 @@ function schoolBooking() {
       // Only if it was this session's question. A confirmation open on one
       // session is not answered by a decision taken about another.
       if (this.leadTimeConfirm === String(eventId)) this.leadTimeConfirm = null;
-      this.afterAcknowledgement();
+      this.afterSelectionChange();
     },
 
     isLeadTimeAcknowledged(eventId) {
@@ -2611,7 +2638,21 @@ function schoolBooking() {
     // The selection always, and the preview when there is one to keep honest:
     // its blockers are the selection's, carried verbatim, so a decision taken
     // on either screen has to reach both.
-    afterAcknowledgement() {
+    //
+    // Every change to the selection comes through here, not just an
+    // acknowledgement (#145). A tick is a change to what the run books, and
+    // step 5's own blocker list offers "Remove this session" — so a tick
+    // changed from either screen left the preview describing a run that no
+    // longer existed: the old booking count, the old permanence sentence, and
+    // the name of a session nobody is booking any more.
+    //
+    // Rebuilt rather than discarded. A step-3 edit calls `discardPreview` and
+    // throws the Clubworx check away with it, which is right there — the
+    // students changed. Here they have not, and the check is 3 requests a
+    // student out of a gym-wide allowance. The preview is a pure function of
+    // what step 3, the check and the selection hold, so rebuilding it costs
+    // nothing and cannot be stale.
+    afterSelectionChange() {
       this.refreshSelection();
       if (this.preview) this.refreshPreview();
     },
@@ -2779,6 +2820,13 @@ function schoolBooking() {
 
     permanenceLine() {
       return window.schoolBookingPreview.permanenceLine(this.preview);
+    },
+
+    // #145. Derived from the preview, so `afterSelectionChange` rebuilding it
+    // is the whole of "reflected here without a reload" — there is no second
+    // copy of the acknowledgement list on this side to keep in step.
+    liftedRestrictionsLine() {
+      return window.schoolBookingPreview.liftedRestrictionsLine(this.preview);
     },
 
     consequenceLine(line) {

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -24,7 +24,7 @@
 // already has a contact comes back as `new`, and a second permanent contact is
 // written for them. Nothing throws: both spellings are individually valid, and
 // contacts cannot be deleted.
-import { compareForm } from './parse.js?v=6';
+import { compareForm } from './parse.js?v=7';
 
 // ---------------------------------------------------------------------------
 // Match states (P2b)

--- a/school-booking/preview.js
+++ b/school-booking/preview.js
@@ -42,6 +42,12 @@
 // are counted exactly, and returning students are named as a pass that has not
 // been settled rather than folded into the total either way.
 
+// Asked, not restated. A session reads the same here as it does on the step
+// that picked it and in the blocker that named it — #145 says "the same session
+// label used elsewhere", and a second spelling of a date is how two screens
+// come to disagree about which Tuesday they mean.
+import { sessionLabel } from './events.js?v=7';
+
 const plural = (n, noun) => `${n} ${noun}${n === 1 ? '' : 's'}`;
 // "School Pass" does not take a bare -s, and it is the noun this line is most
 // about. Spelled here rather than patched after the fact.
@@ -246,6 +252,46 @@ export function permanenceLine(preview) {
 }
 
 /**
+ * The sessions this run will book with their Clubworx restriction lifted by
+ * hand — #145, ADR 0007.
+ *
+ * The per-session confirmation (#144) is taken at the moment of
+ * *acknowledgement*, on the blocker. This is read at the moment of *approval*,
+ * over the whole run. They are two different readings and both are needed: an
+ * operator who acknowledged a Tuesday session two steps ago should not have to
+ * remember it to approve the run honestly.
+ *
+ * It says nothing when there is nothing to say. A line that is always present
+ * is a line that stops being read — the same argument that keeps the permanence
+ * sentence off all 63 rows.
+ *
+ * This does not replace the session's own blocker. That is carried into step 5
+ * verbatim from selection, warning and actions intact, so the override is
+ * visible both as a per-session warning and as this run-level fact.
+ */
+export function liftedRestrictionsLine(preview) {
+  const lifted = preview?.liftedSessionLabels ?? [];
+  if (lifted.length === 0) return '';
+
+  // Semicolons, because a session label contains a comma of its own: "School
+  // Session, 2026-09-01, School Session, 2026-09-08" reads as four things.
+  const named = lifted.join('; ');
+  const one = lifted.length === 1;
+
+  // "On your word" rather than "lifted by hand" a second time: the heading
+  // above this says what was done, and what this sentence has to add is *who
+  // said so*. Nothing has checked it — ADR 0007's whole safety is a person
+  // agreeing to go and lift a restriction, and an override taken without
+  // actually lifting one fails loudly, once per student, halting the run on the
+  // third. That is an acceptable failure mode precisely because it is said out
+  // loud first, and this is the last place to say it before Apply.
+  return `${plural(lifted.length, 'session')} ${one ? 'is' : 'are'} being booked on your word that `
+    + `${one ? 'its' : 'their'} Clubworx booking restriction has been lifted: ${named}. `
+    + `Every booking for ${one ? 'it' : 'them'} will fail if the restriction is still on when the `
+    + 'run starts.';
+}
+
+/**
  * What a run *is*, reduced to one comparable string — #111.
  *
  * The gate this feeds needs to answer "has this exact work already been done?",
@@ -368,6 +414,15 @@ export function buildPreview({ rows, matches, selection, review, plan, decisions
     });
   }
 
+  // Derived from the sessions actually picked, never from the id list alone:
+  // `selectionReport` only ever emits an id for a session on screen, and
+  // deriving the labels the same way means an id that outlives its session
+  // names nothing rather than naming an empty string.
+  const acknowledgedIds = new Set((picked.acknowledgedEventIds ?? []).map(String));
+  const liftedSessionLabels = (picked.events ?? [])
+    .filter((event) => acknowledgedIds.has(String(event?.event_id)))
+    .map((event) => sessionLabel(event));
+
   const fingerprint = runFingerprint({ schoolTag, preview: { rows: previewed, sessions: picked.events ?? [] } });
 
   // #111. `settled` is outcome.js's answer to "did this run leave anything
@@ -400,6 +455,13 @@ export function buildPreview({ rows, matches, selection, review, plan, decisions
     blockers,
     ready: !blockers.some((b) => b.severity === 'block'),
     plan: plan?.ok ? plan.plan : null,
+    // #145. Named for what it holds — label strings, not sessions and not ids.
+    // Everything downstream of here is a sentence a person reads; the ids the
+    // Worker needs travel on the selection report, which is where the run picks
+    // them up. Derived here rather than emitted by `selectionReport` on purpose:
+    // the ids are the contract (ADR 0007), and a second array of labels shipped
+    // beside them is two lists that have to stay in step.
+    liftedSessionLabels,
     sessions: picked.events ?? [],
     lastSession: picked.lastSession ?? null,
     fingerprint,

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -39,7 +39,7 @@
 // written something the Worker answers 200 and carries `reason: "throttled"`,
 // because the body is then the only record of what was written.
 
-import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=6';
+import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=7';
 
 /** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
 export const RETRY_BACKOFF_MS = 20_000;

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -43,7 +43,7 @@
 //
 // Bump this in lockstep with school-booking.html. alpine-bindings.test.js
 // fails if the two ever disagree.
-import { compareForm, readDate, writeForm } from './parse.js?v=6';
+import { compareForm, readDate, writeForm } from './parse.js?v=7';
 
 const DOMAIN = 'urbanjungleirc.com';
 

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -1555,6 +1555,180 @@ describe('the override reaches the wire (#144)', () => {
   });
 });
 
+describe('the lifted sessions are named on the confirmation step (#145)', () => {
+  const SOON_LABEL = 'School Session — Newman, 2026-08-22';
+
+  test('the run consequence names the session whose restriction was lifted', async () => {
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+
+    const line = app.liftedRestrictionsLine();
+    // The same label the picker and the blocker use, not a second spelling.
+    expect(line).toContain(SOON_LABEL);
+    expect(app.selection.blockers.find((b) => b.kind === 'lead-time').detail)
+      .toContain(SOON_LABEL);
+    expect(line).toMatch(/restriction/i);
+    expect(line).toMatch(/fail/i);
+  });
+
+  test('a run nobody overrode says nothing at all', async () => {
+    const app = await upToPreview(component());
+    expect(app.liftedRestrictionsLine()).toBe('');
+    // And the permanence sentence is still there beside the silence.
+    expect(app.permanenceLine()).not.toBe('');
+  });
+
+  test('the permanence sentence is unchanged by an override', async () => {
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+    const withOverride = app.permanenceLine();
+    expect(withOverride).not.toBe('');
+
+    // The same run, one acknowledgement lighter. What the run writes has not
+    // changed, so the sentence about what it writes must not have either — the
+    // override changes what is said *beside* it, never it.
+    app.takeBackLeadTimeOverride('e0');
+    expect(app.permanenceLine()).toBe(withOverride);
+    expect(app.liftedRestrictionsLine()).toBe('');
+  });
+
+  test("the acknowledged session's own warning still reaches the preview", async () => {
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+
+    const carried = app.preview.blockers.find((b) => b.kind === 'lead-time');
+    expect(carried).toBeTruthy();
+    expect(carried.severity).toBe('warn');
+    expect(app.preview.ready).toBe(true);
+  });
+
+  test('taking the acknowledgement back on the preview clears the line, with no reload', async () => {
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+    expect(app.liftedRestrictionsLine()).toContain(SOON_LABEL);
+
+    // The preview's own blocker list, which is the selection's carried verbatim.
+    const takeBack = app.preview.blockers
+      .find((b) => b.kind === 'lead-time')
+      .actions.find((a) => a.answers === 'unacknowledge-lead-time');
+    app.answerSelection(takeBack);
+
+    expect(app.liftedRestrictionsLine()).toBe('');
+    expect(app.preview.ready).toBe(false);
+  });
+
+  test('and re-taking it there brings the line back, still without a reload', async () => {
+    // The only way onto step 5 is with every block cleared, so an override can
+    // never be *first* taken from here — but it can be taken back and re-taken,
+    // and both directions have to reach this line.
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+
+    app.takeBackLeadTimeOverride('e0');
+    expect(app.liftedRestrictionsLine()).toBe('');
+
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    expect(app.liftedRestrictionsLine()).toContain(SOON_LABEL);
+    expect(app.preview.ready).toBe(true);
+  });
+
+  test('two lifted sessions are both named', async () => {
+    const second = { ...SOON, event_id: 'e0b', event_start_at: '2026-08-22T13:00:00+08:00' };
+    const app = await withEvents(component({ eventList: [SOON, second, ...EVENTS] }));
+    app.pickSeries('e0');
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    app.askLeadTimeOverride('e0b');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+
+    const line = app.liftedRestrictionsLine();
+    expect(line).toMatch(/^2 sessions /);
+    expect(line.split(SOON_LABEL).length - 1).toBe(2);
+  });
+
+  test('an acknowledgement taken back at the SELECTION step reaches the preview', async () => {
+    // The criterion names step 4 specifically. Walking back there with a live
+    // preview is the path a real operator takes — approve, hesitate, go back —
+    // and it is the one `afterSelectionChange` exists for.
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+    expect(app.liftedRestrictionsLine()).toContain(SOON_LABEL);
+
+    app.go(3); // back to the session picker, preview still built
+    app.answerSelection(leadTimeBlocker(app).actions
+      .find((a) => a.answers === 'unacknowledge-lead-time'));
+
+    expect(app.preview).toBeTruthy();
+    expect(app.liftedRestrictionsLine()).toBe('');
+    expect(app.preview.ready).toBe(false);
+  });
+
+  test('un-ticking an acknowledged session at selection takes its name off too', async () => {
+    // The tick and the statement are one act (#144). The name has to go with
+    // them, or the run is approved against a session it will not book.
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+
+    app.go(3);
+    app.togglePick('e0');
+
+    expect(app.picked).toEqual(['e1', 'e2']);
+    expect(app.liftedRestrictionsLine()).toBe('');
+  });
+
+  test('a tick changed anywhere rebuilds the preview, not just this line', async () => {
+    // The staleness this line exposed was never only about this line. Step 5's
+    // own blocker list offers "Remove this session", so a preview describing
+    // the old booking count was reachable from the screen that approves the
+    // run — and the permanence sentence is the number that matters there.
+    const app = await withSoon();
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+
+    const three = app.preview.totals.bookings;
+    expect(app.preview.sessions).toHaveLength(3);
+
+    // Straight off the preview's own blocker, the way an operator would.
+    app.answerSelection(app.preview.blockers
+      .find((b) => b.kind === 'lead-time')
+      .actions.find((a) => a.answers === 'remove'));
+
+    expect(app.preview.sessions).toHaveLength(2);
+    expect(app.preview.totals.bookings).toBeLessThan(three);
+    expect(app.permanenceLine()).toContain(`${app.preview.totals.bookings} bookings`);
+    // And the removed session is not still named as lifted.
+    expect(app.liftedRestrictionsLine()).toBe('');
+  });
+
+  test('the page renders it above the table and again where the run starts', () => {
+    // Twice on purpose: the consequence area is where the run is approved and
+    // the confirm block is where it is started, and the restriction has to be
+    // off in Clubworx by the second one.
+    expect(html.split('x-text="liftedRestrictionsLine()"').length - 1).toBe(2);
+    // Its own x-show at both, so it is absent rather than an empty amber box.
+    expect(html.split('x-show="liftedRestrictionsLine()"').length - 1).toBe(2);
+    // And the permanence line still has its own, unchanged.
+    expect(html).toContain('x-show="permanenceLine()"');
+  });
+});
+
 describe('the override confirmation is on the page, and bound (#144)', () => {
   test('the blocker list renders it against the session it is about', () => {
     // Both blocker lists dispatch through `answerSelection`, so a confirmation

--- a/school-booking/test/preview.test.js
+++ b/school-booking/test/preview.test.js
@@ -8,6 +8,7 @@ import { describe, expect, test } from 'vitest';
 import {
   buildPreview,
   consequenceLine,
+  liftedRestrictionsLine,
   matchDecision,
   permanenceLine,
   resolveMatch,
@@ -294,6 +295,91 @@ describe('the permanence line', () => {
   test('with nothing bookable there is no sentence to make', () => {
     const preview = build({ matches: { 3: match({ state: 'unmatchable', reason: 'no-dob' }) } });
     expect(permanenceLine(preview)).toBe('');
+  });
+});
+
+describe('the lifted restrictions line', () => {
+  // #145. Read at the moment of approval, over the whole run — where the
+  // per-session confirmation (#144) was read at the moment of acknowledgement.
+  // An operator who acknowledged a session two steps ago should not have to
+  // remember it to approve the run honestly.
+
+  const acknowledged = (ids) => selection({ acknowledgedEventIds: ids });
+
+  test('it names every acknowledged session, by the label used everywhere else', () => {
+    const preview = build({ selection: acknowledged(['a']) });
+    expect(liftedRestrictionsLine(preview)).toContain('School Session, 2026-09-01');
+  });
+
+  test('two acknowledged sessions are both named, and separated readably', () => {
+    // The label itself contains a comma, so a comma-joined list reads as four
+    // things rather than two.
+    const line = liftedRestrictionsLine(build({ selection: acknowledged(['a', 'b']) }));
+    expect(line).toContain('School Session, 2026-09-01');
+    expect(line).toContain('School Session, 2026-09-08');
+    expect(line).not.toContain('2026-09-01, School Session');
+    expect(line).toMatch(/2026-09-01; School Session/);
+  });
+
+  test('it says nothing at all when nothing was acknowledged', () => {
+    // A line that is always present is a line that stops being read.
+    expect(liftedRestrictionsLine(build())).toBe('');
+    expect(liftedRestrictionsLine(build({ selection: acknowledged([]) }))).toBe('');
+  });
+
+  test('it names the acknowledged sessions and not the rest of the selection', () => {
+    const line = liftedRestrictionsLine(build({ selection: acknowledged(['b']) }));
+    expect(line).toContain('2026-09-08');
+    expect(line).not.toContain('2026-09-01');
+  });
+
+  test('the count agrees with the names, in both grammars', () => {
+    expect(liftedRestrictionsLine(build({ selection: acknowledged(['a']) })))
+      .toMatch(/^1 session is being booked on your word that its /);
+    expect(liftedRestrictionsLine(build({ selection: acknowledged(['a', 'b']) })))
+      .toMatch(/^2 sessions are being booked on your word that their /);
+  });
+
+  test('it names the consequence of the restriction still being on', () => {
+    // ADR 0007: an override taken without actually lifting the restriction
+    // fails loudly, one refusal per student. This is the last place to say so
+    // before the run starts.
+    const line = liftedRestrictionsLine(build({ selection: acknowledged(['a']) }));
+    expect(line).toMatch(/fail/i);
+  });
+
+  test('an id naming no picked session names nothing', () => {
+    // selectionReport only ever emits ids for sessions on screen, so this is
+    // defence against a caller that is not it — and against an acknowledgement
+    // surviving a session being un-ticked.
+    expect(liftedRestrictionsLine(build({ selection: acknowledged(['ghost']) }))).toBe('');
+  });
+
+  test('the permanence sentence is untouched by an acknowledgement', () => {
+    const plain = permanenceLine(build());
+    expect(plain).not.toBe('');
+    expect(permanenceLine(build({ selection: acknowledged(['a', 'b']) }))).toBe(plain);
+  });
+
+  test("an acknowledged session's own warning still reaches the preview's blockers", () => {
+    // Carried verbatim from selection, as every selection blocker is — this
+    // line is the aggregate beside them, never a replacement for them.
+    const preview = build({
+      selection: selection({
+        acknowledgedEventIds: ['a'],
+        blockers: [{
+          key: 'lead-time:a',
+          kind: 'lead-time',
+          eventId: 'a',
+          severity: 'warn',
+          title: 'A session starts too soon — its restriction is being lifted by hand',
+          detail: 'School Session, 2026-09-01 — Starts within the lead time.',
+          actions: [],
+        }],
+      }),
+    });
+    expect(preview.blockers.map((b) => b.key)).toContain('lead-time:a');
+    expect(preview.ready).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #145. Fourth of ADR 0007's five tickets — #143 (Worker gate) and #144 (the override itself) shipped earlier today; #146 (post-run reminder) remains open.

## What this adds

The run-level consequence above the preview table now names every session carrying a lifted Clubworx booking restriction, so the operator approves the run with that fact in front of them. #144's confirmation is read at the moment of *acknowledgement*, on the blocker; this is read at the moment of *approval*, over the whole run — an operator who acknowledged a session two steps ago should not have to remember it to approve the run honestly.

Silent when nothing was acknowledged. A line that is always present is a line that stops being read.

`liftedRestrictionsLine()` lives in `preview.js` beside `permanenceLine()` and never inside it: the permanence box goes away when nothing is bookable, while a lifted restriction is still something somebody has to put back. Names are built with `events.js`'s `sessionLabel()`, so they match the picker and the blocker exactly.

Rendered above the preview table and again in "Before this starts", which already repeats the permanence line and is where the run actually starts. It gets its own heading and a left accent so two amber panels do not read as one sentence split in half.

## A staleness this exposed but did not cause

`togglePick`, `pickSeries` and `loadEvents` refreshed the selection and left the preview alone, so a tick changed after previewing left the preview describing the old run — the old booking count and the old permanence sentence. Step 5's own blocker list offers "Remove this session", so this was reachable from the screen that approves the run.

All four selection mutators now go through `afterSelectionChange()` (was `afterAcknowledgement()`), which **rebuilds** the preview rather than discarding it. `discardPreview()` is right for a step-3 edit, where the students changed and the Clubworx check is genuinely void; a tick change must not re-spend 3 requests a student out of a gym-wide allowance. Two tests pin this — both fail if the rebuild is reverted.

## Docs

`CONTEXT.md`'s *Lead time* entry and the design spec's §11 hard-stop row both still said the override was unbuilt. ADR 0007 explicitly names a stale entry here as how this feature gets removed as a bug, so both are brought back in step, with #146 named as the part still open.

Module version pins bumped 6 → 7, in lockstep as the chain walk requires.

## Review

Ran on both axes.

- **Spec** — all five acceptance criteria met, no scope creep, no #146 content leaked in. It flagged AC5's selection-step path as untested and the new panel as visually identical to the permanence box; both fixed here.
- **Standards** — version pins clean. It flagged the two stale doc entries (fixed) and a `lifted` → `liftedSessionLabels` rename (applied). One call declined: emitting the labels from `selectionReport` would save a pass over a handful of sessions but ship a second array beside `acknowledgedEventIds`. The ids are ADR 0007's contract, and two lists that must stay in step is the drift the single derivation avoids.

## Tests

574 in school-booking, 21 new. 1657 across the repo. The one failure, `vouchers/test/version.test.js`, is pre-existing and fails on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBEEQhSPQ8MUygKPf4wEHX