### PR TITLE
fix(vouchers): the hub bootstraps once, not twice (vouchers#70)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,17 @@ vouchers/delete-logic.js - pure confirmation rules behind the hard-delete action
 vouchers/type-surfaces.js - which voucher-type fields feed which output surface (unit tested)
 vouchers/nav-menu.js    - what the header hamburger holds, and which section it is hiding (unit tested)
 vouchers/expiry-flag.js - whether a voucher counts as "expiring soon" (unit tested)
+vouchers/test/single-bootstrap.test.js - guards EVERY .html on the site, not just
+                          the voucher pages: an Alpine component whose x-data is
+                          paired with an x-init calling init() bootstraps twice,
+                          because Alpine already calls init() itself. It lives in
+                          this suite because there is no test runner at the repo
+                          root, and it is site-wide because the defect is
+                          invisible unless the page happens to hold something
+                          that running twice disturbs — on stats.html four charts
+                          died mid-animation (#69), while the hub and the
+                          unsubscribes list just quietly issued two of every
+                          opening request for months (#70).
 vouchers/scripts/version.mjs - derives the hub's build version from git at deploy time (unit tested)
 vouchers/version-display.js - formats that version for the footer, in Perth time (unit tested)
 .github/workflows/pages.yml - publishes the site to Pages; the repo's only build step

--- a/vouchers/index.html
+++ b/vouchers/index.html
@@ -763,8 +763,14 @@
     ::-webkit-scrollbar-thumb { background: rgba(139, 28, 35, 0.2); border-radius: 3px; }
   </style>
 </head>
+<!-- No x-init calling init(). Alpine calls a component's own init() for us, so
+     naming it here as well ran the whole bootstrap twice: the identity fetch,
+     the opening search(), loadDashStats() and loadStaffMe() all doubled, and
+     the focus listeners and the 5-minute refresh tick installed twice over.
+     Nothing on this page showed it, which is the reason it stood for so long.
+     See vouchers#70; test/single-bootstrap.test.js pins it site-wide. -->
 <body class="bg-neutral-100 text-neutral-900 min-h-screen antialiased font-sans"
-  x-data="staffApp()" x-init="init()" x-cloak
+  x-data="staffApp()" x-cloak
   @keydown.window="onScanKey($event)">
 
   <!-- ── Header ──────────────────────────────────────────────────────────── -->

--- a/vouchers/test/scan-wiring.test.js
+++ b/vouchers/test/scan-wiring.test.js
@@ -61,10 +61,11 @@ describe('the listener is wired', () => {
     expect(page).toContain('window.scanInput = scanInput;');
   });
 
-  // Bound in the markup rather than added in init(). The page carries
-  // x-data + x-init="init()", which Alpine runs TWICE — once itself and once
-  // for the directive — so a listener attached there would double-handle every
-  // keystroke. A directive binds once per element whatever init does.
+  // Bound in the markup rather than added in init(). A directive binds once per
+  // element however often init() runs, which a bare addEventListener does not:
+  // while the page carried x-data + x-init="init()" together, Alpine ran init()
+  // twice (vouchers#70) and a listener attached there would have double-handled
+  // every keystroke. The pairing is gone, but the reason to bind here stands.
   test('keydown is bound on the root, at window scope', () => {
     expect(page).toContain('@keydown.window="onScanKey($event)"');
     expect(between('x-data="staffApp()"', '>')).toContain('@keydown.window');

--- a/vouchers/test/single-bootstrap.test.js
+++ b/vouchers/test/single-bootstrap.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, test } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Alpine calls a component's own init() for us. A page that names it in x-init
+// as well runs its whole bootstrap a second time: every opening fetch twice,
+// every listener registered twice, every interval installed twice — and the
+// handle to the first one overwritten, so it can never be cleared.
+//
+// The defect is invisible unless something on the page happens to be sensitive
+// to running twice. On stats.html it was: the second pass destroyed four
+// Chart.js charts mid-animation and the page sat blank (vouchers#69). On the
+// hub and the unsubscribes list nothing showed on screen at all — measured, the
+// hub opened with two of every request instead of one (vouchers#70).
+//
+// This file therefore sweeps EVERY page on the site, not the voucher pages. It
+// lives in this suite because this suite is where the defect was found twice
+// and where the tooling already is; there is no test runner at the repo root.
+
+const ROOT = fileURLToPath(new URL('../../', import.meta.url));
+
+function htmlFiles(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...htmlFiles(full));
+    else if (entry.name.endsWith('.html')) found.push(full);
+  }
+  return found;
+}
+
+// Comments are stripped first: all four Alpine pages now carry a note saying
+// why they have no x-init, and the sweep would read those notes as the defect.
+const withoutComments = (html) => html.replace(/<!--[\s\S]*?-->/g, '');
+
+// Every opening tag, closing '>' included. Attribute values hold '>' on this
+// site (arrow functions inside x-text and x-show), so the scan walks quoted
+// runs rather than stopping at the first '>' it sees.
+function openingTags(html) {
+  const tags = [];
+  const opens = /<[a-zA-Z][a-zA-Z0-9-]*/g;
+  let open;
+  while ((open = opens.exec(html)) !== null) {
+    let i = opens.lastIndex;
+    let quote = '';
+    while (i < html.length) {
+      const c = html[i];
+      if (quote) { if (c === quote) quote = ''; }
+      else if (c === '"' || c === "'") quote = c;
+      else if (c === '>') break;
+      i += 1;
+    }
+    tags.push(html.slice(open.index, i + 1));
+  }
+  return tags;
+}
+
+const attr = (tag, name) => {
+  const m = tag.match(new RegExp(`\\s${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`));
+  return m ? (m[1] ?? m[2]) : null;
+};
+
+// `init(` as a call, not `myInit(` and not `this.init(` — the second is a
+// deliberate re-run from inside the component, which is not what this pins.
+const CALLS_INIT = /(?:^|[^\w.$])init\s*\(/;
+
+// Any x-init, not only one sharing a tag with x-data: an x-init on a child
+// element evaluates in the nearest component scope, so `init()` there is the
+// same method and doubles the same bootstrap.
+const offendingTags = (html) => openingTags(withoutComments(html))
+  .filter((tag) => {
+    const init = attr(tag, 'x-init');
+    return init !== null && CALLS_INIT.test(init);
+  });
+
+const componentTags = (html) => openingTags(withoutComments(html))
+  .filter((tag) => attr(tag, 'x-data') !== null);
+
+const pages = htmlFiles(ROOT).map((file) => {
+  const name = relative(ROOT, file).split(sep).join('/');
+  return { name, html: readFileSync(file, 'utf8') };
+});
+
+// Pages carrying an Alpine component, paired with the factory that builds it.
+// Derived rather than listed, so a page added later is swept without an edit
+// here — the whole point of vouchers#70's "cover every page on the site".
+const alpinePages = pages
+  .map(({ name, html }) => ({ name, html, factory: (html.match(/x-data="(\w+)\(\)"/) || [])[1] }))
+  .filter((page) => page.factory);
+
+describe('the sweep can see the defect it is pinning', () => {
+  // Without these, the sweep below passes by finding nothing: once every
+  // x-init is gone from the repo, its filter matches no tag and its
+  // expectations never run. A matcher no test exercises is not a pin.
+  test('it catches the pairing this bug was', () => {
+    expect(offendingTags('<body x-data="staffApp()" x-init="init()" x-cloak>')).toHaveLength(1);
+  });
+
+  test('it catches an x-init on a child of the component', () => {
+    expect(offendingTags('<div x-data="app()"><span x-init="init()"></span></div>')).toHaveLength(1);
+  });
+
+  test('it reads past a > inside an attribute value', () => {
+    // school-booking.html and the hub both carry arrow functions in bindings.
+    const html = '<div x-show="rows.some((r) => r.bad)" x-init="init()"></div>';
+    expect(offendingTags(html)).toHaveLength(1);
+  });
+
+  test('it leaves an x-init that calls something else alone', () => {
+    expect(offendingTags('<div x-data="app()" x-init="$watch(\'q\', load)"></div>')).toHaveLength(0);
+    expect(offendingTags('<div x-data="app()" x-init="reinit()"></div>')).toHaveLength(0);
+    expect(offendingTags('<div x-data="app()" x-init="this.init()"></div>')).toHaveLength(0);
+  });
+
+  test('it does not read a comment about x-init as an x-init', () => {
+    expect(offendingTags('<!-- No x-init="init()" here -->\n<body x-data="app()">')).toHaveLength(0);
+  });
+});
+
+describe('every page on the site bootstraps exactly once', () => {
+  test('the sweep sees the pages it is meant to guard', () => {
+    // A broken walk would pass every assertion below by finding nothing.
+    const names = pages.map(({ name }) => name);
+    expect(names).toContain('vouchers/index.html');
+    expect(names).toContain('vouchers/stats.html');
+    expect(names).toContain('vouchers/unsubscribes.html');
+    expect(names).toContain('school-booking.html');
+  });
+
+  test('and it parses real markup, not only the fixtures above', () => {
+    // openingTags/attr working on a hand-written string is no evidence they
+    // work on a 5,000-line page with arrow functions inside its bindings.
+    for (const { name, html } of alpinePages) {
+      expect(componentTags(html), `${name} has a readable x-data tag`).not.toHaveLength(0);
+    }
+  });
+
+  test.each(pages.map(({ name, html }) => [name, html]))(
+    '%s does not call init() from x-init as well',
+    (_name, html) => {
+      expect(offendingTags(html)).toEqual([]);
+    },
+  );
+});
+
+describe('the components Alpine bootstraps still define init()', () => {
+  // The other half of the pair. Dropping x-init is only safe while the method
+  // is still called init(); rename it and the page stops bootstrapping at all,
+  // with nothing on screen to say so. Every Alpine page on this site has a
+  // bootstrap, so this holds for all of them and is derived, not listed.
+  test.each(alpinePages.map(({ name, factory }) => [name, factory]))(
+    '%s: %s() defines an init()',
+    (name) => {
+      const { html } = alpinePages.find((page) => page.name === name);
+      // async or not: school-booking's is synchronous, the voucher pages' are not.
+      // Exactly one, so a rename cannot be covered for by an unrelated init()
+      // elsewhere in the page — the match is not tied to the factory's body.
+      const defined = html.match(/\n\s+(?:async )?init\(\) \{/g) || [];
+      expect(defined).toHaveLength(1);
+    },
+  );
+});

--- a/vouchers/test/stats-chart-lifecycle.test.js
+++ b/vouchers/test/stats-chart-lifecycle.test.js
@@ -9,22 +9,9 @@ import { readFileSync } from 'node:fs';
 
 const page = readFileSync(new URL('../stats.html', import.meta.url), 'utf8');
 
-describe('the page bootstraps exactly once', () => {
-  test('x-init does not call init() as well as Alpine', () => {
-    // Alpine calls a component's own init() for us. Naming it in x-init too ran
-    // the whole bootstrap twice — two fetches, and a second draw() that
-    // destroyed four charts mid-animation.
-    const body = page.slice(page.indexOf('<body'), page.indexOf('>', page.indexOf('<body')));
-    expect(body).toMatch(/x-data="voucherStats\(\)"/);
-    expect(body).not.toMatch(/x-init/);
-  });
-
-  test('the component still defines the init() Alpine calls', () => {
-    // The other half of the pair: if init() were renamed, removing x-init would
-    // stop the page bootstrapping at all.
-    expect(page).toMatch(/\n\s+async init\(\) \{/);
-  });
-});
+// The bootstrap-once half of vouchers#69 lives in single-bootstrap.test.js now:
+// it is the same defect on every page of the site, so it is pinned once there
+// rather than repeated per file.
 
 describe('a redraw never releases a canvas', () => {
   test('nothing destroys a chart', () => {

--- a/vouchers/unsubscribes.html
+++ b/vouchers/unsubscribes.html
@@ -233,8 +233,11 @@
     }
   </style>
 </head>
+<!-- No x-init calling init(). Alpine calls a component's own init() for us, so
+     naming it here as well ran the bootstrap twice and loaded the suppression
+     list twice on every open. See vouchers#70. -->
 <body class="bg-neutral-100 text-neutral-900 min-h-screen antialiased font-sans"
-  x-data="unsubscribes()" x-init="init()" x-cloak>
+  x-data="unsubscribes()" x-cloak>
 
   <!-- ── Header ──────────────────────────────────────────────────────────── -->
   <header class="hub-header text-white">


### PR DESCRIPTION
Closes urbanjungleirc/vouchers#70.

> ⚠️ Merging this deploys it — `main` is production on this repo. Nothing here needs a Worker or a migration first, so it can go whenever.

## What was wrong

Alpine calls a component's own `init()` for us. `vouchers/index.html` and `vouchers/unsubscribes.html` named it in `x-init` as well, so both ran their whole bootstrap twice on every load.

Measured against a local copy, the way the ticket did:

| page | before | after |
|---|---|---|
| hub — `/cdn-cgi/access/get-identity` | 2 | 1 |
| unsubscribes — `/v1/staff/optouts` | 2 | 1 |

On the fixed hub `init()` still runs to its last line: `_refreshTimer` and `_lastRefresh` both set, `x-cloak` lifted.

## Was anything unsafe to have run twice?

The ticket asked. No — and the two it named are the two worth spelling out:

- `refreshData()` returns early inside 60 seconds of the last one, so the duplicate `visibilitychange`/`focus` listeners and the second 5-minute tick were all absorbed by that throttle.
- `_refreshTimer` is never cleared anywhere, so the handle the second `init()` overwrote cost nothing.

Two doublings the ticket did not name are also harmless: `positionTip` is idempotent, and the two concurrent `search()` calls assign the same rows. It was waste, not a fault, which is why it stood — neither page has anything on screen that running twice disturbs.

## The pin

`vouchers/test/single-bootstrap.test.js`, replacing the per-file half of `stats-chart-lifecycle.test.js` as the ticket's follow-up comment asked. It sweeps **every** `.html` on the site (17 files), and catches an `x-init` on a child element as well as on the `x-data` tag — a child `x-init` evaluates in the nearest component scope, so it is the same defect.

Two things it does that are easy to leave out:

- **It pins itself.** Once the last `x-init` is gone the filter matches nothing, and a pin whose only assertion never runs is green for the wrong reason. Five fixtures exercise the matcher, the quote walk (attribute values on this site contain `>`) and the comment stripping directly.
- **The paired half is derived, not listed** — "the component still defines the `init()` Alpine calls" now covers `school-booking.html` too, whose `init()` is synchronous and was pinned nowhere before.

Verified by mutation: restoring `x-init` on the hub, adding it to `school-booking.html`, and renaming `init()` on either `school-booking.html` or the unsubscribes list each fail this file.

## Tests

`vouchers` 342 passed, `school-booking` 588 passed.

One pre-existing failure, unrelated and **not from this branch**: `vouchers/test/version.test.js` expects `version: "dev"` from a temp dir and gets the real git version, because `$TMPDIR` on that machine sits inside a repo. It fails on `main` too, and passes in CI.

## Out of scope

The public customer page has the same pairing but deploys from `vouchers.github.io`, so it stays filed separately — as the ticket's comment said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3ckU81AhLKtY25ndBBQCX