### PR TITLE
Lead-time override: remind staff to put the lifted restrictions back (#146)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,11 @@ school-booking.html     - the school booking page, steps 1-6 (#71, #72, #73, #10
                           equals a fresh one field by field — the reset restates
                           the component literal's initial values and nothing in
                           the language links the two copies.
+                          `runLiftedSessions` is #146's snapshot, taken from
+                          the selection at Apply and stored with the run, so the
+                          reminder outlives the selection, the preview and the
+                          tab. A stored run from before that field names
+                          nothing rather than guessing.
                           ADR 0007 (#144) added `leadTimeAcknowledgements` — the
                           per-session log of too-soon sessions an operator has
                           stated they lifted the Clubworx restriction for — and
@@ -314,6 +319,16 @@ school-booking/outcome.js - what one `POST /student` answer means, and what a
                           settled. The two answer different questions — "is
                           there anything worth doing again?" and "did this
                           work?" — and a cancel since takes the second back.
+                          liftedRestrictionsReminder() is #146's post-run
+                          obligation: the sessions whose Clubworx restriction an
+                          operator lifted by hand, named on the result surface
+                          beside strandedWarning() and carried in D10's record.
+                          Its argument is the acknowledged session LABELS, not
+                          the records, and that signature is the ticket: a run
+                          halted by D7 has no result row for the acknowledged
+                          session, so a reminder derived from results would go
+                          silent on the run most likely to have left a class
+                          open to public booking.
 school-booking/parse.js - turns a pasted school student list into rows plus the
                           list-level inferences (layout, column mapping, date
                           orientation). Pure and unit tested; §7 of the design

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -745,15 +745,17 @@ blocker, and the write chain re-checks per student as a backstop before any
 write. Neither is the whole rule, and the minimum itself is defined once and
 re-exported to the write chain.
 
-> **An operator override — decided 2026-08-25, built except the reminder**
+> **An operator override — decided and built 2026-08-25**
 > ([ADR 0007](docs/adr/0007-lead-time-is-an-operator-override.md),
 > [#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#146](https://github.com/urbanjungleirc/staff-site/issues/146)).
 > The **write chain** narrows its backstop to sessions absent from the
 > acknowledged list (#143), the **session picker** offers the override and takes
 > the confirmation (#144), and the **confirmation step** names every session
 > carrying a lifted restriction above the preview table and again where the run
-> is started (#145). Still open: #146, the post-run reminder to put the
-> restriction back.
+> is started (#145). After the run, the **result surface** and the JSON run
+> record both name every session whose restriction was lifted, so it gets put
+> back (#146) — sourced from the selection, never from the run's results, so a
+> run halted before it reached those sessions still says so.
 >
 > The minimum is a *lift-able* Clubworx booking restriction, not a property of
 > time: a manager can remove it on the specific conflicted class, run the
@@ -770,8 +772,12 @@ re-exported to the write chain.
 >
 > *Avoid*: treating a lifted restriction as spent when the run ends. The lasting
 > damage in this whole area is a **class left open to public booking** because
-> nobody put the restriction back, which is why the run must remind (#146) and
-> why the reminder belongs in the run record.
+> nobody put the restriction back — which is why the reminder is sourced from the
+> selection rather than the results (a halted run has no result row for the
+> session it never reached, and that is the run most likely to have left the
+> restriction off), and why it is written into the run record staff paste into a
+> ticket. The tool never restores a restriction itself; it reminds, and a person
+> acts.
 
 ### Unknown refusal
 

--- a/docs/adr/0007-lead-time-is-an-operator-override.md
+++ b/docs/adr/0007-lead-time-is-an-operator-override.md
@@ -1,6 +1,6 @@
 # ADR 0007 — the lead time is an operator override, not a law
 
-- **Status**: Accepted — pending implementation ([#143](https://github.com/urbanjungleirc/staff-site/issues/143), [#144](https://github.com/urbanjungleirc/staff-site/issues/144), [#145](https://github.com/urbanjungleirc/staff-site/issues/145), [#146](https://github.com/urbanjungleirc/staff-site/issues/146))
+- **Status**: Accepted — built ([#143](https://github.com/urbanjungleirc/staff-site/issues/143), [#144](https://github.com/urbanjungleirc/staff-site/issues/144), [#145](https://github.com/urbanjungleirc/staff-site/issues/145), [#146](https://github.com/urbanjungleirc/staff-site/issues/146))
 - **Date**: 2026-08-25
 - **Context**: school group booking ([#138](https://github.com/urbanjungleirc/staff-site/issues/138)); design spec [`2026-08-19-school-group-booking-design.md`](../superpowers/specs/2026-08-19-school-group-booking-design.md) §11, D9
 

--- a/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
+++ b/docs/superpowers/specs/2026-08-19-school-group-booking-design.md
@@ -935,7 +935,7 @@ staleness. Nothing else is re-validated.
 | Condition | Ruling |
 |---|---|
 | School Pass plan unresolved, or the name ambiguous | **Hard-stop the run** |
-| Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* — **overridable per session since 2026-08-25: an operator who states they have lifted the class's Clubworx booking restriction keeps it, and it drops to a warning ([ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md), [#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#145](https://github.com/urbanjungleirc/staff-site/issues/145))** |
+| Any selected event starts inside the 24-hour lead time | **Hard-stop**, with the reason on screen and a one-click *"remove this session"* — **overridable per session since 2026-08-25: an operator who states they have lifted the class's Clubworx booking restriction keeps it, and it drops to a warning ([ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md), [#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#146](https://github.com/urbanjungleirc/staff-site/issues/146))** |
 | No events selected, or zero parseable rows | **Hard-stop** |
 | Any unresolved gate — unparseable row, count mismatch, unconfirmed age | **Hard-stop** (§9) |
 | The last selected session falls outside `today + membership_duration` | **Hard-stop the run** (§3, ADR 0005) |
@@ -947,10 +947,8 @@ adjustment. Staff must never meet Clubworx's own message here — *"Sorry! This
 class is now closed for bookings."* — which names no cause and reads like a
 capacity problem.
 
-> **Amended 2026-08-25, after the spec was written — built except the reminder**
-> ([#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#145](https://github.com/urbanjungleirc/staff-site/issues/145)
-> shipped; [#146](https://github.com/urbanjungleirc/staff-site/issues/146), the post-run
-> reminder, is still open). The hard-stop
+> **Amended 2026-08-25, after the spec was written — built**
+> ([#143](https://github.com/urbanjungleirc/staff-site/issues/143)–[#146](https://github.com/urbanjungleirc/staff-site/issues/146)). The hard-stop
 > half of D9 is reversed: a too-soon session becomes **keepable, per session**, by
 > an operator who confirms they have lifted that class's Clubworx booking
 > restriction — it is a lift-able restriction, not a property of time, and
@@ -963,8 +961,12 @@ capacity problem.
 > Two things this table cannot show. The rule is enforced **twice** — here and
 > again in the write chain per student — so an override travels to the Worker as
 > the explicit list of acknowledged event ids, never a run-wide flag. And the run
-> must remind staff to **put the restriction back**; a class left open to public
-> booking is the only damage in this area that stays silent.
+> reminds staff to **put the restriction back** — on the result surface beside
+> the stranded-student warning, and in the JSON run record (#146). That reminder
+> is built from the **selection**, never from the results: a run halted on its
+> third consecutive failure has no result row for the acknowledged session at
+> all, and it is that run whose restriction is most likely still off. A class
+> left open to public booking is the only damage in this area that stays silent.
 >
 > [ADR 0007](../../adr/0007-lead-time-is-an-operator-override.md), [#138](https://github.com/urbanjungleirc/staff-site/issues/138).
 

--- a/school-booking.html
+++ b/school-booking.html
@@ -68,14 +68,14 @@
      or missing module into a visible refusal rather than a page whose gates
      quietly do nothing. -->
 <script type="module">
-  import * as parser from './school-booking/parse.js?v=7';
-  import * as steps from './school-booking/steps.js?v=7';
-  import * as identity from './school-booking/identity.js?v=7';
-  import * as events from './school-booking/events.js?v=7';
-  import * as preview from './school-booking/preview.js?v=7';
-  import * as calendar from './school-booking/calendar.js?v=7';
-  import * as outcome from './school-booking/outcome.js?v=7';
-  import * as run from './school-booking/run.js?v=7';
+  import * as parser from './school-booking/parse.js?v=8';
+  import * as steps from './school-booking/steps.js?v=8';
+  import * as identity from './school-booking/identity.js?v=8';
+  import * as events from './school-booking/events.js?v=8';
+  import * as preview from './school-booking/preview.js?v=8';
+  import * as calendar from './school-booking/calendar.js?v=8';
+  import * as outcome from './school-booking/outcome.js?v=8';
+  import * as run from './school-booking/run.js?v=8';
   window.schoolListParser = parser;
   window.schoolBookingSteps = steps;
   window.schoolBookingIdentity = identity;
@@ -1480,6 +1480,26 @@
           </div>
         </div>
 
+        <!-- #146. Directly beneath the summary, beside the stranded-student
+             warning it sits under: both say *this run left something for a
+             human to finish in Clubworx*.
+             Its own block, deliberately, and not a line inside that banner.
+             Two reasons, and the first is the ticket's:
+               - The banner is shown on `resultLine()`, which is empty when a
+                 run produced no records. Nesting this inside it would put the
+                 reminder behind the run's RESULTS after taking such care to
+                 source it from the selection — the exact coupling #146 refuses,
+                 latent rather than live, but one refactor away from being real.
+               - Tone. On a clean run that banner is emerald, and a restriction
+                 left off is the one obligation that must never be rendered as
+                 part of a confirmation.
+             It is not `x-cloak`-hidden behind the table either: this outlives
+             the run it reports on, and is the last thing anybody reads before
+             closing the tab. -->
+        <div class="rounded-xl bg-amber-50 border border-amber-300 text-amber-900 px-3.5 py-2.5 text-sm mb-3"
+             x-show="liftedRestrictionsReminder()" x-cloak
+             x-text="liftedRestrictionsReminder()"></div>
+
         <div class="rounded-card border border-neutral-200 overflow-hidden bg-white"
              x-show="runRecords.length > 0" x-cloak>
           <div class="overflow-x-auto">
@@ -1785,6 +1805,12 @@ function schoolBooking() {
     runRemaining: 0,
     runAt: null,
     runSessionStarts: [],
+    // #146: the sessions this run was told had had their Clubworx restriction
+    // lifted, as labels, snapshotted from the selection at Apply. Held rather
+    // than re-derived because the reminder has to outlive the selection, the
+    // preview and the tab — the whole point is that it is still true after the
+    // page has moved on.
+    runLiftedSessions: [],
     // #111: what the last finished run covered, as `{ state, fingerprint }`.
     // Only a `complete` one closes Apply, and only against an identical
     // fingerprint — the rules are preview.js's, not this page's.
@@ -2917,6 +2943,11 @@ function schoolBooking() {
       this.cancelMessage = '';
       this.runAt = new Date().toISOString();
       this.runSessionStarts = (this.preview.sessions ?? []).map((e) => e.event_start_at);
+      // #146. Taken here, from the selection's own reading of what was
+      // acknowledged, and never rebuilt from the run afterwards: a run halted
+      // on its third refusal has no record for the acknowledged session at all,
+      // and that is the run whose restriction is most likely still off.
+      this.runLiftedSessions = this.preview.liftedSessionLabels ?? [];
       const fingerprint = this.preview.fingerprint;
       this.expandedResult = null;
       this.runRemaining = 0;
@@ -2992,6 +3023,13 @@ function schoolBooking() {
         at: this.runAt,
         school: this.tag,
         sessions: this.runSessionStarts,
+        // #146. Stored with the run, because a reminder that dies with the tab
+        // is no reminder: the restriction is off in Clubworx either way, and
+        // the operator who reopens this page is the one who has to put it back.
+        // `liftedSessions`, not `lifted`: this is the LIST of labels, where
+        // D10's record carries a key called `lifted` holding the sentence built
+        // from it. Two artifacts, two shapes — so two names.
+        liftedSessions: this.runLiftedSessions,
         state: this.runState,
         records: this.runRecords,
         // #111. Without these the gate dies with the tab, and reopening a
@@ -3039,6 +3077,17 @@ function schoolBooking() {
 
     strandedWarning() {
       return window.schoolBookingOutcome.strandedWarning(this.runRecords);
+    },
+
+    /**
+     * #146 — the restrictions this run left lifted, and nothing else.
+     *
+     * Reads the snapshot, never the records. Sourcing it from the run's results
+     * would look identical on a clean run and go silent on a halted one, which
+     * is the run that most needs it.
+     */
+    liftedRestrictionsReminder() {
+      return window.schoolBookingOutcome.liftedRestrictionsReminder(this.runLiftedSessions);
     },
 
     resultTone(record) {
@@ -3142,6 +3191,8 @@ function schoolBooking() {
         school: this.tag,
         at: this.runAt,
         sessions: this.runSessionStarts,
+        // #146 — the obligation goes into the ticket with the booking ids.
+        lifted: this.runLiftedSessions,
       });
     },
 
@@ -3171,6 +3222,10 @@ function schoolBooking() {
       this.runRecords = this.restored.records ?? [];
       this.runAt = this.restored.at ?? null;
       this.runSessionStarts = this.restored.sessions ?? [];
+      // #146. A run stored before this field carries no lifted sessions, and
+      // guessing one would name a session nobody acknowledged. Silence is the
+      // honest answer; the ticket the operator already has is the other record.
+      this.runLiftedSessions = this.restored.liftedSessions ?? [];
       // #112. The store is written per student (D10), so a tab closed on
       // student 19 leaves `running` behind — and a restored `running` is the
       // one state that cannot be true, because nothing is calling anything.
@@ -3337,6 +3392,7 @@ function schoolBooking() {
       this.runRemaining = 0;
       this.runAt = null;
       this.runSessionStarts = [];
+      this.runLiftedSessions = [];
       this.expandedResult = null;
       this.cancelState = 'idle';
       this.cancelMessage = '';

--- a/school-booking/identity.js
+++ b/school-booking/identity.js
@@ -24,7 +24,7 @@
 // already has a contact comes back as `new`, and a second permanent contact is
 // written for them. Nothing throws: both spellings are individually valid, and
 // contacts cannot be deleted.
-import { compareForm } from './parse.js?v=7';
+import { compareForm } from './parse.js?v=8';
 
 // ---------------------------------------------------------------------------
 // Match states (P2b)

--- a/school-booking/outcome.js
+++ b/school-booking/outcome.js
@@ -516,6 +516,47 @@ export function strandedWarning(records) {
 }
 
 /**
+ * The restrictions this run left lifted — #146, ADR 0007.
+ *
+ * Takes the session labels an operator **acknowledged**, not the run's records.
+ * That is the whole point of the function's signature: the lifted sessions are
+ * known before the first write, and a run halted by D7's breaker produces no
+ * record at all for the acknowledged session — which is exactly the case where
+ * a restriction is most likely to still be off. A reminder derived from results
+ * would go missing precisely when it matters most.
+ *
+ * It is the counterpart to `strandedWarning` and sits beside it: both say *this
+ * run left something for a human to finish in Clubworx*. The difference is
+ * which way the failure is loud. A stranded student is visible on their own row
+ * for as long as the page is open; a restriction left off is visible nowhere —
+ * the class simply takes public bookings until somebody notices. So this one
+ * names the stakes out loud rather than only the obligation.
+ *
+ * Nothing here touches Clubworx. It reminds; a person acts.
+ */
+export function liftedRestrictionsReminder(sessions) {
+  // `filter(Boolean)` where preview.js's twin has none, and the asymmetry is
+  // deliberate: that one reads labels it has just built from live events, and
+  // this one reads a list that has been through `localStorage` and back. A
+  // blank entry there would put a stray "; " in the middle of the one sentence
+  // telling somebody a class is open to the public.
+  const lifted = (sessions ?? []).filter(Boolean);
+  if (lifted.length === 0) return '';
+
+  // Semicolons — a session label carries a comma of its own, so commas here
+  // would read "School Session, 2026-09-01, School Session, 2026-09-08" as four
+  // things. Same rule as the preview's line (#145).
+  const named = lifted.join('; ');
+  const one = lifted.length === 1;
+
+  return `⚠ ${plural(lifted.length, 'session')} ${one ? 'was' : 'were'} run with `
+    + `${one ? 'its' : 'their'} Clubworx booking restriction lifted by hand: ${named}. `
+    + `Put ${one ? 'it' : 'them'} back on in Clubworx — nothing here does that, and until `
+    + `${one ? 'it is' : 'they are'} back on ${one ? 'the session is' : 'those sessions are'} `
+    + 'open to public booking.';
+}
+
+/**
  * The record staff keep — D10.
  *
  * JSON rather than prose, because the thing being defended against is a page
@@ -533,6 +574,11 @@ export function runRecordText(records, meta = {}) {
       sessions: meta.sessions ?? [],
       summary: resultLine(records),
       stranded: strandedWarning(records),
+      // #146. The obligation travels with the record: this is what staff paste
+      // into a ticket, and a restriction left off outlives the page that
+      // reported it. `meta.lifted` is the acknowledged session labels, taken
+      // from the selection at Apply — never rebuilt from `records`.
+      lifted: liftedRestrictionsReminder(meta.lifted),
       students: (records ?? []).map((row) => ({
         name: row.name,
         dob: row.dob,

--- a/school-booking/preview.js
+++ b/school-booking/preview.js
@@ -46,7 +46,7 @@
 // that picked it and in the blocker that named it — #145 says "the same session
 // label used elsewhere", and a second spelling of a date is how two screens
 // come to disagree about which Tuesday they mean.
-import { sessionLabel } from './events.js?v=7';
+import { sessionLabel } from './events.js?v=8';
 
 const plural = (n, noun) => `${n} ${noun}${n === 1 ? '' : 's'}`;
 // "School Pass" does not take a bare -s, and it is the noun this line is most

--- a/school-booking/run.js
+++ b/school-booking/run.js
@@ -39,7 +39,7 @@
 // written something the Worker answers 200 and carries `reason: "throttled"`,
 // because the body is then the only record of what was written.
 
-import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=7';
+import { cancelRows, cancellable, isFailure, notRunRecord, studentRecord } from './outcome.js?v=8';
 
 /** #51 measured ~18 s of throttling. Two attempts, then the page is told. */
 export const RETRY_BACKOFF_MS = 20_000;

--- a/school-booking/steps.js
+++ b/school-booking/steps.js
@@ -43,7 +43,7 @@
 //
 // Bump this in lockstep with school-booking.html. alpine-bindings.test.js
 // fails if the two ever disagree.
-import { compareForm, readDate, writeForm } from './parse.js?v=7';
+import { compareForm, readDate, writeForm } from './parse.js?v=8';
 
 const DOMAIN = 'urbanjungleirc.com';
 

--- a/school-booking/test/outcome.test.js
+++ b/school-booking/test/outcome.test.js
@@ -25,6 +25,7 @@ import {
   resultTotals,
   runRecordText,
   settledRun,
+  liftedRestrictionsReminder,
   strandedWarning,
   successLine,
   studentRecord,
@@ -657,5 +658,63 @@ describe('successLine — the confirmation, and what it refuses to confirm', () 
     const nothing = record({}, complete({ bookings: [] }));
     expect(nothing.state).toBe('already booked');
     expect(successLine('complete', [nothing])).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #146 — the restrictions this run left lifted
+// ---------------------------------------------------------------------------
+// A failed booking is loud and self-correcting; a restriction left lifted is
+// silent — a class open to public booking until somebody notices. So the
+// reminder is made of the sessions an operator *acknowledged*, never of what
+// the run managed to book, and it says the same thing whether the run finished
+// or halted on its third failure.
+
+describe('the restrictions left lifted — #146', () => {
+  const LABEL = 'School Session — Newman, 2026-08-22';
+  const SECOND = 'School Session — Newman, 2026-08-29';
+
+  test('it names every lifted session and says who has to put it back', () => {
+    const line = liftedRestrictionsReminder([LABEL]);
+    expect(line).toContain(LABEL);
+    expect(line).toMatch(/restriction/i);
+    // The obligation, in the imperative: the tool never restores one itself.
+    expect(line).toMatch(/put it back/i);
+    // And the stakes, which are the reason this ticket exists.
+    expect(line).toMatch(/public booking/i);
+  });
+
+  test('two lifted sessions are both named, and the sentence agrees with itself', () => {
+    const line = liftedRestrictionsReminder([LABEL, SECOND]);
+    expect(line).toMatch(/^⚠ 2 sessions were/);
+    expect(line).toContain(LABEL);
+    expect(line).toContain(SECOND);
+    // Semicolons — a session label carries a comma of its own.
+    expect(line).toContain(`${LABEL}; ${SECOND}`);
+  });
+
+  test('a run nobody overrode says nothing at all, rather than a zero', () => {
+    expect(liftedRestrictionsReminder([])).toBe('');
+    expect(liftedRestrictionsReminder(null)).toBe('');
+    expect(liftedRestrictionsReminder(undefined)).toBe('');
+  });
+
+  test('the record staff keep carries the obligation with it', () => {
+    const text = runRecordText([record({}, complete())], {
+      school: 'newman',
+      at: '2026-08-25T10:00:00+08:00',
+      lifted: [LABEL],
+    });
+    const parsed = JSON.parse(text);
+    expect(parsed.lifted).toContain(LABEL);
+    expect(parsed.lifted).toMatch(/restriction/i);
+    // The rest of the record is untouched by it.
+    expect(parsed.students).toHaveLength(1);
+    expect(parsed.summary).toBe(resultLine([record({}, complete())]));
+  });
+
+  test('a record from a run with no override carries an empty obligation', () => {
+    const parsed = JSON.parse(runRecordText([record({}, complete())], { school: 'newman' }));
+    expect(parsed.lifted).toBe('');
   });
 });

--- a/school-booking/test/page-component.test.js
+++ b/school-booking/test/page-component.test.js
@@ -2846,3 +2846,151 @@ describe('the reset leaves nothing of the last import behind (#113)', () => {
     expect(app.schools).toEqual(fresh.schools);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #146 — the reminder that outlives the run
+// ---------------------------------------------------------------------------
+// The lasting damage this feature can do is not a failed booking — that is loud
+// and self-correcting. It is a Clubworx restriction left off: a class open to
+// public booking for as long as nobody notices. So the reminder is sourced from
+// the *selection*, and the two tests that matter most below are the halted run
+// and the reload.
+
+describe('the restrictions left lifted are named after the run (#146)', () => {
+  const SOON_LABEL = 'School Session — Newman, 2026-08-22';
+
+  const ranWithOverride = async (opts = {}) => {
+    const app = await withSoon(opts);
+    app.askLeadTimeOverride('e0');
+    app.confirmLeadTimeOverride();
+    await app.toPreview();
+    app.askApply();
+    await app.apply();
+    return app;
+  };
+
+  test('a finished run still names the session whose restriction was lifted', async () => {
+    // A clean run is exactly the case an operator would call finished and walk
+    // away from — and it left the restriction off just the same.
+    const app = await ranWithOverride();
+    expect(app.runState).toBe('complete');
+
+    const reminder = app.liftedRestrictionsReminder();
+    expect(reminder).toContain(SOON_LABEL);
+    expect(reminder).toMatch(/restriction/i);
+    expect(reminder).toMatch(/put it back/i);
+  });
+
+  test('a run that halted before reaching the session still names it', async () => {
+    // The criterion this ticket turns on. Three refusals in a row halt the run
+    // (D7), so there is no result row for the acknowledged session at all — and
+    // a reminder read off the results would vanish here, on the run most likely
+    // to have left a restriction open.
+    const app = await ranWithOverride({
+      student: () => ({
+        status: 200,
+        body: { outcome: 'refused', reason: 'lead-time', written: false, message: 'too soon' },
+      }),
+    });
+
+    expect(app.runState).toBe('halted');
+    expect(app.runRecords.some((r) => r.state === 'booked')).toBe(false);
+    expect(app.liftedRestrictionsReminder()).toContain(SOON_LABEL);
+  });
+
+  test('a run nobody overrode shows no reminder', async () => {
+    const app = await upToApply(component());
+    expect(app.runRecords).toHaveLength(6);
+    expect(app.liftedRestrictionsReminder()).toBe('');
+  });
+
+  test('the summary and the stranded warning are untouched beside it', async () => {
+    // Both surfaces say "a human has something left to do in Clubworx", and
+    // both have to be able to say it at once.
+    const app = await ranWithOverride({
+      student: (body, n) => (n === 1
+        ? {
+          status: 200,
+          body: {
+            outcome: 'abandoned',
+            reason: 'booking-refused',
+            written: true,
+            contact: { contact_key: 'c-new', state: 'created' },
+            pass: { state: 'created-with-contact' },
+            bookings: [],
+            stranded: true,
+            strandedDetail: 'contact and pass, no bookings',
+            message: 'refused',
+          },
+        }
+        : { status: 200, body: STUDENT_OK }),
+    });
+
+    expect(app.strandedWarning()).toContain('contact and a pass but no bookings');
+    expect(app.resultLine()).toContain('created (permanent)');
+    expect(app.liftedRestrictionsReminder()).toContain(SOON_LABEL);
+  });
+
+  test('the record staff copy out carries it too', async () => {
+    const app = await ranWithOverride();
+    const parsed = JSON.parse(app.recordText());
+    expect(parsed.lifted).toContain(SOON_LABEL);
+    // D10's record is otherwise what it was.
+    expect(parsed.students).toHaveLength(6);
+    expect(parsed.school).toBe('newman');
+  });
+
+  test('it survives the tab: a restored run still names the lifted session', async () => {
+    const first = await ranWithOverride();
+    expect(first.__stored.get('uj-school-booking-run')).toBeTruthy();
+
+    const second = await upToPreview(component({
+      restored: JSON.parse(first.__stored.get('uj-school-booking-run')),
+    }));
+    second.openRestored();
+    expect(second.liftedRestrictionsReminder()).toContain(SOON_LABEL);
+    expect(JSON.parse(second.recordText()).lifted).toContain(SOON_LABEL);
+  });
+
+  test('a stored run from before this field says nothing rather than guessing', async () => {
+    const app = await upToPreview(component({
+      restored: {
+        at: '2026-08-24T10:00:00+08:00', school: 'newman', sessions: [], state: 'complete', records: [],
+      },
+    }));
+    app.openRestored();
+    expect(app.liftedRestrictionsReminder()).toBe('');
+  });
+
+  test('nothing about the reminder is gated on the run having results', async () => {
+    // The value is sourced from the selection; this pins the *rendering* to the
+    // same rule. `resultLine()` is empty over no records, and it is what the
+    // summary banner is shown on — so a reminder rendered inside that banner
+    // would be behind the run's results after all the care taken to keep it
+    // out of them. Both halves are asserted: the state, and the markup that
+    // reads it.
+    const app = await ranWithOverride();
+    app.runRecords = [];
+    expect(app.resultLine()).toBe('');
+    expect(app.liftedRestrictionsReminder()).toContain(SOON_LABEL);
+
+    // The reminder's own block, and its only condition is itself.
+    const at = html.indexOf('x-show="liftedRestrictionsReminder()"');
+    expect(at, 'the reminder is rendered on the result surface').toBeGreaterThan(-1);
+    // The reset control is the last thing inside that banner, so a reminder
+    // after it is a reminder outside it.
+    // `lastIndexOf` — step 1 renders the same control, and it is the step 6
+    // copy that closes this banner.
+    const lastInBanner = html.lastIndexOf('@click="startAnotherImport()"');
+    expect(lastInBanner).toBeGreaterThan(html.indexOf('x-show="resultLine()"'));
+    expect(at, 'the reminder sits outside the resultLine() banner').toBeGreaterThan(lastInBanner);
+  });
+
+  test('starting another import clears it', async () => {
+    const app = await ranWithOverride();
+    expect(app.liftedRestrictionsReminder()).toContain(SOON_LABEL);
+    app.askReset();
+    app.startAnotherImport();
+    expect(app.liftedRestrictionsReminder()).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #146. Completes ADR 0007 (#143–#146).

## What this does

After a run, the result surface names every session whose Clubworx booking
restriction an operator lifted by hand, so it gets put back. The JSON run
record carries the same sentence, so the obligation survives a reload and hands
off to whoever picks the job up.

This is the ticket that addresses the feature's real lasting damage. A failed
booking is loud and self-correcting — refusals arrive, three in a row halts the
run. A restriction left lifted is silent: a class open to public booking for as
long as nobody notices.

**Nothing here changes a Clubworx restriction.** It reminds; a person acts.

## Sourced from the selection, not the results

`liftedRestrictionsReminder()` takes session **labels**, not records, and that
signature is the ticket. A run halted by D7's breaker produces no result row for
the acknowledged session at all — and that is the run whose restriction is most
likely still off, so a reminder derived from results would go missing exactly
when it matters most.

For the same reason it renders as its **own block** rather than a line inside
the summary banner, which is shown on `resultLine()` — nesting it there would
put the reminder back behind the run's results after all the care taken to keep
it out of them. Its own amber box also stops a clean run's emerald banner
absorbing the one obligation that must never read as part of a confirmation.
A test pins that invariant in both the state and the markup.

## The plumbing

The page snapshots the preview's selection-derived labels at Apply into
`runLiftedSessions`, stores them with the run as `liftedSessions` (the list —
D10's record key `lifted` holds the sentence built from it), restores them on
reload and clears them on reset. A stored run from before the field names
nothing rather than guessing.

`?v=7` → `?v=8` across the import chain, per the repo's lockstep rule.

## Docs

ADR 0007's status, `CONTEXT.md` and the design spec's D9 amendment all move off
"pending" / "built except the reminder"; `CLAUDE.md`'s roster gains the new
export and the new state field.

## Verification

- 588/588 school-booking tests pass (15 new across `outcome.test.js` and
  `page-component.test.js`), including the halted run, the reload, and all
  three warnings rendering together.
- Full repo suite 1671/1672. The one failure, `vouchers/test/version.test.js`
  "falls back to dev outside a git repository", is a pre-existing
  git-detection quirk — confirmed failing on a clean stashed tree before any of
  this work.
- Reviewed on both axes (standards + spec): no hard standards violations, all 7
  acceptance criteria met, Clubworx paths byte-identical. Two review findings
  fixed in the branch — a key name that meant two types across the two JSON
  artifacts, and the results-gated rendering described above.

## Acceptance criteria

- [x] After a run with acknowledged sessions, the result surface shows a reminder naming every session whose restriction was lifted
- [x] The reminder is sourced from the selection, so it appears even when the run halts early on failures
- [x] It appears when the run succeeds completely, too
- [x] A run with no acknowledged sessions shows no reminder
- [x] The lifted sessions appear in the JSON run record staff copy out
- [x] The existing stranded-student warning and result summary are unchanged, and both can appear alongside the new reminder
- [x] Nothing in this ticket changes a Clubworx restriction

> ⚠️ `main` is production — merging this deploys it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBEEQhSPQ8MUygKPf4wEHX
